### PR TITLE
added show typeclass to TreeRep draw method

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -14,7 +14,7 @@ import com.gsk.kg.sparqlparser.Expr
   * render them nicely wit the drawTree method.
   */
 trait ToTree[T] {
-  def toTree(t: T): TreeRep
+  def toTree(t: T): TreeRep[String]
 }
 
 object ToTree extends LowPriorityToTreeInstances0 {
@@ -22,14 +22,14 @@ object ToTree extends LowPriorityToTreeInstances0 {
   def apply[T](implicit T: ToTree[T]): ToTree[T] = T
 
   implicit class ToTreeOps[T](private val t: T)(implicit T: ToTree[T]) {
-    def toTree: TreeRep = ToTree[T].toTree(t)
+    def toTree: TreeRep[String] = ToTree[T].toTree(t)
   }
 
   implicit def dagToTree[T: Basis[DAG, *]]: ToTree[T] =
     new ToTree[T] {
-      def toTree(tree: T): TreeRep = {
+      def toTree(tree: T): TreeRep[String] = {
         import TreeRep._
-        val alg = Algebra[DAG, TreeRep] {
+        val alg = Algebra[DAG, TreeRep[String]] {
           case DAG.Describe(vars, r) =>
             Node("Describe", vars.map(_.s.toTree).toStream #::: Stream(r))
           case DAG.Ask(r) => Node("Ask", Stream(r))
@@ -77,9 +77,9 @@ object ToTree extends LowPriorityToTreeInstances0 {
 
   implicit def expressionfToTree[T: Basis[ExpressionF, *]]: ToTree[T] =
     new ToTree[T] {
-      def toTree(tree: T): TreeRep = {
+      def toTree(tree: T): TreeRep[String] = {
         import TreeRep._
-        val alg = Algebra[ExpressionF, TreeRep] {
+        val alg = Algebra[ExpressionF, TreeRep[String]] {
           case ExpressionF.EQUALS(l, r)    => Node("EQUALS", Stream(l, r))
           case ExpressionF.GT(l, r)        => Node("GT", Stream(l, r))
           case ExpressionF.LT(l, r)        => Node("LT", Stream(l, r))
@@ -120,7 +120,7 @@ trait LowPriorityToTreeInstances0 {
   // Instance of ToTree for anything that has a Show
   implicit def showToTree[T: Show]: ToTree[T] =
     new ToTree[T] {
-      def toTree(t: T): TreeRep = TreeRep.Leaf(Show[T].show(t))
+      def toTree(t: T): TreeRep[String] = TreeRep.Leaf(Show[T].show(t))
     }
 
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/TreeRep.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/TreeRep.scala
@@ -10,17 +10,17 @@ import cats.Eval
   *
   * ported from scalaz.Tree
   */
-sealed trait TreeRep {
+sealed trait TreeRep[A] {
 
   import TreeRep._
 
   /** The label at the root of this tree. */
-  def rootLabel: String
+  def rootLabel: A
 
   /** The child nodes of this tree. */
-  def subForest: Stream[TreeRep]
+  def subForest: Stream[TreeRep[A]]
 
-  def drawTree: String = {
+  def drawTree(implicit ev: Show[A]): String = {
     val reversedLines: Vector[StringBuilder] = draw.run
     val first = new StringBuilder(reversedLines.head.toString.reverse)
     val rest = reversedLines.tail
@@ -33,13 +33,13 @@ sealed trait TreeRep {
     * Uses reversed StringBuilders for performance, because they are
     * prepended to.
     **/
-  private def draw: Trampoline[Vector[StringBuilder]] = {
+  private def draw(implicit ev: Show[A]): Trampoline[Vector[StringBuilder]] = {
     import Trampoline._
     val branch = " -+" // "+- ".reverse
     val stem = " -`" // "`- ".reverse
     val trunk = "  |" // "|  ".reverse
 
-    def drawSubTrees(s: Stream[TreeRep]): Trampoline[Vector[StringBuilder]] = s match {
+    def drawSubTrees(s: Stream[TreeRep[A]]): Trampoline[Vector[StringBuilder]] = s match {
       case ts if ts.isEmpty       =>
         done(Vector.empty[StringBuilder])
       case t #:: ts if ts.isEmpty =>
@@ -64,7 +64,7 @@ sealed trait TreeRep {
     }
 
     drawSubTrees(subForest).map { subtrees =>
-      new StringBuilder(rootLabel.reverse) +: subtrees
+      new StringBuilder(ev.show(rootLabel).reverse) +: subtrees
     }
   }
 }
@@ -72,19 +72,19 @@ sealed trait TreeRep {
 object TreeRep {
 
 
-  final case class Node(root: String, forest: Stream[TreeRep]) extends TreeRep {
+  final case class Node[A](root: A, forest: Stream[TreeRep[A]]) extends TreeRep[A] {
 
-    override def rootLabel: String = root
+    override def rootLabel: A = root
 
-    override def subForest: Stream[TreeRep] = forest
+    override def subForest: Stream[TreeRep[A]] = forest
 
   }
 
-  final case class Leaf(root: String) extends TreeRep {
+  final case class Leaf[A](root: A) extends TreeRep[A] {
 
-    override def rootLabel: String = root
+    override def rootLabel: A = root
 
-    override def subForest: Stream[TreeRep] = Stream.empty
+    override def subForest: Stream[TreeRep[A]] = Stream.empty
 
   }
 


### PR DESCRIPTION
This PR parametrizes ToTree[A] so the nodes of the tree now can hold an A type. 
With this we can draw more generic tree representations when provided an evidence of typeclass Show on A when draw method is called.