### PR TITLE
Sparql parser tests on sample queries

### DIFF
--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/Visitors.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/Visitors.scala
@@ -23,13 +23,13 @@ trait Visitor[T] {
 
   def visitGraph(g: StringLike, d: T): T
 
-  def visitConstruct(vars: Seq[VARIABLE], bgp: BGP, d: T): T
-
   def visitSelect(vars: Seq[VARIABLE], d: T): T
 
   def visitOffsetLimit(off: Option[Long], lmt: Option[Long], d: T): T
 
   def visitDistinct(e: T): T
+
+  def visitOpNil: T
 }
 
 object Visitors {
@@ -63,14 +63,14 @@ object Visitors {
         visitor.visitJoin(left, right)
       case Graph(g, e) =>
         visitor.visitGraph(g, dispatch(e, visitor))
-      case Construct(vars, bgp, r) =>
-        visitor.visitConstruct(vars, bgp, dispatch(r, visitor))
-      case Select(vars, r) =>
+      case Project(vars, r) =>
         visitor.visitSelect(vars, dispatch(r, visitor))
       case OffsetLimit(offset,limit, r) =>
         visitor.visitOffsetLimit(offset, limit, dispatch(r, visitor))
       case Distinct(r) =>
         visitor.visitDistinct(dispatch(r,visitor))
+      case OpNil() => visitor.visitOpNil
+
 
     }
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/impl/ExprToText.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/impl/ExprToText.scala
@@ -1,9 +1,9 @@
 package com.gsk.kg.sparql.impl
 
 import com.gsk.kg.sparqlparser.FilterFunction._
-import com.gsk.kg.sparqlparser.StringFunc.{CONCAT, ISBLANK, STR, STRAFTER, URI}
+import com.gsk.kg.sparqlparser.StringFunc.{CONCAT, ISBLANK, REPLACE, STR, STRAFTER, URI}
 import com.gsk.kg.sparqlparser.StringVal._
-import com.gsk.kg.sparqlparser.{FilterFunction, StringFunc, StringLike, StringVal}
+import com.gsk.kg.sparqlparser.{Expression, FilterFunction, StringFunc, StringLike, StringVal}
 
 object ExprToText {
 
@@ -25,6 +25,7 @@ object ExprToText {
             case STRAFTER(s, f) => s"strafter(${s.text}, ${f.text})"
             case CONCAT(appendTo, append) => s"concat(${appendTo.text}, ${append.text})"
             case ISBLANK(s) => s"isBlank(s)"
+            case REPLACE(st, pattern, by) => s"replace(${st.text}, ${pattern.text}, ${by.text})"
           }
       }
     }
