### PR TITLE
Construct support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val commonDependencies = Seq(
   )
 )
 
-lazy val root = project
+lazy val bellman = project
   .in(file("."))
   .settings(buildSettings)
   .settings(noPublishSettings)

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -67,40 +67,8 @@ object Engine {
     eval(query.r)
       .runA(dataframe)
       .map(_.dataframe)
-      .map(qqq(query))
+      .map(QueryExecutor.execute(query))
   }
-
-  private def qqq(
-      query: Query
-  )(df: DataFrame)(implicit sc: SQLContext): DataFrame =
-    query match {
-      case Construct(vars, bgp, r) =>
-        import sc.implicits._
-        val acc = List.empty[(String, String, String)].toDF("s", "p", "o")
-
-        bgp.triples
-          .map({ triple =>
-            import org.apache.spark.sql.functions._
-
-            val cols = (triple.getVariables ++ triple.getPredicates)
-
-            cols
-              .foldLeft(df)({
-                case (df, (sv, pos)) =>
-                  if (df.columns.contains(sv.s)) {
-                    df.withColumnRenamed(sv.s, pos)
-                  } else {
-                    df.withColumn(pos, lit(sv.s))
-                  }
-              })
-              .select("s", "p", "o")
-          })
-          .foldLeft(acc) { (acc, other) =>
-            acc.union(other)
-          }
-
-      case _ => df
-    }
 
   private def evaluateBGPF(
       triples: Seq[Expr.Triple]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -20,12 +20,6 @@ import com.gsk.kg.engine.Predicate.None
 
 object Engine {
 
-  sealed trait EngineError
-
-  object EngineError {
-    case class General(description: String) extends EngineError
-  }
-
   type Result[A] = Either[EngineError, A]
   val Result = Either
   type M[A] = StateT[Result, DataFrame, A]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
@@ -1,0 +1,7 @@
+package com.gsk.kg.engine
+
+sealed trait EngineError
+
+object EngineError {
+  case class General(description: String) extends EngineError
+}

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExecutor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExecutor.scala
@@ -1,0 +1,43 @@
+package com.gsk.kg.engine
+
+import com.gsk.kg.sparqlparser.Query
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SQLContext
+import com.gsk.kg.sparqlparser.Query.Construct
+
+object QueryExecutor {
+
+  def execute(
+      query: Query
+  )(df: DataFrame)(implicit sc: SQLContext): DataFrame =
+    query match {
+      case Construct(vars, bgp, r) =>
+        import sc.implicits._
+        val acc = List.empty[(String, String, String)].toDF("s", "p", "o")
+
+        bgp.triples
+          .map({ triple =>
+            import org.apache.spark.sql.functions._
+
+            val cols = (triple.getVariables ++ triple.getPredicates)
+
+            cols
+              .foldLeft(df)({
+                case (df, (sv, pos)) =>
+                  if (df.columns.contains(sv.s)) {
+                    df.withColumnRenamed(sv.s, pos)
+                  } else {
+                    df.withColumn(pos, lit(sv.s))
+                  }
+              })
+              .select("s", "p", "o")
+          })
+          .foldLeft(acc) { (acc, other) =>
+            acc.union(other)
+          }
+
+      case _ => df
+    }
+
+
+}

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExecutor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExecutor.scala
@@ -34,7 +34,7 @@ object QueryExecutor {
           })
           .foldLeft(acc) { (acc, other) =>
             acc.union(other)
-          }
+          }.dropDuplicates()
 
       case _ => df
     }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
@@ -106,7 +106,7 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     )
   }
 
