### PR TITLE
added limit operation support for sparql queries on compiler

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -40,7 +40,7 @@ object Engine {
       case DAG.Union(l, r)                   => l.union(r).pure[M]
       case DAG.Filter(funcs, expr)           => notImplemented("Filter")
       case DAG.Join(l, r)                    => notImplemented("Join")
-      case DAG.OffsetLimit(offset, limit, r) => notImplemented("OffsetLimit")
+      case DAG.OffsetLimit(offset, limit, r) => evaluateOffsetLimit(offset, limit, r)
       case DAG.Distinct(r)                   => notImplemented("Distinct")
       case DAG.Noop(str)                     => notImplemented("Noop")
     }
@@ -58,6 +58,9 @@ object Engine {
       .runA(dataframe)
       .map(_.dataframe)
   }
+
+  private def evaluateOffsetLimit(offset: Option[Long], limit: Option[Long], r: Multiset): M[Multiset] =
+    M.liftF(r.offsetLimit(offset, limit))
 
   private def evaluateConstruct[T](
       bgp: Expr.BGP,

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
@@ -5,4 +5,6 @@ sealed trait EngineError
 object EngineError {
   case class General(description: String) extends EngineError
   case class UnknownFunction(fn: String) extends EngineError
+  case class UnexpectedNegativeLimit(description: String) extends EngineError
+  case class NumericTypesDoNotMatch(description: String) extends EngineError
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -250,6 +250,83 @@ class CompilerSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     Compiler.compile(inputDF, query).right.get.collect.toSet shouldEqual outputDF.collect().toSet
   }
 
+  it should "query a real DF with limit greater than 0 and obtain a correct result" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("a", "b", "c"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Anthony"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Perico"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Henry")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+        |
+        |SELECT  ?name
+        |WHERE   { ?x foaf:name ?name }
+        |LIMIT   2
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Right[_, _]]
+    result.right.get.collect.length shouldEqual 2
+    result.right.get.collect.toSet shouldEqual Set(Row("Anthony"), Row("Perico"))
+  }
+
+  it should "query a real DF with limit equal to 0 and obtain no results" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("a", "b", "c"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Anthony"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Perico"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Henry")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+        |
+        |SELECT  ?name
+        |WHERE   { ?x foaf:name ?name }
+        |LIMIT   0
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Right[_, _]]
+    result.right.get.collect.length shouldEqual 0
+    result.right.get.collect.toSet shouldEqual Set.empty
+  }
+
+  it should "query a real DF with limit greater than Java MAX INTEGER and obtain an error" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("a", "b", "c"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Anthony"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Perico"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Henry")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+        |
+        |SELECT  ?name
+        |WHERE   { ?x foaf:name ?name }
+        |LIMIT   2147483648
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldEqual EngineError.NumericTypesDoNotMatch("2147483648 to big to be converted to an Int")
+  }
+
   private def readNTtoDF(path: String) = {
     import sqlContext.implicits._
     import scala.collection.JavaConverters._


### PR DESCRIPTION
This PR adds SparQL Solution Sequence Modifier LIMIT support.

Acceptance criteria:

If LIMIT greater than 0, will return a maximum of LIMIT elements.
If LIMIT equals 0, will return no elements.
If LIMIT less than 0, an Engine Error will happen.
If LIMIT is greater than Java MAX_INTEGER, an Engine Error will happen. (Due to Spark limit type Int)

WIP: Offset support

CLOSES: #73 