### PR TITLE
Create basic structure for the spark Engine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ lazy val Versions = Map(
   "fastparse"      -> "2.1.2",
   "cats"           -> "2.0.0",
   "scala212"       -> "2.12.12",
-  "scala211"       -> "2.11.12"
+  "scala211"       -> "2.11.12",
+  "droste"         -> "0.8.0",
+  "spark"          -> "2.4.7",
 )
 
 inThisBuild(List(
@@ -45,12 +47,16 @@ lazy val noPublishSettings = Seq(
 
 lazy val compilerPlugins = Seq(
   libraryDependencies ++= Seq(
-    compilerPlugin("org.typelevel" %% "kind-projector" % Versions("kind-projector") cross CrossVersion.full)
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
+    compilerPlugin("org.typelevel" %% "kind-projector" % Versions("kind-projector") cross CrossVersion.full),
   )
 )
 
 lazy val commonDependencies = Seq(
   libraryDependencies ++= Seq(
+    "org.typelevel" %% "cats-core" % Versions("cats"),
+    "io.higherkindness" %% "droste-core" % Versions("droste"),
+    "io.higherkindness" %% "droste-macros" % Versions("droste"),
     "org.scalatest" %% "scalatest" % Versions("scalatest") % Test,
   )
 )
@@ -83,8 +89,10 @@ lazy val `bellman-spark-engine` = project
   .settings(compilerPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-core" % Versions("cats")
+      "org.apache.spark"  %% "spark-core"    % Versions("spark"),
+      "org.apache.spark"  %% "spark-sql"     % Versions("spark")
     )
   )
+  .dependsOn(`bellman-algebra-parser`)
 
 addCommandAlias("ci-test", ";scalastyle ;+test")

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,17 @@
 import xerial.sbt.Sonatype._
 
 lazy val Versions = Map(
-  "kind-projector" -> "0.11.3",
-  "cats"           -> "2.0.0",
-  "jena"           -> "3.17.0",
-  "scalatest"      -> "3.2.3",
-  "fastparse"      -> "2.1.2",
-  "cats"           -> "2.0.0",
-  "scala212"       -> "2.12.12",
-  "scala211"       -> "2.11.12",
-  "droste"         -> "0.8.0",
-  "spark"          -> "2.4.7",
+  "kind-projector"     -> "0.11.3",
+  "cats"               -> "2.0.0",
+  "jena"               -> "3.17.0",
+  "scalatest"          -> "3.2.3",
+  "fastparse"          -> "2.1.2",
+  "cats"               -> "2.0.0",
+  "scala212"           -> "2.12.12",
+  "scala211"           -> "2.11.12",
+  "droste"             -> "0.8.0",
+  "spark"              -> "2.4.7",
+  "spark-testing-base" -> "2.4.5_0.14.0"
 )
 
 inThisBuild(List(
@@ -91,7 +92,8 @@ lazy val `bellman-spark-engine` = project
   .settings(compilerPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "org.apache.spark"  %% "spark-sql"     % Versions("spark"),
+      "org.apache.spark"  %% "spark-sql"          % Versions("spark"),
+      "com.holdenkarau"   %% "spark-testing-base" % Versions("spark-testing-base") % Test
     )
   )
   .dependsOn(`bellman-algebra-parser`)

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,9 @@ lazy val `bellman-algebra-parser` = project
   .settings(compilerPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "org.apache.jena" % "apache-jena-libs" % Versions("jena") pomOnly(),
+      "org.apache.jena" % "apache-jena-libs" % Versions("jena")excludeAll(
+        ExclusionRule(organization = "com.fasterxml.jackson.core"),
+      ),
       "com.lihaoyi" %% "fastparse" % Versions("fastparse"),
     )
   )
@@ -89,8 +91,7 @@ lazy val `bellman-spark-engine` = project
   .settings(compilerPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "org.apache.spark"  %% "spark-core"    % Versions("spark"),
-      "org.apache.spark"  %% "spark-sql"     % Versions("spark")
+      "org.apache.spark"  %% "spark-sql"     % Versions("spark"),
     )
   )
   .dependsOn(`bellman-algebra-parser`)

--- a/build.sbt
+++ b/build.sbt
@@ -77,8 +77,9 @@ lazy val `bellman-algebra-parser` = project
   .settings(compilerPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "org.apache.jena" % "apache-jena-libs" % Versions("jena")excludeAll(
-        ExclusionRule(organization = "com.fasterxml.jackson.core"),
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.4",
+      "org.apache.jena" % "jena-arq" % Versions("jena") excludeAll(
+        ExclusionRule(organization = "com.fasterxml.jackson.core")
       ),
       "com.lihaoyi" %% "fastparse" % Versions("fastparse"),
     )

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,8 @@ lazy val Versions = Map(
   "scala211"           -> "2.11.12",
   "droste"             -> "0.8.0",
   "spark"              -> "2.4.7",
-  "spark-testing-base" -> "2.4.5_0.14.0"
+  "spark-testing-base" -> "2.4.5_0.14.0",
+  "jackson"            -> "2.6.7",
 )
 
 inThisBuild(List(
@@ -77,12 +78,9 @@ lazy val `bellman-algebra-parser` = project
   .settings(compilerPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.4",
-      "org.apache.jena" % "jena-arq" % Versions("jena") excludeAll(
-        ExclusionRule(organization = "com.fasterxml.jackson.core")
-      ),
+      "org.apache.jena" % "jena-arq" % Versions("jena"),
       "com.lihaoyi" %% "fastparse" % Versions("fastparse"),
-    )
+    ),
   )
 
 lazy val `bellman-spark-engine` = project
@@ -95,6 +93,9 @@ lazy val `bellman-spark-engine` = project
     libraryDependencies ++= Seq(
       "org.apache.spark"  %% "spark-sql"          % Versions("spark"),
       "com.holdenkarau"   %% "spark-testing-base" % Versions("spark-testing-base") % Test
+    ),
+    dependencyOverrides ++= Seq(
+      "com.fasterxml.jackson.core" % "jackson-databind" % Versions("jackson"),
     )
   )
   .dependsOn(`bellman-algebra-parser`)

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -1,7 +1,9 @@
 package com.gsk.kg.engine
 
 import cats.data.StateT
-import cats.implicits._
+import cats.instances.all._
+import cats.syntax.either._
+import cats.syntax.applicative._
 
 import org.apache.spark.sql.DataFrame
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -1,36 +1,46 @@
 package com.gsk.kg.engine
 
-import cats.data.State
+import cats.data.StateT
+import cats.instances.either._
 
 import org.apache.spark.sql.DataFrame
 
 import com.gsk.kg.sparqlparser.Expr
 import com.gsk.kg.sparqlparser.Expr.fixedpoint._
 
-import higherkindness.droste.AlgebraM
-import higherkindness.droste.scheme
+import higherkindness.droste._
+import cats.data.IndexedStateT
 
 object Engine {
 
-  val evaluateAlgebraM: AlgebraM[State[DataFrame, *], ExprF, DataFrame] =
-    AlgebraM[State[DataFrame, *], ExprF, DataFrame] {
-      case BGPF(triples)                => State.get
-      case TripleF(s, p, o)             => State.get
-      case LeftJoinF(l, r)              => State.get
-      case FilteredLeftJoinF(l, r, f)   => State.get
-      case UnionF(l, r)                 => State.get
-      case ExtendF(bindTo, bindFrom, r) => State.get
-      case FilterF(funcs, expr)         => State.get
-      case JoinF(l, r)                  => State.get
-      case GraphF(g, e)                 => State.get
-      case ConstructF(vars, bgp, r)     => State.get
-      case SelectF(vars, r)             => State.get
+  sealed trait EngineError
+
+  object EngineError {
+    case class General(description: String) extends EngineError
+  }
+
+  type Result[A] = Either[EngineError, A]
+  type M[A] = StateT[Result, DataFrame, A]
+
+  val evaluateAlgebraM: AlgebraM[M, ExprF, DataFrame] =
+    AlgebraM[M, ExprF, DataFrame] {
+      case BGPF(triples)                => StateT.get[Result, DataFrame]
+      case TripleF(s, p, o)             => StateT.get[Result, DataFrame]
+      case LeftJoinF(l, r)              => StateT.get[Result, DataFrame]
+      case FilteredLeftJoinF(l, r, f)   => StateT.get[Result, DataFrame]
+      case UnionF(l, r)                 => StateT.get[Result, DataFrame]
+      case ExtendF(bindTo, bindFrom, r) => StateT.get[Result, DataFrame]
+      case FilterF(funcs, expr)         => StateT.get[Result, DataFrame]
+      case JoinF(l, r)                  => StateT.get[Result, DataFrame]
+      case GraphF(g, e)                 => StateT.get[Result, DataFrame]
+      case ConstructF(vars, bgp, r)     => StateT.get[Result, DataFrame]
+      case SelectF(vars, r)             => StateT.get[Result, DataFrame]
     }
 
-  def evaluate(dataframe: DataFrame, query: Expr): DataFrame = {
-    val eval = scheme.cataM[State[DataFrame, *], ExprF, Expr, DataFrame](evaluateAlgebraM)
+  def evaluate(dataframe: DataFrame, query: Expr): Result[DataFrame] = {
+    val eval = scheme.cataM[M, ExprF, Expr, DataFrame](evaluateAlgebraM)
 
-    eval(query).runA(dataframe).value
+    eval(query).runA(dataframe)
   }
 
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -37,25 +37,8 @@ object Engine {
         StateT.get[Result, DataFrame].map { df: DataFrame =>
           Foldable[List].fold(
             triples.toList.map({ triple =>
-              val current = Predicate.fromTriple(triple) match {
-                case Predicate.SPO(s, p, o) =>
-                  df.filter(df("s") === s && df("p") === p && df("o") === o)
-                case Predicate.SP(s, p) =>
-                  df.filter(df("s") === s && df("p") === p)
-                case Predicate.PO(p, o) =>
-                  df.filter(df("p") === p && df("o") === o)
-                case Predicate.SO(s, o) =>
-                  df.filter(df("s") === s && df("o") === o)
-                case Predicate.S(s) =>
-                  df.filter(df("s") === s)
-                case Predicate.P(p) =>
-                  df.filter(df("p") === p)
-                case Predicate.O(o) =>
-                  df.filter(df("o") === o)
-                case Predicate.None =>
-                  df
-              }
-
+              val predicate = Predicate.fromTriple(triple)
+              val current = applyPredicateToDataFrame(predicate, df)
               val variables = triple.getVariables
               val selected =
                 current.select(variables.map(v => $"${v._2}".as(v._1.s)): _*)
@@ -100,5 +83,28 @@ object Engine {
 
     eval(query).runA(dataframe).map(_.dataframe)
   }
+
+  private def applyPredicateToDataFrame(
+      predicate: Predicate,
+      df: DataFrame
+  ): DataFrame =
+    predicate match {
+      case Predicate.SPO(s, p, o) =>
+        df.filter(df("s") === s && df("p") === p && df("o") === o)
+      case Predicate.SP(s, p) =>
+        df.filter(df("s") === s && df("p") === p)
+      case Predicate.PO(p, o) =>
+        df.filter(df("p") === p && df("o") === o)
+      case Predicate.SO(s, o) =>
+        df.filter(df("s") === s && df("o") === o)
+      case Predicate.S(s) =>
+        df.filter(df("s") === s)
+      case Predicate.P(p) =>
+        df.filter(df("p") === p)
+      case Predicate.O(o) =>
+        df.filter(df("o") === o)
+      case Predicate.None =>
+        df
+    }
 
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -1,0 +1,36 @@
+package com.gsk.kg.engine
+
+import cats.data.State
+
+import org.apache.spark.sql.DataFrame
+
+import com.gsk.kg.sparqlparser.Expr
+import com.gsk.kg.sparqlparser.Expr.fixedpoint._
+
+import higherkindness.droste.AlgebraM
+import higherkindness.droste.scheme
+
+object Engine {
+
+  val evaluateAlgebraM: AlgebraM[State[DataFrame, *], ExprF, DataFrame] =
+    AlgebraM[State[DataFrame, *], ExprF, DataFrame] {
+      case BGPF(triples)                => State.get
+      case TripleF(s, p, o)             => State.get
+      case LeftJoinF(l, r)              => State.get
+      case FilteredLeftJoinF(l, r, f)   => State.get
+      case UnionF(l, r)                 => State.get
+      case ExtendF(bindTo, bindFrom, r) => State.get
+      case FilterF(funcs, expr)         => State.get
+      case JoinF(l, r)                  => State.get
+      case GraphF(g, e)                 => State.get
+      case ConstructF(vars, bgp, r)     => State.get
+      case SelectF(vars, r)             => State.get
+    }
+
+  def evaluate(dataframe: DataFrame, query: Expr): DataFrame = {
+    val eval = scheme.cataM[State[DataFrame, *], ExprF, Expr, DataFrame](evaluateAlgebraM)
+
+    eval(query).runA(dataframe).value
+  }
+
+}

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -24,17 +24,17 @@ object Engine {
 
   val evaluateAlgebraM: AlgebraM[M, ExprF, DataFrame] =
     AlgebraM[M, ExprF, DataFrame] {
-      case BGPF(triples)                => StateT.get[Result, DataFrame]
-      case TripleF(s, p, o)             => StateT.get[Result, DataFrame]
-      case LeftJoinF(l, r)              => StateT.get[Result, DataFrame]
-      case FilteredLeftJoinF(l, r, f)   => StateT.get[Result, DataFrame]
-      case UnionF(l, r)                 => StateT.get[Result, DataFrame]
-      case ExtendF(bindTo, bindFrom, r) => StateT.get[Result, DataFrame]
-      case FilterF(funcs, expr)         => StateT.get[Result, DataFrame]
-      case JoinF(l, r)                  => StateT.get[Result, DataFrame]
-      case GraphF(g, e)                 => StateT.get[Result, DataFrame]
-      case ConstructF(vars, bgp, r)     => StateT.get[Result, DataFrame]
-      case SelectF(vars, r)             => StateT.get[Result, DataFrame]
+      case BGPF(triples)                => StateT.get
+      case TripleF(s, p, o)             => StateT.get
+      case LeftJoinF(l, r)              => StateT.get
+      case FilteredLeftJoinF(l, r, f)   => StateT.get
+      case UnionF(l, r)                 => StateT.get
+      case ExtendF(bindTo, bindFrom, r) => StateT.get
+      case FilterF(funcs, expr)         => StateT.get
+      case JoinF(l, r)                  => StateT.get
+      case GraphF(g, e)                 => StateT.get
+      case ConstructF(vars, bgp, r)     => StateT.get
+      case SelectF(vars, r)             => StateT.get
     }
 
   def evaluate(dataframe: DataFrame, query: Expr): Result[DataFrame] = {

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -8,6 +8,11 @@ final case class Multiset(
   dataframe: DataFrame
 ) {
 
-  def join(other: Multiset) = this
+  def join(other: Multiset) = (this, other) match {
+    case (a, b) if a.isEmpty => b
+    case (a, b) if b.isEmpty => a
+  }
+
+  def isEmpty: Boolean = bindings.isEmpty && dataframe.isEmpty
 
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -1,0 +1,13 @@
+package com.gsk.kg.engine
+
+import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+import org.apache.spark.sql.DataFrame
+
+final case class Multiset(
+  bindings: Set[VARIABLE],
+  dataframe: DataFrame
+) {
+
+  def join(other: Multiset) = this
+
+}

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -26,9 +26,9 @@ final case class Multiset(
     * instead.
     *
     * @param other
-    * @return
+    * @return the join result of both multisets
     */
-  def join(other: Multiset) = (this, other) match {
+  def join(other: Multiset): Multiset = (this, other) match {
     case (a, b) if a.isEmpty => b
     case (a, b) if b.isEmpty => a
     case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) if aBindings.intersect(bBindings).isEmpty =>
@@ -44,6 +44,11 @@ final case class Multiset(
 
   def isEmpty: Boolean = bindings.isEmpty && dataframe.isEmpty
 
+  def select(vars: VARIABLE*): Multiset =
+    Multiset(
+      bindings.intersect(vars.toSet),
+      dataframe.select(vars.map(v => dataframe(v.s)): _*)
+    )
 }
 
 object Multiset {

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -11,6 +11,12 @@ final case class Multiset(
   def join(other: Multiset) = (this, other) match {
     case (a, b) if a.isEmpty => b
     case (a, b) if b.isEmpty => a
+    case (a, b) =>
+      val common = a.bindings.union(b.bindings)
+      val df = a.dataframe.as("a")
+        .join(b.dataframe.as("b"), common.map(_.s).toSeq)
+
+      Multiset(common, df)
   }
 
   def isEmpty: Boolean = bindings.isEmpty && dataframe.isEmpty

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -2,6 +2,9 @@ package com.gsk.kg.engine
 
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 import org.apache.spark.sql.DataFrame
+import cats.kernel.Semigroup
+import org.apache.spark.sql.SQLContext
+import cats.kernel.Monoid
 
 final case class Multiset(
   bindings: Set[VARIABLE],
@@ -26,5 +29,18 @@ final case class Multiset(
   }
 
   def isEmpty: Boolean = bindings.isEmpty && dataframe.isEmpty
+
+}
+
+object Multiset {
+
+  implicit val semigroup: Semigroup[Multiset] = new Semigroup[Multiset] {
+    def combine(x: Multiset, y: Multiset): Multiset = x.join(y)
+  }
+
+  implicit def monoid(implicit sc: SQLContext): Monoid[Multiset] = new Monoid[Multiset] {
+    def combine(x: Multiset, y: Multiset): Multiset = x.join(y)
+    def empty: Multiset = Multiset(Set.empty, sc.emptyDataFrame)
+  }
 
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -11,6 +11,12 @@ final case class Multiset(
   def join(other: Multiset) = (this, other) match {
     case (a, b) if a.isEmpty => b
     case (a, b) if b.isEmpty => a
+    case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) if aBindings.intersect(bBindings).isEmpty =>
+      val df = aDF.as("a")
+        .crossJoin(bDF.as("b"))
+
+      Multiset(aBindings.union(bBindings), df)
+
     case (a, b) =>
       val common = a.bindings.intersect(b.bindings)
       val df = a.dataframe.as("a")

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -6,25 +6,39 @@ import cats.kernel.Semigroup
 import org.apache.spark.sql.SQLContext
 import cats.kernel.Monoid
 
+
+/**
+  * A [[Multiset]], as expressed in SparQL terms.
+  *
+  * @see See [[https://www.w3.org/2001/sw/DataAccess/rq23/rq24-algebra.html]]
+  * @param bindings the variables this multiset expose
+  * @param dataframe the underlying data that the multiset contains
+  */
 final case class Multiset(
   bindings: Set[VARIABLE],
   dataframe: DataFrame
 ) {
 
+  /**
+    * Join two multisets following SparQL semantics.  If two multisets
+    * share some bindings, it performs an _inner join_ between them.
+    * If they don't share any common binding, it performs a cross join
+    * instead.
+    *
+    * @param other
+    * @return
+    */
   def join(other: Multiset) = (this, other) match {
     case (a, b) if a.isEmpty => b
     case (a, b) if b.isEmpty => a
     case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) if aBindings.intersect(bBindings).isEmpty =>
       val df = aDF.as("a")
         .crossJoin(bDF.as("b"))
-
       Multiset(aBindings.union(bBindings), df)
-
     case (a, b) =>
       val common = a.bindings.intersect(b.bindings)
       val df = a.dataframe.as("a")
         .join(b.dataframe.as("b"), common.map(_.s).toSeq)
-
       Multiset(a.bindings.union(b.bindings), df)
   }
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -12,11 +12,11 @@ final case class Multiset(
     case (a, b) if a.isEmpty => b
     case (a, b) if b.isEmpty => a
     case (a, b) =>
-      val common = a.bindings.union(b.bindings)
+      val common = a.bindings.intersect(b.bindings)
       val df = a.dataframe.as("a")
         .join(b.dataframe.as("b"), common.map(_.s).toSeq)
 
-      Multiset(common, df)
+      Multiset(a.bindings.union(b.bindings), df)
   }
 
   def isEmpty: Boolean = bindings.isEmpty && dataframe.isEmpty

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Predicate.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Predicate.scala
@@ -1,0 +1,30 @@
+package com.gsk.kg.engine
+
+import com.gsk.kg.sparqlparser.Expr
+import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+
+sealed trait Predicate
+
+object Predicate {
+  case class SPO(s: String, p: String, o: String) extends Predicate
+  case class SP(s: String, p: String) extends Predicate
+  case class PO(p: String, o: String) extends Predicate
+  case class SO(s: String, o: String) extends Predicate
+  case class S(s: String) extends Predicate
+  case class P(p: String) extends Predicate
+  case class O(o: String) extends Predicate
+  case object None extends Predicate
+
+
+  def fromTriple(triple: Expr.Triple): Predicate =
+    triple match {
+      case Expr.Triple(VARIABLE(_), VARIABLE(_), VARIABLE(_)) => Predicate.None
+      case Expr.Triple(s, VARIABLE(_), VARIABLE(_))           => Predicate.S(s.s)
+      case Expr.Triple(VARIABLE(_), p, VARIABLE(_))           => Predicate.P(p.s)
+      case Expr.Triple(VARIABLE(_), VARIABLE(_), o)           => Predicate.O(o.s)
+      case Expr.Triple(s, p, VARIABLE(_))                     => Predicate.SP(s.s, p.s)
+      case Expr.Triple(VARIABLE(_), p, o)                     => Predicate.PO(p.s, o.s)
+      case Expr.Triple(s, VARIABLE(_), o)                     => Predicate.SO(s.s, o.s)
+      case Expr.Triple(s, p, o)                               => Predicate.SPO(s.s, p.s, o.s)
+    }
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
@@ -10,31 +10,26 @@ import com.gsk.kg.sparqlparser.QueryConstruct
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.DataFrame
 import org.scalatest.BeforeAndAfterAll
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
 
-class EngineSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
 
-  val spark = SparkSession
-    .builder()
-    .appName("Spark SQL basic example")
-    .config("spark.master", "local")
-    .getOrCreate()
+  override implicit def reuseContextIfPossible: Boolean = true
 
-  import spark.implicits._
-
-  val df: DataFrame = Seq(
-    (
-      "test",
-      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-      "http://id.gsk.com/dm/1.0/Document"
-    ),
-    ("test", "http://id.gsk.com/dm/1.0/docSource", "source")
-    ).toDF("s", "p", "o")
-
-  override protected def afterAll(): Unit = {
-    spark.stop()
-  }
+  override implicit def enableHiveSupport: Boolean = false
 
   "An Engine" should "perform query operations in the dataframe" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = Seq(
+      (
+        "test",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://id.gsk.com/dm/1.0/Document"
+      ),
+      ("test", "http://id.gsk.com/dm/1.0/docSource", "source")
+    ).toDF("s", "p", "o")
+
     val expr = QueryConstruct.parseADT("""
       SELECT
         ?s ?p ?o

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
@@ -9,8 +9,9 @@ import org.scalatest.matchers.should.Matchers
 import com.gsk.kg.sparqlparser.QueryConstruct
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.DataFrame
+import org.scalatest.BeforeAndAfterAll
 
-class EngineSpec extends AnyFlatSpec with Matchers {
+class EngineSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   val spark = SparkSession
     .builder()
@@ -27,7 +28,11 @@ class EngineSpec extends AnyFlatSpec with Matchers {
       "http://id.gsk.com/dm/1.0/Document"
     ),
     ("test", "http://id.gsk.com/dm/1.0/docSource", "source")
-  ).toDF("s", "p", "o")
+    ).toDF("s", "p", "o")
+
+  override protected def afterAll(): Unit = {
+    spark.stop()
+  }
 
   "An Engine" should "perform query operations in the dataframe" in {
     val expr = QueryConstruct.parseADT("""

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
@@ -30,7 +30,6 @@ class EngineSpec extends AnyFlatSpec with Matchers {
   ).toDF("s", "p", "o")
 
   "An Engine" should "perform query operations in the dataframe" in {
-
     val expr = QueryConstruct.parseADT("""
       SELECT
         ?s ?p ?o
@@ -39,7 +38,7 @@ class EngineSpec extends AnyFlatSpec with Matchers {
       }
       """)
 
-    Engine.evaluate(df, expr).collect() shouldEqual df.collect()
+    Engine.evaluate(df, expr).right.get.collect() shouldEqual df.collect()
   }
 
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
@@ -1,0 +1,45 @@
+package com.gsk.kg.engine
+
+import com.gsk.kg.sparqlparser.Expr._
+import com.gsk.kg.sparqlparser.FilterFunction._
+import com.gsk.kg.sparqlparser.StringFunc._
+import com.gsk.kg.sparqlparser.StringVal._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import com.gsk.kg.sparqlparser.QueryConstruct
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.DataFrame
+
+class EngineSpec extends AnyFlatSpec with Matchers {
+
+  val spark = SparkSession
+    .builder()
+    .appName("Spark SQL basic example")
+    .config("spark.master", "local")
+    .getOrCreate()
+
+  import spark.implicits._
+
+  val df: DataFrame = Seq(
+    (
+      "test",
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      "http://id.gsk.com/dm/1.0/Document"
+    ),
+    ("test", "http://id.gsk.com/dm/1.0/docSource", "source")
+  ).toDF("s", "p", "o")
+
+  "An Engine" should "perform query operations in the dataframe" in {
+
+    val expr = QueryConstruct.parseADT("""
+      SELECT
+        ?s ?p ?o
+      WHERE {
+        ?s ?p ?o .
+      }
+      """)
+
+    Engine.evaluate(df, expr).collect() shouldEqual df.collect()
+  }
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.apache.spark.sql.Dataset
 import org.scalatest.matchers.should.Matchers
+import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 
 class MultisetSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
@@ -21,11 +22,25 @@ class MultisetSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     spark.stop()
   }
 
-  "Multiset.join" should "join two empty multisets together" in {
+  "Multiset.join empty" should "join two empty multisets together" in {
     val ms1 = Multiset(Set.empty, spark.emptyDataFrame)
     val ms2 = Multiset(Set.empty, spark.emptyDataFrame)
 
     ms1.join(ms2) shouldEqual Multiset(Set.empty, spark.emptyDataFrame)
+  }
+
+  it should "join other nonempty multiset on the right" in {
+    val empty = Multiset(Set.empty, spark.emptyDataFrame)
+    val nonEmpty = Multiset(Set(VARIABLE("d")), Seq("test1", "test2").toDF("d"))
+
+    empty.join(nonEmpty) shouldEqual nonEmpty
+  }
+
+  it should "join other nonempty multiset on the left" in {
+    val empty = Multiset(Set.empty, spark.emptyDataFrame)
+    val nonEmpty = Multiset(Set(VARIABLE("d")), Seq("test1", "test2").toDF("d"))
+
+    nonEmpty.join(empty) shouldEqual nonEmpty
   }
 
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -19,7 +19,10 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     val ms1 = Multiset(Set.empty, spark.emptyDataFrame)
     val ms2 = Multiset(Set.empty, spark.emptyDataFrame)
 
-    assertMultisetEquals(ms1.join(ms2), Multiset(Set.empty, spark.emptyDataFrame))
+    assertMultisetEquals(
+      ms1.join(ms2),
+      Multiset(Set.empty, spark.emptyDataFrame)
+    )
   }
 
   it should "join other nonempty multiset on the right" in {
@@ -44,23 +47,102 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     val ms1 = Multiset(Set(variable), List("test1", "test2").toDF("d"))
     val ms2 = Multiset(Set(variable), List("test1", "test3").toDF("d"))
 
-    assertMultisetEquals(ms1.join(ms2), Multiset(Set(variable), List("test1").toDF("d")))
+    assertMultisetEquals(
+      ms1.join(ms2),
+      Multiset(Set(variable), List("test1").toDF("d"))
+    )
   }
 
-  "Multiset.join" should "join other multiset when they share one binding" in {
+  it should "join other multiset when they share one binding" in {
     import sqlContext.implicits._
     val d = VARIABLE("d")
     val e = VARIABLE("e")
     val f = VARIABLE("f")
-    val ms1 = Multiset(Set(d, e), List(("test1", 234), ("test2", 123)).toDF(d.s, e.s))
-    val ms2 = Multiset(Set(d, f), List(("test1", "hello"), ("test3", "goodbye")).toDF(d.s, f.s))
+    val ms1 = Multiset(
+      Set(d, e),
+      List(("test1", "234"), ("test2", "123")).toDF(d.s, e.s)
+    )
+    val ms2 = Multiset(
+      Set(d, f),
+      List(("test1", "hello"), ("test3", "goodbye")).toDF(d.s, f.s)
+    )
 
-    assertMultisetEquals(ms1.join(ms2), Multiset(Set(d, e, f), List(("test1", 234, "hello")).toDF("d", "e", "f")))
+    assertMultisetEquals(
+      ms1.join(ms2),
+      Multiset(
+        Set(d, e, f),
+        List(("test1", "234", "hello")).toDF("d", "e", "f")
+      )
+    )
+  }
+
+  it should "join other multiset when they share more than one binding" in {
+    import sqlContext.implicits._
+    val d = VARIABLE("d")
+    val e = VARIABLE("e")
+    val f = VARIABLE("f")
+    val g = VARIABLE("g")
+    val h = VARIABLE("h")
+    val ms1 = Multiset(
+      Set(d, e, g, h),
+      List(("test1", "234", "g1", "h1"), ("test2", "123", "g2", "h2"))
+        .toDF(d.s, e.s, g.s, h.s)
+    )
+    val ms2 = Multiset(
+      Set(d, e, f),
+      List(("test1", "234", "hello"), ("test3", "e2", "goodbye"))
+        .toDF(d.s, e.s, f.s)
+    )
+
+    assertMultisetEquals(
+      ms1.join(ms2),
+      Multiset(
+        Set(d, e, f, g, h),
+        List(("test1", "234", "g1", "h1", "hello"))
+          .toDF("d", "e", "g", "h", "f")
+      )
+    )
+  }
+
+  it should "perform a union when there's no shared bindings between multisets" in {
+    import sqlContext.implicits._
+    val d = VARIABLE("d")
+    val e = VARIABLE("e")
+    val f = VARIABLE("f")
+    val g = VARIABLE("g")
+    val h = VARIABLE("h")
+    val i = VARIABLE("i")
+
+    val ms1 = Multiset(
+      Set(d, e, f),
+      List(("test1", "234", "g1"), ("test2", "123", "g2")).toDF(d.s, e.s, f.s)
+    )
+    val ms2 = Multiset(
+      Set(g, h, i),
+      List(("test1", "234", "hello"), ("test3", "e2", "goodbye"))
+        .toDF(g.s, h.s, i.s)
+    )
+
+    assertMultisetEquals(
+      ms1.join(ms2),
+      Multiset(
+        Set(d, e, f, g, h, i),
+        List(
+          ("test1","234","g1","test1","234","hello"),
+          ("test1","234","g1","test3","e2","goodbye"),
+          ("test2","123","g2","test1","234","hello"),
+          ("test2","123","g2","test3","e2","goodbye")
+        ).toDF("d", "e", "g", "h", "f", "i")
+      )
+    )
   }
 
   def assertMultisetEquals(ms1: Multiset, ms2: Multiset): Unit = {
     assert(ms1.bindings === ms2.bindings, "bindings are different")
-    assert(ms1.dataframe.collect === ms2.dataframe.collect, "dataframes are different")
+    assert(
+      ms1.dataframe.collect === ms2.dataframe.collect,
+      "dataframes are different"
+    )
   }
 
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -38,13 +38,24 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     assertMultisetEquals(nonEmpty.join(empty), nonEmpty)
   }
 
-  "Multiset.join" should "join other multiset when they share one binding" in {
+  "Multiset.join" should "join other multiset when they have both the same single binding" in {
     import sqlContext.implicits._
     val variable = VARIABLE("d")
     val ms1 = Multiset(Set(variable), List("test1", "test2").toDF("d"))
     val ms2 = Multiset(Set(variable), List("test1", "test3").toDF("d"))
 
     assertMultisetEquals(ms1.join(ms2), Multiset(Set(variable), List("test1").toDF("d")))
+  }
+
+  "Multiset.join" should "join other multiset when they share one binding" in {
+    import sqlContext.implicits._
+    val d = VARIABLE("d")
+    val e = VARIABLE("e")
+    val f = VARIABLE("f")
+    val ms1 = Multiset(Set(d, e), List(("test1", 234), ("test2", 123)).toDF(d.s, e.s))
+    val ms2 = Multiset(Set(d, f), List(("test1", "hello"), ("test3", "goodbye")).toDF(d.s, f.s))
+
+    assertMultisetEquals(ms1.join(ms2), Multiset(Set(d, e, f), List(("test1", 234, "hello")).toDF("d", "e", "f")))
   }
 
   def assertMultisetEquals(ms1: Multiset, ms2: Multiset): Unit = {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -1,0 +1,31 @@
+package com.gsk.kg.engine
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.apache.spark.sql.{SparkSession, DataFrame}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.apache.spark.sql.Dataset
+import org.scalatest.matchers.should.Matchers
+
+class MultisetSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  val spark = SparkSession
+    .builder()
+    .appName("Spark SQL basic example")
+    .config("spark.master", "local")
+    .getOrCreate()
+
+  import spark.implicits._
+
+  override protected def afterAll(): Unit = {
+    spark.stop()
+  }
+
+  "Multiset.join" should "join two empty multisets together" in {
+    val ms1 = Multiset(Set.empty, spark.emptyDataFrame)
+    val ms2 = Multiset(Set.empty, spark.emptyDataFrame)
+
+    ms1.join(ms2) shouldEqual Multiset(Set.empty, spark.emptyDataFrame)
+  }
+
+}

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -8,9 +8,6 @@ import higherkindness.droste.macros.deriveFixedPoint
 object Expr {
   final case class BGP(triples:Seq[Triple]) extends Expr
   final case class Triple(s:StringVal, p:StringVal, o:StringVal) extends Expr {
-    def getPredicates: List[(StringVal, String)] = {
-      List((s, "s"),(p, "p"),(o, "o")).filterNot(_._1.isVariable)
-    }
     def getVariables: List[(StringVal, String)] = {
       List((s, "s"),(p, "p"),(o, "o")).filter(_._1.isVariable)
     }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -7,7 +7,14 @@ import higherkindness.droste.macros.deriveFixedPoint
 
 object Expr {
   final case class BGP(triples:Seq[Triple]) extends Expr
-  final case class Triple(s:StringVal, p:StringVal, o:StringVal) extends Expr
+  final case class Triple(s:StringVal, p:StringVal, o:StringVal) extends Expr {
+    def getPredicates: List[(StringVal, String)] = {
+      List((s, "s"),(p, "p"),(o, "o")).filterNot(_._1.isVariable)
+    }
+    def getVariables: List[(StringVal, String)] = {
+      List((s, "s"),(p, "p"),(o, "o")).filter(_._1.isVariable)
+    }
+  }
   final case class LeftJoin(l:Expr, r:Expr) extends Expr
   final case class FilteredLeftJoin(l:Expr, r:Expr, f:FilterFunction) extends Expr
   final case class Union(l:Expr, r:Expr) extends Expr

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -1,7 +1,9 @@
 package com.gsk.kg.sparqlparser
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 
-sealed trait Expr
+import higherkindness.droste.macros.deriveFixedPoint
+
+@deriveFixedPoint sealed trait Expr
 
 object Expr {
   final case class BGP(triples:Seq[Triple]) extends Expr

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringLike.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringLike.scala
@@ -3,7 +3,16 @@ package com.gsk.kg.sparqlparser
 sealed trait StringLike
 
 sealed trait StringFunc extends StringLike
-sealed trait StringVal extends StringLike
+sealed trait StringVal extends StringLike {
+  val s: String
+  def isVariable = this match {
+    case StringVal.STRING(s) => false
+    case StringVal.NUM(s) => false
+    case StringVal.VARIABLE(s) => true
+    case StringVal.URIVAL(s) => false
+    case StringVal.BLANK(s) => false
+  }
+}
 
 object StringFunc {
   final case class URI(s:StringLike) extends StringFunc
@@ -19,4 +28,3 @@ object StringVal {
   final case class URIVAL(s:String) extends StringVal
   final case class BLANK(s:String) extends StringVal
 }
-

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringLike.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringLike.scala
@@ -5,7 +5,7 @@ sealed trait StringLike
 sealed trait StringFunc extends StringLike
 sealed trait StringVal extends StringLike {
   val s: String
-  def isVariable = this match {
+  def isVariable: Boolean = this match {
     case StringVal.STRING(s) => false
     case StringVal.NUM(s) => false
     case StringVal.VARIABLE(s) => true


### PR DESCRIPTION
This PR introduces the basic structure for the Spark engine.100%

first of all, I've need to juggle with dependencies a bit to make both
Jena and Spark coexist in the project.  Jena uses a newer version of
JAckson, while spark uses an old one.  I needed to downgrade Jena's.

## Engine

The entry point for the project is the `Engine` object.  It contains
the evaluate method that will receive an `Expr`, a `DataFrame`, and
will apply the SparQL algebra expression tothe DF.100%

So far, only `SELECT` with Basic Graph Patterns are supported.  I
still have to add some more tests to it to check that the semantics
are correct.

## Multiset

The other central piece for the engine is the `Multiset` datatype.
I've modeled BGP & Select semantics described on
https://www.w3.org/2001/sw/DataAccess/rq23/rq24-algebra.html directly
there.

One can think of `Multiset` as a DataFrame with some bindings, that
can be joined with other `MultiSet`s, or one can project a bunch of
variables from it using the `select` method.