@@ -37,9 +38,19 @@ object ExprToText {
         case EQUALS(l, r) => s"${l.text} = ${r.text}"
         case GT(l, r) => s"${l.text} > ${r.text}"
         case LT(l, r) => s"${l.text} < ${r.text}"
+        case OR(l, r) => s"${l.text} || ${r.text}"
+        case AND(l, r) => s"${l.text} && ${r.text}"
         case STRSTARTS(l, r) => s"strstarts(${l.text}, ${r.text})"
         case NEGATE(s) => s"! ${s}"
-        case STRFUN(f) => f.text
+      }
+    }
+  }
+
+  implicit class ExpressionToText(e: Expression) {
+    def text: String = {
+      e match {
+        case st: StringLike => st.text
+        case ff: FilterFunction => ff.text
       }
     }
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/impl/SimpleVisitor.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/impl/SimpleVisitor.scala
@@ -42,7 +42,7 @@ class SimpleVisitor extends Visitor[String] {
     s"GRAPH ${g.text} {\n${d}}\n"
   }
 
-  override def visitConstruct(vars: Seq[StringVal.VARIABLE], bgp: Expr.BGP, d: String): String = { //construct
+  def toConstruct(vars: Seq[StringVal.VARIABLE], bgp: Expr.BGP, d: String): String = { //construct
     val toCons = this.visitBGP(bgp.triples.map(this.visitTriple(_)))
     s"CONSTRUCT {\n$toCons} WHERE {\n${d}\n}\n"
   }
@@ -58,6 +58,8 @@ class SimpleVisitor extends Visitor[String] {
   }
 
   override def visitDistinct(e: String): String = s"DISTINCT ${e} "
+
+  override def visitOpNil: String = ""
 }
 
 object SimpleVisitor {

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -1,7 +1,19 @@
 package com.gsk.kg.sparqlparser
+
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 
 sealed trait Expr
+sealed trait Query {
+  def r: Expr
+}
+
+object Query {
+  import com.gsk.kg.sparqlparser.Expr.BGP
+  final case class Describe(vars: Seq[VARIABLE], r: Expr) extends Query
+  final case class Ask(r: Expr) extends Query
+  final case class Construct(vars: Seq[VARIABLE], bgp: BGP, r: Expr) extends Query
+  final case class Select(vars: Seq[VARIABLE], r: Expr) extends Query
+}
 
 object Expr {
   final case class BGP(triples:Seq[Triple]) extends Expr
@@ -13,8 +25,10 @@ object Expr {
   final case class Filter(funcs:Seq[FilterFunction], expr:Expr) extends Expr
   final case class Join(l:Expr, r:Expr) extends Expr
   final case class Graph(g:StringVal, e:Expr) extends Expr
-  final case class Construct(vars: Seq[VARIABLE], bgp: BGP, r:Expr) extends Expr
-  final case class Select(vars: Seq[VARIABLE], r:Expr) extends Expr
+  final case class Project(vars: Seq[VARIABLE], r:Expr) extends Expr
   final case class OffsetLimit(offset: Option[Long], limit: Option[Long], r:Expr) extends Expr
   final case class Distinct(r:Expr) extends Expr
+  final case class OpNil() extends Expr
 }
+
+trait Expression

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -20,8 +20,10 @@ object ExprParser {
   def offsetLimit[_:P]:P[Unit] = P("slice")
   def distinct[_:P]:P[Unit] = P("distinct")
 
-  def selectParen[_:P]:P[Select] = P("(" ~ select ~ "(" ~ (StringValParser.variable).rep(1) ~ ")" ~ graphPattern ~ ")")
-    .map(p => Select(p._1, p._2))
+  def opNull[_:P]:P[OpNil] = P("(null)").map(_ => OpNil())
+
+  def selectParen[_:P]:P[Project] = P("(" ~ select ~ "(" ~ (StringValParser.variable).rep(1) ~ ")" ~ graphPattern ~ ")")
+    .map(p => Project(p._1, p._2))
 
   def offsetLimitParen[_:P]:P[OffsetLimit] = P("(" ~ offsetLimit ~
     StringValParser.optionLong ~
@@ -91,7 +93,8 @@ object ExprParser {
       | unionParen
       | extendParen
       | filterSingleParen
-      | filterListParen)
+      | filterListParen
+      | opNull)
 
   def parser[_:P]:P[Expr] = P(graphPattern)
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/FilterFunction.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/FilterFunction.scala
@@ -1,15 +1,17 @@
 package com.gsk.kg.sparqlparser
 
-sealed trait FilterFunction
+sealed trait FilterFunction extends Expression
 
 object FilterFunction {
-  final case class EQUALS(l:StringLike, r:StringLike) extends FilterFunction
-  final case class REGEX(l:StringLike, r:StringLike) extends FilterFunction
-  final case class STRSTARTS(l:StringLike, r:StringLike) extends FilterFunction
-  final case class GT(l:StringLike, r:StringLike) extends FilterFunction
-  final case class LT(l:StringLike, r:StringLike) extends FilterFunction
-  final case class NEGATE(s: StringLike) extends FilterFunction
-  final case class STRFUN(f: StringLike) extends FilterFunction
+  final case class EQUALS(l:Expression, r:Expression) extends FilterFunction
+  final case class REGEX(l:Expression, r:Expression) extends FilterFunction
+  final case class STRSTARTS(l:Expression, r:Expression) extends FilterFunction
+  final case class GT(l:Expression, r:Expression) extends FilterFunction
+  final case class LT(l:Expression, r:Expression) extends FilterFunction
+  final case class OR(l:Expression, r:Expression) extends FilterFunction
+  final case class AND(l:Expression, r:Expression) extends FilterFunction
+  final case class NEGATE(s: Expression) extends FilterFunction
+
 }
 
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/FilterFunctionParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/FilterFunctionParser.scala
@@ -10,43 +10,53 @@ object FilterFunctionParser {
   def strstarts[_:P]:P[Unit] = P("strstarts")
   def gt[_:P]:P[Unit] = P(">")
   def lt[_:P]:P[Unit] = P("<")
+  def and[_:P]:P[Unit] = P("&&")
+  def or[_:P]:P[Unit] = P("||")
   def negate[_:P]:P[Unit] = P("!")
 
   def equalsParen[_:P]:P[EQUALS] =
-    P("(" ~ equals ~ (StringFuncParser.parser | StringValParser.tripleValParser) ~
-      (StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
+    P("(" ~ equals ~ (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~
+      (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
      f => EQUALS(f._1, f._2)
     )
 
   def regexParen[_:P]:P[REGEX] =
-    P("(" ~ regex ~ (StringFuncParser.parser | StringValParser.tripleValParser) ~
-      (StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
+    P("(" ~ regex ~ (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~
+      (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
       f => REGEX(f._1, f._2)
     )
 
   def strstartsParen[_:P]:P[STRSTARTS] =
-    P("(" ~ strstarts ~ (StringFuncParser.parser | StringValParser.tripleValParser) ~
-      (StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
+    P("(" ~ strstarts ~ (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~
+      (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
       f => STRSTARTS(f._1, f._2)
     )
 
   def gtParen[_:P]:P[GT] =
-    P("(" ~ gt ~ (StringFuncParser.parser | StringValParser.tripleValParser) ~
-      (StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
+    P("(" ~ gt ~ (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~
+      (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
       f => GT(f._1, f._2)
     )
 
   def ltParen[_:P]:P[LT] =
-    P("(" ~ lt ~ (StringFuncParser.parser | StringValParser.tripleValParser) ~
-      (StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
+    P("(" ~ lt ~ (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~
+      (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
       f => LT(f._1, f._2)
     )
 
-  def negateParen[_:P]:P[NEGATE] =
-    P("(" ~ negate ~(StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(NEGATE(_))
+  def andParen[_:P]:P[AND] =
+    P("(" ~ and ~ (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~
+      (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
+      f => AND(f._1, f._2)
+    )
+  def orParen[_:P]:P[OR] =
+    P("(" ~ or ~ (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~
+      (FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(
+      f => OR(f._1, f._2)
+    )
 
-  def strfun[_:P]:P[STRFUN] =
-    P(StringFuncParser.parser).map(STRFUN(_))
+  def negateParen[_:P]:P[NEGATE] =
+    P("(" ~ negate ~(FilterFunctionParser.parser | StringFuncParser.parser | StringValParser.tripleValParser) ~ ")").map(NEGATE(_))
 
   def parser[_:P]:P[FilterFunction] =
     P(equalsParen
@@ -54,6 +64,7 @@ object FilterFunctionParser {
     | strstartsParen
     | gtParen
     | ltParen
-    | negateParen
-    | strfun)
+    | andParen
+    | orParen
+    | negateParen)
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringFuncParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringFuncParser.scala
@@ -13,6 +13,7 @@ object StringFuncParser {
   def str[_:P]:P[Unit] = P("str")
   def strafter[_:P]:P[Unit] = P("strafter")
   def isBlank[_:P]:P[Unit] = P("isBlank")
+  def replace[_:P]:P[Unit] = P("replace")
 
   def uriParen[_:P]:P[URI] = P("(" ~ uri ~ stringPatterns ~ ")").map{ s => URI(s)}
   def concatParen[_:P]:P[CONCAT] = ("(" ~ concat ~ stringPatterns ~ stringPatterns ~ ")").map{
@@ -25,12 +26,17 @@ object StringFuncParser {
 
   def isBlankParen[_:P]:P[ISBLANK] = P("(" ~ isBlank ~ stringPatterns ~ ")").map(ISBLANK(_))
 
+  def replaceParen[_:P]:P[REPLACE] = P("(" ~ replace ~ stringPatterns ~ stringPatterns ~ stringPatterns ~")").map{
+    s => REPLACE(s._1, s._2, s._3)
+  }
+
   def stringPatterns[_:P]:P[StringLike] =
     P(uriParen
       | concatParen
       | strParen
       | strafterParen
       | isBlankParen
+      | replaceParen
       | StringValParser.string
       | StringValParser.variable)
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringLike.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringLike.scala
@@ -1,6 +1,6 @@
 package com.gsk.kg.sparqlparser
 
-sealed trait StringLike
+sealed trait StringLike extends Expression
 
 sealed trait StringFunc extends StringLike
 sealed trait StringVal extends StringLike
@@ -11,6 +11,7 @@ object StringFunc {
   final case class STR(s:StringLike) extends StringFunc
   final case class STRAFTER(s:StringLike, f:StringLike) extends StringFunc
   final case class ISBLANK(s: StringLike) extends StringFunc
+  final case class REPLACE(st: StringLike, pattern: StringLike, by: StringLike) extends StringFunc
 }
 
 object StringVal {

--- a/modules/parser/src/test/scala/com/gsk/kg/sparql/impl/SimpleVisitorSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparql/impl/SimpleVisitorSpec.scala
@@ -2,6 +2,7 @@ package com.gsk.kg.sparql.impl
 
 import org.scalatest.flatspec.AnyFlatSpec
 import com.gsk.kg.sparql.Visitors
+import com.gsk.kg.sparqlparser.Query.Construct
 import com.gsk.kg.sparqlparser.{QueryConstruct, TestUtils}
 
 class SimpleVisitorSpec extends AnyFlatSpec {
@@ -74,14 +75,18 @@ class SimpleVisitorSpec extends AnyFlatSpec {
           }
         }
       """
-    val expr = QueryConstruct.parseADT(query)
+    val q = QueryConstruct.parse(query).asInstanceOf[Construct]
+    val expr =q.r
     val result = Visitors.dispatch(expr,visitor)
-    assert(expr == QueryConstruct.parseADT(result))
+    val dual = visitor.toConstruct(q.vars,q.bgp,result)
+    assert(expr == QueryConstruct.parseADT(dual))
   }
 
   "Lit search query" should "work" in {
-    val expr = TestUtils.queryConstruct("/queries/lit-search-2.sparql")
+    val q = TestUtils.query("/queries/lit-search-2.sparql").asInstanceOf[Construct]
+    val expr = q.r
     val result = Visitors.dispatch(expr,visitor)
-    assert(expr == QueryConstruct.parseADT(result))
+    val dual = visitor.toConstruct(q.vars,q.bgp,result)
+    assert(expr == QueryConstruct.parseADT(dual))
   }
 }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
@@ -1,13 +1,14 @@
 package com.gsk.kg.sparqlparser
 
 import com.gsk.kg.sparqlparser.Expr._
+import com.gsk.kg.sparqlparser.Query._
 import com.gsk.kg.sparqlparser.StringVal._
 import org.scalatest.flatspec.AnyFlatSpec
 
 class QueryConstructSpec extends AnyFlatSpec {
 
   "Simple Query" should "parse Construct statement with correct number of Triples" in {
-    TestUtils.queryConstruct("/queries/q0-simple-basic-graph-pattern.sparql") match {
+    TestUtils.query("/queries/q0-simple-basic-graph-pattern.sparql") match {
       case Construct(vars, bgp, expr) =>
         assert(vars.size == 2 && bgp.triples.size == 2)
       case _ => fail
@@ -16,7 +17,7 @@ class QueryConstructSpec extends AnyFlatSpec {
 
 
   "Construct" should "result in proper variables, a basic graph pattern, and algebra expression" in {
-    TestUtils.queryConstruct("/queries/q3-union.sparql") match {
+    TestUtils.query("/queries/q3-union.sparql") match {
       case Construct(vars, bgp, Union(BGP(triplesL: Seq[Triple]), BGP(triplesR: Seq[Triple]))) =>
         val temp = QueryConstruct.getAllVariableNames(bgp)
         val all = vars.map(_.s).toSet
@@ -27,7 +28,7 @@ class QueryConstructSpec extends AnyFlatSpec {
 
 
   "Construct with Bind" should "contains bind variable" in {
-    TestUtils.queryConstruct("/queries/q4-simple-bind.sparql") match {
+    TestUtils.query("/queries/q4-simple-bind.sparql") match {
       case Construct(vars, bgp, Extend(l: StringVal, r: StringVal, BGP(triples: Seq[Triple]))) =>
         vars.exists(_.s == "?dbind")
       case _ => fail
@@ -35,7 +36,7 @@ class QueryConstructSpec extends AnyFlatSpec {
   }
 
   "Complex named graph query" should "be captured properly in Construct" in {
-    TestUtils.queryConstruct("/queries/q13-complex-named-graph.sparql") match {
+    TestUtils.query("/queries/q13-complex-named-graph.sparql") match {
       case Construct(vars, bgp, expr) =>
         assert(vars.size == 13)
         assert(vars.exists(va => va.s == "?ogihw"))
@@ -44,7 +45,7 @@ class QueryConstructSpec extends AnyFlatSpec {
   }
 
   "Complex lit-search query" should "return proper Construct type" in {
-    TestUtils.queryConstruct("/queries/lit-search-3.sparql") match {
+    TestUtils.query("/queries/lit-search-3.sparql") match {
       case Construct(vars, bgp, expr) =>
         assert(bgp.triples.size == 11)
         assert(bgp.triples.head.o.asInstanceOf[BLANK].s == bgp.triples(1).s.asInstanceOf[BLANK].s)
@@ -54,7 +55,7 @@ class QueryConstructSpec extends AnyFlatSpec {
   }
 
   "Extra large query" should "return proper Construct type" in {
-    TestUtils.queryConstruct("/queries/lit-search-xlarge.sparql") match {
+    TestUtils.query("/queries/lit-search-xlarge.sparql") match {
       case Construct(vars, bgp, expr) =>
         assert(bgp.triples.size == 67)
         assert(bgp.triples.head.s.asInstanceOf[VARIABLE].s == "?Year")
@@ -81,8 +82,8 @@ class QueryConstructSpec extends AnyFlatSpec {
         }
       """
 
-    QueryConstruct.parseADT(query) match {
-      case Construct(vars, bgp, Select(Seq(VARIABLE("?name"), VARIABLE("?person")),Filter(funcs,expr))) => succeed
+    QueryConstruct.parse(query) match {
+      case Construct(vars, bgp, Project(Seq(VARIABLE("?name"), VARIABLE("?person")),Filter(funcs,expr))) => succeed
       case _ => fail
     }
   }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -152,6 +152,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     }
   }
 
+  // ignore for now since for diff position, Jena generates different representations
   "Test BIND in another position in the query" should "parse to same as q12" ignore {
     val query = QuerySamples.q13
     val expr = QueryConstruct.parseADT(query)

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -1,6 +1,7 @@
 package com.gsk.kg.sparqlparser
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.FilterFunction._
+import com.gsk.kg.sparqlparser.Query.{Construct, Describe, Select}
 import com.gsk.kg.sparqlparser.StringFunc._
 import com.gsk.kg.sparqlparser.StringVal._
 import org.apache.jena.query.QueryFactory
@@ -28,7 +29,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q2
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, BGP(_)) =>
+      case Project(vs, BGP(_)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
       case _ =>
         fail
@@ -39,7 +40,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q3
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Distinct(Select(vs, BGP(_))) =>
+      case Distinct(Project(vs, BGP(_))) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
       case _ =>
         fail
@@ -50,7 +51,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q4
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, BGP(_)) =>
+      case Project(vs, BGP(_)) =>
         assert(vs.nonEmpty && vs.size == 2)
       case _ =>
         fail
@@ -61,7 +62,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q5
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, BGP(_)) =>
+      case Project(vs, BGP(_)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
       case _ =>
         fail
@@ -72,7 +73,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q6
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, Filter(funcs,r)) =>
+      case Project(vs, Filter(funcs,r)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
       case _ =>
         fail
@@ -83,7 +84,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q7
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, BGP(triples)) =>
+      case Project(vs, BGP(triples)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?species"))
         assert(triples.size==7)
       case _ =>
@@ -95,7 +96,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q8
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, BGP(triples)) =>
+      case Project(vs, BGP(triples)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?species"))
         assert(triples.size==7)
       case _ =>
@@ -107,7 +108,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q9
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, BGP(triples)) =>
+      case Project(vs, BGP(triples)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
       case _ =>
         fail
@@ -118,7 +119,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q10
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, BGP(triples)) =>
+      case Project(vs, BGP(triples)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
         assert(triples.size == 1)
       case _ =>
@@ -131,7 +132,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q11
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Distinct(Select(vs, BGP(triples))) =>
+      case Distinct(Project(vs, BGP(triples))) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?parent_name"))
         assert(triples.size == 2)
       case _ =>
@@ -143,7 +144,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q12
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, Filter(funcs,Extend(to,from,BGP(_)))) =>
+      case Project(vs, Filter(funcs,Extend(to,from,BGP(_)))) =>
         assert(vs.nonEmpty && vs.size == 3)
         assert(funcs.size == 1)
         assert(to == VARIABLE("?o"))
@@ -158,7 +159,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val expr = QueryConstruct.parseADT(query)
     println(expr)
     expr match {
-      case Select(vs, Filter(funcs,Extend(to,from,BGP(_)))) =>
+      case Project(vs, Filter(funcs,Extend(to,from,BGP(_)))) =>
         assert(vs.nonEmpty && vs.size == 3)
         assert(funcs.size == 1)
         assert(to == VARIABLE("?o"))
@@ -171,12 +172,90 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q14
     val expr = QueryConstruct.parseADT(query)
     expr match {
-      case Select(vs, Union(l,r)) =>
+      case Project(vs, Union(l,r)) =>
         assert(vs.nonEmpty && vs.size == 3)
         r match {
           case Filter(funcs,e) => succeed
           case _ => fail
         }
+      case _ =>
+        fail
+    }
+  }
+
+  "Test simple describe query" should "parse" in {
+    val query = QuerySamples.q15
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Describe(_, OpNil()) =>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Test describe query" should "parse" in {
+    val query = QuerySamples.q16
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Describe(vars, Project(vs, Filter(_,_))) =>
+        assert(vars == vs)
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Tests str conversion and logical operators" should "parse" in {
+    val query = QuerySamples.q17
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(vs, Filter(_,_)))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Tests FILTER positioning with graph sub-patterns" should "parse" in {
+    val query = QuerySamples.q18
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(vs, Filter(_,_)))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Test for FILTER in different positions" should "parse" ignore {
+    val query = QuerySamples.q19
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Distinct(Project(vs, Filter(_,_))))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Test CONSTRUCT and string replacement" should "parse" in {
+    val query = QuerySamples.q20
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Construct(vars, _, Extend(to,REPLACE(_,_,_),r))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Test document query" should "parse" in {
+    val query = QuerySamples.q21
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(vs, BGP(ts)))=>
+        assert(ts.size == 21)
       case _ =>
         fail
     }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
@@ -15,10 +15,16 @@ object TestUtils {
     Algebra.compile(query).toString
   }
 
-  def queryConstruct(fileLoc: String): Expr = {
+  def queryAlgebra(fileLoc: String): Expr = {
     val q = readOutputFile(fileLoc)
     QueryConstruct.parseADT(q)
   }
+
+  def query(fileLoc: String): Query = {
+    val q = readOutputFile(fileLoc)
+    QueryConstruct.parse(q)
+  }
+
 
   def readOutputFile(fileLoc: String): String = {
     val path = getClass.getResource(fileLoc).getPath


### PR DESCRIPTION
Factor out Query types (Construct, Select, Describe, Ask) from Expr
Change Select in Expr to Project
Make FilterFunction and StringLike all are Expression trait
add support of ||, && binary expressions
add support of replace function
Two of sample queries failed to parse, put under ignore and will fix them later.