### PR TITLE
Evaluate union queries

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -40,7 +40,7 @@ object Engine {
       case FilteredLeftJoinF(l, r, f) =>
         StateT.get[Result, DataFrame].map(df => Multiset(Set.empty, df))
       case UnionF(l, r) =>
-        StateT.get[Result, DataFrame].map(df => Multiset(Set.empty, df))
+        l.union(r).pure[M]
       case ExtendF(bindTo, bindFrom, r) =>
         StateT.get[Result, DataFrame].map(df => Multiset(Set.empty, df))
       case FilterF(funcs, expr) =>

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -32,24 +32,7 @@ object Engine {
 
   def evaluateAlgebraM(implicit sc: SQLContext): AlgebraM[M, ExprF, Multiset] =
     AlgebraM[M, ExprF, Multiset] {
-      case BGPF(triples) =>
-        import sc.implicits._
-        StateT.get[Result, DataFrame].map { df: DataFrame =>
-          Foldable[List].fold(
-            triples.toList.map({ triple =>
-              val predicate = Predicate.fromTriple(triple)
-              val current = applyPredicateToDataFrame(predicate, df)
-              val variables = triple.getVariables
-              val selected =
-                current.select(variables.map(v => $"${v._2}".as(v._1.s)): _*)
-
-              Multiset(
-                variables.map(_._1.asInstanceOf[StringVal.VARIABLE]).toSet,
-                selected
-              )
-            })
-          )
-        }
+      case BGPF(triples) => evaluateBGPF(triples)
       case TripleF(s, p, o) =>
         StateT.get[Result, DataFrame].map(df => Multiset(Set.empty, df))
       case LeftJoinF(l, r) =>
@@ -86,6 +69,29 @@ object Engine {
       scheme.cataM[M, ExprF, Expr, Multiset](evaluateAlgebraM)
 
     eval(query).runA(dataframe).map(_.dataframe)
+  }
+
+  private def evaluateBGPF(
+      triples: Seq[Expr.Triple]
+  )(implicit sc: SQLContext) = {
+    import sc.implicits._
+    StateT.get[Result, DataFrame].map { df: DataFrame =>
+      Foldable[List].fold(
+        triples.toList.map({ triple =>
+          val predicate = Predicate.fromTriple(triple)
+          val current = applyPredicateToDataFrame(predicate, df)
+          val variables = triple.getVariables
+          val selected =
+            current.select(variables.map(v => $"${v._2}".as(v._1.s)): _*)
+
+          Multiset(
+            variables.map(_._1.asInstanceOf[StringVal.VARIABLE]).toSet,
+            selected
+          )
+        })
+      )
+    }
+
   }
 
   private def applyPredicateToDataFrame(

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -60,6 +60,10 @@ final case class Multiset(
       bindings.intersect(vars.toSet),
       dataframe.select(vars.map(v => dataframe(v.s)): _*)
     )
+
+
+  def union(other: Multiset): Multiset =
+      return this
 }
 
 object Multiset {

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -26,6 +26,13 @@ final case class Multiset(
     * If they don't share any common binding, it performs a cross join
     * instead.
     *
+    * =Spec=
+    *
+    * Defn: Join
+    * Let Ω1 and Ω2 be multisets of mappings. We define:
+    * Join(Ω1, Ω2) = { merge(μ1, μ2) | μ1 in Ω1and μ2 in Ω2, and μ1 and μ2 are compatible }
+    * card[Join(Ω1, Ω2)](μ) = sum over μ in (Ω1 set-union Ω2), card[Ω1](μ1)*card[Ω2](μ2)
+    *
     * @param other
     * @return the join result of both multisets
     */
@@ -64,6 +71,20 @@ final case class Multiset(
     )
 
 
+  /**
+    * Perform a union between [[this]] and [[other]], as described in
+    * SparQL Algebra doc.
+    *
+    * =Spec=
+    *
+    * Defn: Union
+    * Let Ω1 and Ω2 be multisets of mappings. We define:
+    * Union(Ω1, Ω2) = { μ | μ in Ω1 or μ in Ω2 }
+    * card[Union(Ω1, Ω2)](μ) = card[Ω1](μ) + card[Ω2](μ)
+    *
+    * @param other
+    * @return the Union of both multisets
+    */
   def union(other: Multiset): Multiset =
     (this, other) match {
       case (a, b) if a.isEmpty => b

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -67,6 +67,12 @@ final case class Multiset(
     (this, other) match {
       case (a, b) if a.isEmpty => b
       case (a, b) if b.isEmpty => a
+      case (a, b) =>
+        Multiset(
+          a.bindings.union(b.bindings),
+          a.dataframe.union(b.dataframe)
+        )
+
     }
 
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -42,8 +42,19 @@ final case class Multiset(
       Multiset(a.bindings.union(b.bindings), df)
   }
 
+  /**
+    * Return wether both the dataframe & bindings are empty
+    *
+    * @return
+    */
   def isEmpty: Boolean = bindings.isEmpty && dataframe.isEmpty
 
+  /**
+    * Get a new multiset with only the projected [[vars]].
+    *
+    * @param vars
+    * @return
+    */
   def select(vars: VARIABLE*): Multiset =
     Multiset(
       bindings.intersect(vars.toSet),

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -28,19 +28,20 @@ final case class Multiset(
     * @param other
     * @return the join result of both multisets
     */
-  def join(other: Multiset): Multiset = (this, other) match {
-    case (a, b) if a.isEmpty => b
-    case (a, b) if b.isEmpty => a
-    case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) if aBindings.intersect(bBindings).isEmpty =>
-      val df = aDF.as("a")
-        .crossJoin(bDF.as("b"))
-      Multiset(aBindings.union(bBindings), df)
-    case (a, b) =>
-      val common = a.bindings.intersect(b.bindings)
-      val df = a.dataframe.as("a")
-        .join(b.dataframe.as("b"), common.map(_.s).toSeq)
-      Multiset(a.bindings.union(b.bindings), df)
-  }
+  def join(other: Multiset): Multiset =
+    (this, other) match {
+      case (a, b) if a.isEmpty => b
+      case (a, b) if b.isEmpty => a
+      case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) if aBindings.intersect(bBindings).isEmpty =>
+        val df = aDF.as("a")
+          .crossJoin(bDF.as("b"))
+        Multiset(aBindings.union(bBindings), df)
+      case (a, b) =>
+        val common = a.bindings.intersect(b.bindings)
+        val df = a.dataframe.as("a")
+          .join(b.dataframe.as("b"), common.map(_.s).toSeq)
+        Multiset(a.bindings.union(b.bindings), df)
+    }
 
   /**
     * Return wether both the dataframe & bindings are empty
@@ -63,7 +64,11 @@ final case class Multiset(
 
 
   def union(other: Multiset): Multiset =
-      return this
+    (this, other) match {
+      case (a, b) if a.isEmpty => b
+      case (a, b) if b.isEmpty => a
+    }
+
 }
 
 object Multiset {

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -68,7 +68,7 @@ final case class Multiset(
     (this, other) match {
       case (a, b) if a.isEmpty => b
       case (a, b) if b.isEmpty => a
-      case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) if aDF.columns.length == bDF.columns.length =>
+      case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) if aDF.columns == bDF.columns =>
         Multiset(
           aBindings.union(bBindings),
           aDF.union(bDF)

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -103,7 +103,7 @@ final case class Multiset(
         def genColumns(current: Set[String], total: Set[String]) = {
           total.map(x => x match {
             case x if current.contains(x) => col(x)
-            case _ => lit(null).as(x)
+            case _ => lit(null).as(x) // scalastyle:ignore
           }).toList
         }
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
@@ -1,5 +1,6 @@
 package com.gsk.kg.engine
 
+import com.gsk.kg.sparql.syntax.all._
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.FilterFunction._
 import com.gsk.kg.sparqlparser.StringFunc._
@@ -32,15 +33,15 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     import sqlContext.implicits._
 
     val df = dfList.toDF("s", "p", "o")
-    val expr = QueryConstruct.parseADT("""
+    val query = sparql"""
       SELECT
         ?s ?p ?o
       WHERE {
         ?s ?p ?o .
       }
-      """)
+      """
 
-    Engine.evaluate(df, expr).right.get.collect() shouldEqual df.collect()
+    Engine.evaluate(df, query.r).right.get.collect() shouldEqual df.collect()
   }
 
   it should "execute a query with two dependent BGPs" in {
@@ -48,16 +49,16 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
 
     val df: DataFrame = dfList.toDF("s", "p", "o")
 
-    val expr = QueryConstruct.parseADT("""
+    val query = sparql"""
       SELECT
         ?d ?src
       WHERE {
         ?d a <http://id.gsk.com/dm/1.0/Document> .
         ?d <http://id.gsk.com/dm/1.0/docSource> ?src
       }
-      """)
+      """
 
-    Engine.evaluate(df, expr).right.get.collect() shouldEqual Array(Row("test", "source"))
+    Engine.evaluate(df, query.r).right.get.collect() shouldEqual Array(Row("test", "source"))
   }
 
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
@@ -61,4 +61,44 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     Engine.evaluate(df, query.r).right.get.collect() shouldEqual Array(Row("test", "source"))
   }
 
+  it should "execute a UNION query BGPs with the same bindings" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = (("does", "not", "match") :: dfList).toDF("s", "p", "o")
+
+    val query = sparql"""
+      SELECT
+        ?s ?o
+      WHERE {
+        { ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o }
+        UNION
+        { ?s <http://id.gsk.com/dm/1.0/docSource> ?o }
+      }
+      """
+
+    Engine.evaluate(df, query.r).right.get.collect() shouldEqual Array(
+      Row("test", "<http://id.gsk.com/dm/1.0/Document>"),
+      Row("test", "source"))
+  }
+
+  it should "execute a UNION query BGPs with different bindings" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = (("does", "not", "match") :: dfList).toDF("s", "p", "o")
+
+    val query = sparql"""
+      SELECT
+        ?s ?o ?s2 ?o2
+      WHERE {
+        { ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o }
+        UNION
+        { ?s2 <http://id.gsk.com/dm/1.0/docSource> ?o2 }
+      }
+      """
+
+    Engine.evaluate(df, query.r).right.get.collect() shouldEqual Array(
+      Row("test", "<http://id.gsk.com/dm/1.0/Document>", null, null),
+      Row(null, null, "test", "source"))
+  }
+
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -137,6 +137,16 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     )
   }
 
+  "Multiset.union" should "work both sides are empty" in {
+    val ms1 = Multiset(Set.empty, spark.emptyDataFrame)
+    val ms2 = Multiset(Set.empty, spark.emptyDataFrame)
+
+    assertMultisetEquals(
+      ms1.union(ms2),
+      Multiset(Set.empty, spark.emptyDataFrame)
+    )
+  }
+
   def assertMultisetEquals(ms1: Multiset, ms2: Multiset): Unit = {
     assert(ms1.bindings === ms2.bindings, "bindings are different")
     assert(

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -171,6 +171,24 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     )
   }
 
+  it should "union two multisets with the same bindings" in {
+    import sqlContext.implicits._
+
+    val a = VARIABLE("a")
+    val b = VARIABLE("b")
+
+    val ms1 = Multiset(Set(a, b), List(("A", "1"), ("B", "2"), ("C", "3")).toDF(a.s, b.s))
+    val ms2 = Multiset(Set(a, b), List(("D", "4"), ("E", "5"), ("F", "6")).toDF(a.s, b.s))
+
+    assertMultisetEquals(
+      ms1.union(ms2),
+      Multiset(
+        Set(VARIABLE("a"), VARIABLE("b")),
+        List(("A", "1"), ("B", "2"), ("C", "3"), ("D", "4"), ("E", "5"), ("F", "6")).toDF("a", "b")
+      )
+    )
+  }
+
   def assertMultisetEquals(ms1: Multiset, ms2: Multiset): Unit = {
     assert(ms1.bindings === ms2.bindings, "bindings are different")
     assert(

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -147,6 +147,18 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     )
   }
 
+  it should "work left side empty" in {
+    import sqlContext.implicits._
+
+    val ms1 = Multiset(Set.empty, spark.emptyDataFrame)
+    val ms2 = Multiset(Set(VARIABLE("a")), List("A", "B", "C").toDF("a"))
+
+    assertMultisetEquals(
+      ms1.union(ms2),
+      ms2
+    )
+  }
+
   def assertMultisetEquals(ms1: Multiset, ms2: Multiset): Unit = {
     assert(ms1.bindings === ms2.bindings, "bindings are different")
     assert(

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -147,7 +147,7 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     )
   }
 
-  it should "work left side empty" in {
+  it should "work when left side is empty" in {
     import sqlContext.implicits._
 
     val ms1 = Multiset(Set.empty, spark.emptyDataFrame)
@@ -156,6 +156,18 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     assertMultisetEquals(
       ms1.union(ms2),
       ms2
+    )
+  }
+
+  it should "work when right side is empty" in {
+    import sqlContext.implicits._
+
+    val ms1 = Multiset(Set(VARIABLE("a")), List("A", "B", "C").toDF("a"))
+    val ms2 = Multiset(Set.empty, spark.emptyDataFrame)
+
+    assertMultisetEquals(
+      ms1.union(ms2),
+      ms1
     )
   }
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -183,8 +183,31 @@ class MultisetSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     assertMultisetEquals(
       ms1.union(ms2),
       Multiset(
-        Set(VARIABLE("a"), VARIABLE("b")),
+        Set(a, b),
         List(("A", "1"), ("B", "2"), ("C", "3"), ("D", "4"), ("E", "5"), ("F", "6")).toDF("a", "b")
+      )
+    )
+  }
+
+  it should "union two multisets with different bindings" in {
+    import sqlContext.implicits._
+
+    val a = VARIABLE("a")
+    val b = VARIABLE("b")
+    val c = VARIABLE("c")
+
+    val ms1 = Multiset(Set(a, b), List(("A", "1"), ("B", "2"), ("C", "3")).toDF(a.s, b.s))
+    val ms2 = Multiset(Set(c), List("CC").toDF(c.s))
+
+    assertMultisetEquals(
+      ms1.union(ms2),
+      Multiset(
+        Set(a, b, c),
+        List(
+          ("A" ,"1" ,null),
+          ("B" ,"2" ,null),
+          ("C" ,"3" ,null),
+          (null,null,"CC")).toDF(a.s, b.s, c.s)
       )
     )
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
@@ -1,0 +1,26 @@
+package com.gsk.kg.sparql.syntax
+
+import com.gsk.kg.sparqlparser.Query
+import com.gsk.kg.sparqlparser.QueryConstruct
+import com.gsk.kg.sparqlparser.Expr
+
+trait Interpolators {
+
+  implicit class SparqlQueryInterpolator(sc: StringContext) {
+
+    def sparql(args: Any*): Query = {
+      val strings     = sc.parts.iterator
+      val expressions = args.iterator
+      val buf         = new StringBuilder(strings.next())
+      while (strings.hasNext) {
+        buf.append(expressions.next())
+        buf.append(strings.next())
+      }
+      QueryConstruct.parse(buf.toString())
+    }
+
+  }
+
+}
+
+object Interpolators extends Interpolators

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/all.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/all.scala
@@ -1,0 +1,4 @@
+package com.gsk.kg.sparql.syntax
+
+object all
+  extends Interpolators

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/all.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/all.scala
@@ -1,4 +1,6 @@
 package com.gsk.kg.sparql.syntax
 
+// scalastyle:off
 object all
-  extends Interpolators
+    extends Interpolators
+// scalastyle:on


### PR DESCRIPTION
This PR makes it possible to evaluate union queries.

## Evaluating UNION queries

We rely on Spark DataSet's `union` functions, and depending on the
shared bindings of the different multisets we keep the same DF
structure, or add the needed columns.

## `sparql` interpolator

I also introduced some syntax sugar for making it possible to parse
sparql queries directly, using the `sparql` interpolator.

``` scala
val query: Query = sparql"""
  SELECT {?s ?p ?o}
  WHERE {?s ?p ?o}
  """
```

Under the hood, it just calls `QueryConstruct.parse`.