### PR TITLE
Parsing using recursion schemes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,8 @@ lazy val Versions = Map(
   "fastparse"      -> "2.1.2",
   "cats"           -> "2.0.0",
   "scala212"       -> "2.12.12",
-  "scala211"       -> "2.11.12"
+  "scala211"       -> "2.11.12",
+  "droste"         -> "0.8.0",
 )
 
 inThisBuild(List(
@@ -45,12 +46,15 @@ lazy val noPublishSettings = Seq(
 
 lazy val compilerPlugins = Seq(
   libraryDependencies ++= Seq(
-    compilerPlugin("org.typelevel" %% "kind-projector" % Versions("kind-projector") cross CrossVersion.full)
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
+    compilerPlugin("org.typelevel" %% "kind-projector" % Versions("kind-projector") cross CrossVersion.full),
   )
 )
 
 lazy val commonDependencies = Seq(
   libraryDependencies ++= Seq(
+    "io.higherkindness" %% "droste-core" % Versions("droste"),
+    "io.higherkindness" %% "droste-macros" % Versions("droste"),
     "org.scalatest" %% "scalatest" % Versions("scalatest") % Test,
   )
 )

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -1,7 +1,9 @@
 package com.gsk.kg.sparqlparser
-import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 
-sealed trait Expr
+import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+import higherkindness.droste.macros.deriveFixedPoint
+
+@deriveFixedPoint sealed trait Expr
 
 object Expr {
   final case class BGP(triples:Seq[Triple]) extends Expr

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/SchemeParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/SchemeParser.scala
@@ -1,0 +1,131 @@
+package com.gsk.kg.sparqlparser
+
+import cats.implicits._
+import Expr.fixedpoint._
+import higherkindness.droste.Coalgebra
+import org.apache.jena.graph.Node
+import org.apache.jena.sparql.algebra.Op
+import org.apache.jena.sparql.algebra.op._
+import scala.collection.JavaConverters._
+import com.gsk.kg.sparqlparser.QueryConstruct.SparqlParsingError
+import com.gsk.kg.sparqlparser.StringVal._
+import fastparse.Parsed
+import higherkindness.droste.CoalgebraM
+import cats.data.Reader
+import org.apache.jena.query.Query
+import org.apache.jena.query.QueryFactory
+import higherkindness.droste.scheme
+import org.apache.jena.sparql.algebra.Algebra
+import higherkindness.droste.Basis
+import org.apache.jena.sparql.core.VarExprList
+
+object SchemeParser {
+
+  val parseCoalgebra: Coalgebra[ExprF, Op] =
+    Coalgebra[ExprF, Op] {
+      case op: OpAssign => throw new RuntimeException("OpAssign not implemented")
+      case op: OpBGP =>
+        BGPF(op.getPattern().getList().asScala.map(toTriple))
+      case op: OpDiff            => throw new RuntimeException("OpDiff not implemented")
+      case op: OpDisjunction     => throw new RuntimeException("OpDisjunction not implemented")
+      case op: OpDistinct        => throw new RuntimeException("OpDistinct not implemented")
+      case op: OpDistinctReduced => throw new RuntimeException("OpDistinctReduced not implemented")
+      case op: OpExt             => throw new RuntimeException("OpExt not implemented")
+      case op: OpExtend          =>
+        val (to, from) = op.getVarExprList().getExprs().asScala.toList.get(0).get
+        ExtendF(
+          toStringVal(to),
+          toStringVal(from.asVar()),
+          op.getSubOp())
+      case op: OpExtendAssign    => throw new RuntimeException("OpExtendAssign not implemented")
+      case op: OpFilter =>
+        FilterF(
+          op.getExprs().getList().asScala.map(toFilterFunction),
+          op.getSubOp()
+        )
+      case op: OpFind => throw new RuntimeException("OpFind not implemented")
+      case op: OpGraph =>
+        GraphF(toStringVal(op.getNode()), op.getSubOp())
+      case op: OpGroup => throw new RuntimeException("OpGroup not implemented")
+      case op: OpJoin =>
+        JoinF(op.getLeft(), op.getRight())
+      case op: OpLabel => throw new RuntimeException("OpLabel not implemented")
+      case op: OpLeftJoin =>
+        LeftJoinF(op.getLeft(), op.getRight())
+      case op: OpList        => throw new RuntimeException("OpList not implemented")
+      case op: OpMinus       => throw new RuntimeException("OpMinus not implemented")
+      case op: OpN           => throw new RuntimeException("OpN not implemented")
+      case op: OpNull        => throw new RuntimeException("OpNull not implemented")
+      case op: OpOrder       => throw new RuntimeException("OpOrder not implemented")
+      case op: OpPath        => throw new RuntimeException("OpPath not implemented")
+      case op: OpProcedure   => throw new RuntimeException("OpProcedure not implemented")
+      case op: OpProject     =>
+        SelectF(
+          op.getVars().asScala.map(v => VARIABLE(v.toString())),
+          op.getSubOp()
+        )
+      case op: OpPropFunc    => throw new RuntimeException("OpPropFunc not implemented")
+      case op: OpQuad        => throw new RuntimeException("OpQuad not implemented")
+      case op: OpQuadBlock   => throw new RuntimeException("OpQuadBlock not implemented")
+      case op: OpQuadPattern => throw new RuntimeException("OpQuadPattern not implemented")
+      case op: OpReduced     => throw new RuntimeException("OpReduced not implemented")
+      case op: OpSequence    => throw new RuntimeException("OpSequence not implemented")
+      case op: OpService     => throw new RuntimeException("OpService not implemented")
+      case op: OpSlice       => throw new RuntimeException("OpSlice not implemented")
+      case op: OpTable       => throw new RuntimeException("OpTable not implemented")
+      case op: OpTopN        => throw new RuntimeException("OpTopN not implemented")
+      case op: OpTriple =>
+        toTripleF(op.getTriple())
+      case op: OpUnion =>
+        UnionF(op.getLeft(), op.getRight())
+    }
+
+  def parse: String => Expr = { str =>
+    val query = QueryFactory.create(str)
+    val op = Algebra.compile(query)
+    val go = scheme.ana(parseCoalgebra)
+
+    go(op)
+  }
+
+  private def toFilterFunction(
+      expr: org.apache.jena.sparql.expr.Expr
+  ): FilterFunction = {
+    fastparse.parse(expr.toString(), FilterFunctionParser.parser(_)) match {
+      case Parsed.Success(value, index) => value
+      case Parsed.Failure(str, i, extra) =>
+        throw SparqlParsingError(s"$str at position $i, ${extra.input}")
+      case _ => //Failure()
+        throw SparqlParsingError(s"parsing failure.")
+    }
+  }
+
+  private def toStringVal(n: Node): StringVal = {
+    if (n.isLiteral) {
+      STRING(n.toString())
+    } else if (n.isURI) {
+      URIVAL(s"<${n.toString()}>")
+    } else if (n.isVariable) {
+      VARIABLE(n.toString())
+    } else if (n.isBlank) {
+      BLANK(n.toString())
+    } else {
+      throw new SparqlParsingError(s"$n cannot convert to ADT triple")
+    }
+  }
+
+  private def toTriple(triple: org.apache.jena.graph.Triple): Expr.Triple =
+    Expr.Triple(
+      toStringVal(triple.getSubject()),
+      toStringVal(triple.getPredicate()),
+      toStringVal(triple.getObject())
+    )
+
+  private def toTripleF(triple: org.apache.jena.graph.Triple): ExprF[Op] =
+    TripleF(
+      toStringVal(triple.getSubject()),
+      toStringVal(triple.getPredicate()),
+      toStringVal(triple.getObject())
+    )
+
+}


### PR DESCRIPTION
This PR showcases the use of recursion schemes for parsing.  With the current implementation is already able to parse some queries, although I haven't tested it against all queries in our codebase.

<details>
<summary>
Here you can see a query being parsed.
</summary>

## input

``` scala
val query = """
        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
        PREFIX  dm:  <http://gsk-kg.rdip.gsk.com/dm/1.0/>

        SELECT ?name ?person WHERE {
          GRAPH <http://id.gsk.com/dm/1.0/graph1> {
            ?d a dm:Document .
          }
          {
            ?person foaf:mbox <mailto:alice@example.org> .
            ?person foaf:name ?name .
            OPTIONAL { ?d dm:pubDateYear ?year }
            FILTER (?year > 2015)
            FILTER (?d = "test")
            FILTER (STRSTARTS(str(?name), "al"))
          }
          UNION {
            ?a foaf:mbox <mailto:kg@example.org> .
            OPTIONAL {
              ?person foaf:name ?name .
              FILTER (?name = "def")
            }
            ?le dm:mappedTo ?concept .
            BIND(?d as ?dbind) .
            BIND(?name as ?nm) .
          }
        }
"""

println(SchemeParser.parse(query))
```

## output

```
Select(ArrayBuffer(VARIABLE(?name), VARIABLE(?person)),Join(Graph(URIVAL(<http://id.gsk.com/dm/1.0/graph1>),BGP(ArrayBuffer(Triple(VARIABLE(?d),URIVAL(<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>),URIVAL(<http://gsk-kg.rdip.gsk.com/dm/1.0/Document>))))),Union(Filter(ArrayBuffer(GT(VARIABLE(?year),NUM(2015)), EQUALS(VARIABLE(?d),STRING(test)), STRSTARTS(STR(VARIABLE(?name)),STRING(al))),LeftJoin(BGP(ArrayBuffer(Triple(VARIABLE(?person),URIVAL(<http://xmlns.com/foaf/0.1/mbox>),URIVAL(<mailto:alice@example.org>)), Triple(VARIABLE(?person),URIVAL(<http://xmlns.com/foaf/0.1/name>),VARIABLE(?name)))),BGP(ArrayBuffer(Triple(VARIABLE(?d),URIVAL(<http://gsk-kg.rdip.gsk.com/dm/1.0/pubDateYear>),VARIABLE(?year)))))),Extend(VARIABLE(?nm),VARIABLE(?name),Extend(VARIABLE(?dbind),VARIABLE(?d),Join(LeftJoin(BGP(ArrayBuffer(Triple(VARIABLE(?a),URIVAL(<http://xmlns.com/foaf/0.1/mbox>),URIVAL(<mailto:kg@example.org>)))),BGP(ArrayBuffer(Triple(VARIABLE(?person),URIVAL(<http://xmlns.com/foaf/0.1/name>),VARIABLE(?name))))),BGP(ArrayBuffer(Triple(VARIABLE(?le),URIVAL(<http://gsk-kg.rdip.gsk.com/dm/1.0/mappedTo>),VARIABLE(?concept))))))))))
```

</details>