### PR TITLE
Sparql offset support

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -40,7 +40,7 @@ object Engine {
       case DAG.Union(l, r)             => l.union(r).pure[M]
       case DAG.Filter(funcs, expr)     => notImplemented("Filter")
       case DAG.Join(l, r)              => notImplemented("Join")
-      case DAG.Offset(offset, r)       => notImplemented("Offset")
+      case DAG.Offset(offset, r)       => evaluateOffset(offset, r)
       case DAG.Limit(limit, r)         => evaluateLimit(limit, r)
       case DAG.Distinct(r)             => notImplemented("Distinct")
       case DAG.Noop(str)               => notImplemented("Noop")
@@ -59,6 +59,9 @@ object Engine {
       .runA(dataframe)
       .map(_.dataframe)
   }
+
+  private def evaluateOffset(offset: Long, r: Multiset): M[Multiset] =
+    M.liftF(r.offset(offset))
 
   private def evaluateLimit(limit: Long, r: Multiset): M[Multiset] =
     M.liftF(r.limit(limit))

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
@@ -5,6 +5,6 @@ sealed trait EngineError
 object EngineError {
   case class General(description: String) extends EngineError
   case class UnknownFunction(fn: String) extends EngineError
-  case class UnexpectedNegativeLimit(description: String) extends EngineError
+  case class UnexpectedNegative(description: String) extends EngineError
   case class NumericTypesDoNotMatch(description: String) extends EngineError
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -58,12 +58,12 @@ object ToTree extends LowPriorityToTreeInstances0 {
           case DAG.Offset(offset, r) =>
             Node(
               "Offset",
-              Stream(Leaf(offset.toString), r)
+              Stream(offset.toTree, r)
             )
           case DAG.Limit(limit, r) =>
             Node(
               "Limit",
-              Stream(Leaf(limit.toString), r)
+              Stream(limit.toTree, r)
             )
           case DAG.Distinct(r) => Node("Distinct", Stream(r))
           case DAG.Noop(str)   => Leaf(s"Noop($str)")


### PR DESCRIPTION
This PR adds SparQL Solution Sequence Modifier OFFSET support.

Acceptance criteria:

Given a sequence of solutions S = (S0, S1, ..., Sn) where N is the total number of solutions without modifier.
Then Offset(S, K) where K is the offset:
- If K >= 0 and N >= K it will return S' where S' = S(Sk, Sk+1, ..., Sn)
- If K >= 0 and N < K it will return S' where S' = ()
- If K == 0 it will return S' where S' = S
- If K < 0 it will return an Engine Error

Merge after #75