### PR TITLE
Split offset and limit

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -40,7 +40,7 @@ object Engine {
       case DAG.Union(l, r)                   => l.union(r).pure[M]
       case DAG.Filter(funcs, expr)           => notImplemented("Filter")
       case DAG.Join(l, r)                    => notImplemented("Join")
-      case DAG.OffsetLimit(offset, limit, r) => notImplemented("OffsetLimit")
+      case DAG.OffsetLimit(offset, limit, r) => evaluateOffsetLimit(offset, limit, r)
       case DAG.Distinct(r)                   => notImplemented("Distinct")
       case DAG.Noop(str)                     => notImplemented("Noop")
     }
@@ -58,6 +58,9 @@ object Engine {
       .runA(dataframe)
       .map(_.dataframe)
   }
+
+  private def evaluateOffsetLimit(offset: Option[Long], limit: Option[Long], r: Multiset): M[Multiset] =
+    M.liftF(r.offsetLimit(offset, limit))
 
   private def evaluateConstruct[T](
       bgp: Expr.BGP,

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -34,15 +34,16 @@ object Engine {
       case DAG.Project(variables, r) => r.select(variables: _*).pure[M]
       case DAG.Bind(variable, expression, r) =>
         evaluateBind(variable, expression, r)
-      case DAG.Triple(s, p, o)               => evaluateTriple(s, p, o)
-      case DAG.BGP(triples)                  => Foldable[List].fold(triples).pure[M]
-      case DAG.LeftJoin(l, r, filters)       => notImplemented("LeftJoin")
-      case DAG.Union(l, r)                   => l.union(r).pure[M]
-      case DAG.Filter(funcs, expr)           => notImplemented("Filter")
-      case DAG.Join(l, r)                    => notImplemented("Join")
-      case DAG.OffsetLimit(offset, limit, r) => evaluateOffsetLimit(offset, limit, r)
-      case DAG.Distinct(r)                   => notImplemented("Distinct")
-      case DAG.Noop(str)                     => notImplemented("Noop")
+      case DAG.Triple(s, p, o)         => evaluateTriple(s, p, o)
+      case DAG.BGP(triples)            => Foldable[List].fold(triples).pure[M]
+      case DAG.LeftJoin(l, r, filters) => notImplemented("LeftJoin")
+      case DAG.Union(l, r)             => l.union(r).pure[M]
+      case DAG.Filter(funcs, expr)     => notImplemented("Filter")
+      case DAG.Join(l, r)              => notImplemented("Join")
+      case DAG.Offset(offset, r)       => notImplemented("Offset")
+      case DAG.Limit(limit, r)         => evaluateLimit(limit, r)
+      case DAG.Distinct(r)             => notImplemented("Distinct")
+      case DAG.Noop(str)               => notImplemented("Noop")
     }
 
   def evaluate[T: Basis[DAG, *]](
@@ -59,8 +60,8 @@ object Engine {
       .map(_.dataframe)
   }
 
-  private def evaluateOffsetLimit(offset: Option[Long], limit: Option[Long], r: Multiset): M[Multiset] =
-    M.liftF(r.offsetLimit(offset, limit))
+  private def evaluateLimit(limit: Long, r: Multiset): M[Multiset] =
+    M.liftF(r.limit(limit))
 
   private def evaluateConstruct[T](
       bgp: Expr.BGP,

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
@@ -5,4 +5,6 @@ sealed trait EngineError
 object EngineError {
   case class General(description: String) extends EngineError
   case class UnknownFunction(fn: String) extends EngineError
+  case class UnexpectedNegativeLimit(description: String) extends EngineError
+  case class NumericTypesDoNotMatch(description: String) extends EngineError
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -133,15 +133,13 @@ final case class Multiset(
         .withColumn(binding.s, column)
     )
 
-  def offsetLimit(offset: Option[Long], limit: Option[Long]): Result[Multiset] = limit match {
-    case Some(l) if l < 0 =>
+  def limit(limit: Long): Result[Multiset] = limit match {
+    case l if l < 0 =>
       EngineError.UnexpectedNegativeLimit("Negative limit: $l").asLeft
-    case Some(l) if l > Int.MaxValue.toLong =>
+    case l if l > Int.MaxValue.toLong =>
       EngineError.NumericTypesDoNotMatch(s"$l to big to be converted to an Int").asLeft
-    case Some(l) =>
+    case l =>
       this.copy(dataframe = dataframe.limit(l.toInt)).asRight
-    case None =>
-      this.asRight // An optimization could be done on DAG level when None returning the rest of the algebra
   }
 
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -55,10 +55,15 @@ object ToTree extends LowPriorityToTreeInstances0 {
           case DAG.Filter(funcs, expr) =>
             Node("Filter", funcs.map(_.toTree).toStream #::: Stream(expr))
           case DAG.Join(l, r) => Node("Join", Stream(l, r))
-          case DAG.OffsetLimit(offset, limit, r) =>
+          case DAG.Offset(offset, r) =>
             Node(
-              "OffsetLimit",
-              Stream(Leaf(offset.toString), Leaf(limit.toString), r)
+              "Offset",
+              Stream(Leaf(offset.toString), r)
+            )
+          case DAG.Limit(limit, r) =>
+            Node(
+              "Limit",
+              Stream(Leaf(limit.toString), r)
             )
           case DAG.Distinct(r) => Node("Distinct", Stream(r))
           case DAG.Noop(str)   => Leaf(s"Noop($str)")

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -250,6 +250,83 @@ class CompilerSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     Compiler.compile(inputDF, query).right.get.collect.toSet shouldEqual outputDF.collect().toSet
   }
 
+  it should "query a real DF with limit greater than 0 and obtain a correct result" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("a", "b", "c"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Anthony"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Perico"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Henry")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+        |
+        |SELECT  ?name
+        |WHERE   { ?x foaf:name ?name }
+        |LIMIT   2
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Right[_, _]]
+    result.right.get.collect.length shouldEqual 2
+    result.right.get.collect.toSet shouldEqual Set(Row("Anthony"), Row("Perico"))
+  }
+
+  it should "query a real DF with limit equal to 0 and obtain no results" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("a", "b", "c"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Anthony"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Perico"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Henry")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+        |
+        |SELECT  ?name
+        |WHERE   { ?x foaf:name ?name }
+        |LIMIT   0
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Right[_, _]]
+    result.right.get.collect.length shouldEqual 0
+    result.right.get.collect.toSet shouldEqual Set.empty
+  }
+
+  it should "query a real DF with limit greater than Java MAX INTEGER and obtain an error" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("a", "b", "c"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Anthony"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Perico"),
+      ("team", "<http://xmlns.com/foaf/0.1/name>", "Henry")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+        |
+        |SELECT  ?name
+        |WHERE   { ?x foaf:name ?name }
+        |LIMIT   2147483648
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Left[_, _]]
+    result.left.get shouldEqual EngineError.NumericTypesDoNotMatch("2147483648 to big to be converted to an Int")
+  }
+
   private def readNTtoDF(path: String) = {
     import sqlContext.implicits._
     import scala.collection.JavaConverters._


### PR DESCRIPTION
This PR separates the two different constructs in the DAG.  We don't really need them to be tied together.  Also, in the transformation, we're checking in case both are None, in which case we pass the underlying algebra directly.

To be merged after #74 