-  it should "execute a CONSTRUCT with a single graph pattern" in {
+  it should "execute a CONSTRUCT with a single triple pattern" in {
     import sqlContext.implicits._
 
     val df: DataFrame = dfList.toDF("s", "p", "o")
@@ -124,6 +124,36 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
         "test",
         "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
         "<http://id.gsk.com/dm/1.0/Document>"
+      )
+    )
+
+  }
+
+  it should "execute a CONSTRUCT with more than one triple pattern" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = dfList.toDF("s", "p", "o")
+
+    val query = sparql"""
+      CONSTRUCT {
+        ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o .
+        ?s2 <http://id.gsk.com/dm/1.0/docSource> ?o2
+      } WHERE {
+        ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o .
+        ?s2 <http://id.gsk.com/dm/1.0/docSource> ?o2
+      }
+      """
+
+    val dff = Engine.evaluate(df, query).right.get.collect() shouldEqual Array(
+      Row(
+        "test",
+        "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+        "<http://id.gsk.com/dm/1.0/Document>"
+      ),
+      Row(
+        "test",
+        "<http://id.gsk.com/dm/1.0/docSource>",
+        "source"
       )
     )
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/EngineSpec.scala
@@ -128,10 +128,7 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     )
   }
 
-  // Ignored this test, as I'm not yet 100% sure of the semantics of
-  // the union, although I feel that CONSTRUCT shouldn't contain
-  // duplicates...
-  it should "execute a CONSTRUCT with more than one triple pattern" ignore {
+  it should "execute a CONSTRUCT with more than one triple pattern" in {
     import sqlContext.implicits._
 
     val positive = List(
@@ -139,17 +136,6 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
         ("doesmatchaswell", "<http://id.gsk.com/dm/1.0/docSource>", "potato")
       )
     val df: DataFrame = (positive ++ dfList).toDF("s", "p", "o")
-
-    // df looks like this:
-    //
-    // +---------------+--------------------+--------------------+
-    // |              s|                   p|                   o|
-    // +---------------+--------------------+--------------------+
-    // |      doesmatch|<http://www.w3.or...|<http://id.gsk.co...|
-    // |doesmatchaswell|<http://id.gsk.co...|              potato|
-    // |           test|<http://www.w3.or...|<http://id.gsk.co...|
-    // |           test|<http://id.gsk.co...|              source|
-    // +---------------+--------------------+--------------------+
 
     val query = sparql"""
       CONSTRUCT {
@@ -161,7 +147,7 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
       }
       """
 
-    Engine.evaluate(df, query).right.get.collect() shouldEqual Array(
+    Engine.evaluate(df, query).right.get.collect().toSet shouldEqual Set(
       Row(
         "doesmatch",
         "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
@@ -209,7 +195,7 @@ class EngineSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
       }
       """
 
-    Engine.evaluate(df, query).right.get.collect() shouldEqual Array(
+    Engine.evaluate(df, query).right.get.collect().toSet shouldEqual Set(
       Row(
         "test",
         "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -23,6 +23,10 @@ object Expr {
     def getVariables: List[(StringVal, String)] = {
       List((s, "s"),(p, "p"),(o, "o")).filter(_._1.isVariable)
     }
+
+    def getPredicates: List[(StringVal, String)] = {
+      List((s, "s"),(p, "p"),(o, "o")).filter(!_._1.isVariable)
+    }
   }
   final case class LeftJoin(l:Expr, r:Expr) extends Expr
   final case class FilteredLeftJoin(l:Expr, r:Expr, f:Expression) extends Expr


### PR DESCRIPTION
This PR adds support for CONSTRUCT queries.

I've ignored one of the tests, because I need to still work on it, since the result it's returning is not what I expect.

https://github.com/gsk-aiops/bellman/compare/construct-support?expand=1#diff-00cff14d890e1d2c20ecd6793ff453d1d856242c402fa1d5e58720eadc9f7bb1R131-R186

What the engine is returning is each row duplicated.  By reading the spec, I feel that CONSTRUCT query results shouldn't have duplicated, since it explicitly talks about `set union`, not `multiset union`, and we could safely remove duplicates from result, but am not completely sure.

If you @shihch @JNKHunter know how should we proceed in that regard I'd really appreciate that.