### PR TITLE
Complete query parser on sample queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val Versions = Map(
   "droste"             -> "0.8.0",
   "spark"              -> "2.4.7",
   "spark-testing-base" -> "2.4.5_0.14.0",
-  "jackson"            -> "2.6.7",
+  "jackson"            -> "2.12.1",
 )
 
 inThisBuild(List(
@@ -91,11 +91,12 @@ lazy val `bellman-spark-engine` = project
   .settings(compilerPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "org.apache.spark"  %% "spark-sql"          % Versions("spark"),
+      "org.apache.spark"  %% "spark-sql"          % Versions("spark") % Provided,
       "com.holdenkarau"   %% "spark-testing-base" % Versions("spark-testing-base") % Test
     ),
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-databind" % Versions("jackson"),
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions("jackson"),
     )
   )
   .dependsOn(`bellman-algebra-parser`)

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/Visitors.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/Visitors.scala
@@ -15,7 +15,7 @@ trait Visitor[T] {
 
   def visitUnion(left: T, right: T): T
 
-  def visitExtend(to: Expression, from: Expression, d: T): T
+  def visitExtend(to: VARIABLE, from: Expression, d: T): T
 
   def visitFilter(funcs: Seq[Expression], d: T): T
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/Visitors.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/Visitors.scala
@@ -2,7 +2,7 @@ package com.gsk.kg.sparql
 
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
-import com.gsk.kg.sparqlparser.{Expr, FilterFunction, StringLike}
+import com.gsk.kg.sparqlparser.{Expr, Expression, FilterFunction, StringLike}
 
 trait Visitor[T] {
   def visitTriple(triple: Triple): T
@@ -11,13 +11,13 @@ trait Visitor[T] {
 
   def visitLeftJoin(left: T, right: T): T
 
-  def visitFilteredLeftJoinVisitor(left: T, right: T, f: FilterFunction): T
+  def visitFilteredLeftJoinVisitor(left: T, right: T, f: Expression): T
 
   def visitUnion(left: T, right: T): T
 
-  def visitExtend(to: StringLike, from: StringLike, d: T): T
+  def visitExtend(to: Expression, from: Expression, d: T): T
 
-  def visitFilter(funcs: Seq[FilterFunction], d: T): T
+  def visitFilter(funcs: Seq[Expression], d: T): T
 
   def visitJoin(l: T, r: T): T
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/impl/SimpleVisitor.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/impl/SimpleVisitor.scala
@@ -17,7 +17,7 @@ class SimpleVisitor extends Visitor[String] {
     s"${left}OPTIONAL{$right}\n"
   }
 
-  override def visitFilteredLeftJoinVisitor(left: String, right: String, f: FilterFunction): String = { //when optional follow with filter
+  override def visitFilteredLeftJoinVisitor(left: String, right: String, f: Expression): String = { //when optional follow with filter
     s"${left}OPTIONAL{${right}FILTER(${f.text})}\n"
   }
 
@@ -25,11 +25,11 @@ class SimpleVisitor extends Visitor[String] {
     s"{$left}\nUnion {$right}\n"
   }
 
-  override def visitExtend(to: StringLike, from: StringLike, d: String): String = { //bind
+  override def visitExtend(to: Expression, from: Expression, d: String): String = { //bind
     s"${d}BIND(${from.text} as ${to.text}) .\n"
   }
 
-  override def visitFilter(funcs: Seq[FilterFunction], d: String): String = { //filter
+  override def visitFilter(funcs: Seq[Expression], d: String): String = { //filter
     val fs = funcs.map(f => s"FILTER(${f.text})").mkString("\n")
     s"${d}${fs}\n"
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/impl/SimpleVisitor.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/impl/SimpleVisitor.scala
@@ -3,6 +3,7 @@ package com.gsk.kg.sparql.impl
 import com.gsk.kg.sparql.{Visitor, Visitors}
 import com.gsk.kg.sparqlparser._
 import ExprToText._
+import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 
 class SimpleVisitor extends Visitor[String] {
   override def visitTriple(triple: Expr.Triple): String = {
@@ -25,7 +26,7 @@ class SimpleVisitor extends Visitor[String] {
     s"{$left}\nUnion {$right}\n"
   }
 
-  override def visitExtend(to: Expression, from: Expression, d: String): String = { //bind
+  override def visitExtend(to: VARIABLE, from: Expression, d: String): String = { //bind
     s"${d}BIND(${from.text} as ${to.text}) .\n"
   }
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -25,10 +25,10 @@ object Expr {
     }
   }
   final case class LeftJoin(l:Expr, r:Expr) extends Expr
-  final case class FilteredLeftJoin(l:Expr, r:Expr, f:FilterFunction) extends Expr
+  final case class FilteredLeftJoin(l:Expr, r:Expr, f:Expression) extends Expr
   final case class Union(l:Expr, r:Expr) extends Expr
-  final case class Extend(bindTo:StringLike, bindFrom:StringLike, r:Expr) extends Expr
-  final case class Filter(funcs:Seq[FilterFunction], expr:Expr) extends Expr
+  final case class Extend(bindTo:Expression, bindFrom:Expression, r:Expr) extends Expr
+  final case class Filter(funcs:Seq[Expression], expr:Expr) extends Expr
   final case class Join(l:Expr, r:Expr) extends Expr
   final case class Graph(g:StringVal, e:Expr) extends Expr
   final case class Project(vars: Seq[VARIABLE], r:Expr) extends Expr

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -27,7 +27,7 @@ object Expr {
   final case class LeftJoin(l:Expr, r:Expr) extends Expr
   final case class FilteredLeftJoin(l:Expr, r:Expr, f:Expression) extends Expr
   final case class Union(l:Expr, r:Expr) extends Expr
-  final case class Extend(bindTo:Expression, bindFrom:Expression, r:Expr) extends Expr
+  final case class Extend(bindTo:VARIABLE, bindFrom:Expression, r:Expr) extends Expr
   final case class Filter(funcs:Seq[Expression], expr:Expr) extends Expr
   final case class Join(l:Expr, r:Expr) extends Expr
   final case class Graph(g:StringVal, e:Expr) extends Expr

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -42,8 +42,8 @@ object ExprParser {
 
   def bgpParen[_:P]:P[BGP] = P("(" ~ bgp ~ triple.rep(1) ~ ")").map(BGP(_))
 
-  def filterExprList[_:P]:P[Seq[FilterFunction]] =
-    P("(" ~ exprList ~ FilterFunctionParser.parser.rep(2) ~ ")")
+  def filterExprList[_:P]:P[Seq[Expression]] =
+    P("(" ~ exprList ~ (FilterFunctionParser.parser | StringFuncParser.parser).rep(2) ~ ")")
 
   def filterListParen[_:P]:P[Filter] =
     P("(" ~ filter ~ filterExprList ~ graphPattern ~ ")").map {
@@ -51,7 +51,7 @@ object ExprParser {
     }
 
   def filterSingleParen[_:P]:P[Filter] =
-    P("(" ~ filter ~ FilterFunctionParser.parser ~ graphPattern ~ ")").map {
+    P("(" ~ filter ~ (FilterFunctionParser.parser | StringFuncParser.parser) ~ graphPattern ~ ")").map {
       p => Filter(List(p._1), p._2)
     }
 
@@ -67,8 +67,8 @@ object ExprParser {
     u => Union(u._1, u._2)
   }
   def extendParen[_:P]:P[Extend] = P("(" ~
-    extend ~ "((" ~ (StringValParser.tripleValParser | StringFuncParser.parser) ~
-    (StringValParser.tripleValParser | StringFuncParser.parser) ~ "))" ~
+    extend ~ "((" ~ (StringValParser.tripleValParser | StringFuncParser.parser | FilterFunctionParser.parser) ~
+    (StringValParser.tripleValParser | StringFuncParser.parser | FilterFunctionParser.parser) ~ "))" ~
     graphPattern ~ ")").map{
     ext => Extend(ext._1, ext._2, ext._3)
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -67,7 +67,7 @@ object ExprParser {
     u => Union(u._1, u._2)
   }
   def extendParen[_:P]:P[Extend] = P("(" ~
-    extend ~ "((" ~ (StringValParser.tripleValParser | StringFuncParser.parser | FilterFunctionParser.parser) ~
+    extend ~ "((" ~ (StringValParser.variable) ~
     (StringValParser.tripleValParser | StringFuncParser.parser | FilterFunctionParser.parser) ~ "))" ~
     graphPattern ~ ")").map{
     ext => Extend(ext._1, ext._2, ext._3)

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
@@ -93,7 +93,7 @@ class ExprParserSpec extends AnyFlatSpec {
   "Filter over simple BGP" should "Result in correct nesting of filter and BGP" in {
     val p = fastparse.parse(TestUtils.sparql2Algebra("/queries/q8-filter-simple-basic-graph.sparql"), ExprParser.parser(_))
     p.get.value match {
-      case Filter(s1:Seq[FilterFunction], b:BGP) => succeed
+      case Filter(s1:Seq[Expression], b:BGP) => succeed
       case _ => fail
     }
   }
@@ -112,11 +112,11 @@ class ExprParserSpec extends AnyFlatSpec {
     val p  = fastparse.parse(TestUtils.sparql2Algebra("/queries/q10-complex-filter.sparql"), ExprParser.parser(_))
     p.get.value match {
       case Filter(
-            seq1:Seq[FilterFunction],
+            seq1:Seq[Expression],
               Union(
                 Union(
                   Filter(
-                    seq2:Seq[FilterFunction],
+                    seq2:Seq[Expression],
                     Extend(s1:StringVal, s2:StringVal,
                       LeftJoin(
                         LeftJoin(
@@ -152,12 +152,12 @@ class ExprParserSpec extends AnyFlatSpec {
     val p = fastparse.parse(TestUtils.sparql2Algebra("/queries/q13-complex-named-graph.sparql"), ExprParser.parser(_))
     p.get.value match {
       case Filter(
-        seq1:Seq[FilterFunction],
+        seq1:Seq[Expression],
         Union(
           Union(
             Graph(g1:URIVAL,
             Filter(
-              seq2:Seq[FilterFunction],
+              seq2:Seq[Expression],
               Extend(s1:StringVal, s2:StringVal,
                 LeftJoin(
                   LeftJoin(

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -157,7 +157,6 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
   "Test BIND in another position in the query" should "parse to same as q12" ignore {
     val query = QuerySamples.q13
     val expr = QueryConstruct.parseADT(query)
-    println(expr)
     expr match {
       case Project(vs, Filter(funcs,Extend(to,from,BGP(_)))) =>
         assert(vs.nonEmpty && vs.size == 3)

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -228,7 +228,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     }
   }
 
-  "Test for FILTER in different positions" should "parse" ignore {
+  "Test for FILTER in different positions" should "parse" in {
     val query = QuerySamples.q19
     val q = QueryConstruct.parse(query)
     q match {

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -261,4 +261,160 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     }
   }
 
+  //Comprehensive queries
+
+  "Get a sample of triples joining non-blank nodes" should "parse" in {
+    val query = QuerySamples.q22
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, OffsetLimit(None, Some(10),Project(_,Filter(_,_))))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Check DISTINCT works" should "parse" in {
+    val query = QuerySamples.q23
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, OffsetLimit(None, Some(10),Distinct(Project(vs,_))))=>
+        assert(vs.size == 3)
+      case _ =>
+        fail
+    }
+  }
+
+  "Get class parent-child relations" should "parse" in {
+    val query = QuerySamples.q24
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(_,Filter(_,_))) =>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Get class parent-child relations with optional labels" should "parse" in {
+    val query = QuerySamples.q25
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(_,Filter(_,_))) =>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Get all labels in file" should "parse" in {
+    val query = QuerySamples.q26
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Distinct(Project(_,_)))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Get label of owl:Thing" should "parse" in {
+    val query = QuerySamples.q27
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(vs,_))=>
+        assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
+      case _ =>
+        fail
+    }
+  }
+
+  "Get label of owl:Thing with prefix" should "parse" in {
+    val query = QuerySamples.q28
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(_,_))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Get label of owl:Thing with explanatory comment" should "parse" in {
+    val query = QuerySamples.q29
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(_,_))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Get label of owl:Thing with regex to remove poor label if present" should "parse" in {
+    val query = QuerySamples.q30
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(_,Filter(_,_)))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Construct a graph where everything which is a Thing is asserted to exist" should "parse" in {
+    val query = QuerySamples.q31
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Construct(vars, bgp, BGP(_))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Construct a graph where all the terms derived from a species have a new relation" should "parse" in {
+    val query = QuerySamples.q32
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Construct(vars, bgp, BGP(_))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Detect punned relations in an ontology" should "parse" in {
+    val query = QuerySamples.q33
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(_,_))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Construct a triple where the predicate is derived" should "parse" in {
+    val query = QuerySamples.q34
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Construct(vars, bgp, Union(BGP(_),BGP(_)))=>
+        succeed
+      case _ =>
+        fail
+    }
+  }
+
+  "Query to convert schema of predications" should "parse" in {
+    val query = QuerySamples.q35
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Construct(vars, bgp, Extend(to, from, e))=>
+        assert(to == VARIABLE("?pred"))
+      case _ =>
+        fail
+    }
+  }
+
 }


### PR DESCRIPTION
Query parser successfully test on 34 cases out of 35 queries.
One exception is the BIND statement before BGP, which generates
```
join( extend(((var, expression)), (table unit)), bgp(..))
```
The (table unit) seems specific to jena: 
https://jena.apache.org/documentation/javadoc/arq/org/apache/jena/sparql/algebra/table/TableUnit.html