### PR TITLE
added support for sparql function isBlank

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -134,7 +134,7 @@ object ExpressionF {
       case CONCAT(appendTo, append) => Func.concat(appendTo, append).pure[M]
       case STR(s)                   => s.pure[M]
       case STRAFTER(s, f)           => Func.strafter(s, f).pure[M]
-      case ISBLANK(s)               => M.liftF[Result, DataFrame, Column](EngineError.UnknownFunction("ISBLANK").asLeft[Column])
+      case ISBLANK(s)               => Func.isBlank(s).pure[M] //M.liftF[Result, DataFrame, Column](EngineError.UnknownFunction("ISBLANK").asLeft[Column])
       case REPLACE(st, pattern, by) => Func.replace(st, pattern, by).pure[M]
 
       case STRING(s)   => lit(s).pure[M]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -5,6 +5,10 @@ import org.apache.spark.sql.functions.{concat => cc, _}
 
 object Func {
 
+  def isBlank(col: Column): Column =
+    when(regexp_extract(col, "^_:.*$", 0) =!= "", true)
+      .otherwise(false)
+
   /**
     * Implementation of SparQL REPLACE (without flags) on Spark dataframes.
     *

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
@@ -11,6 +11,33 @@ class FuncSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
   override implicit def enableHiveSupport: Boolean = false
 
+  "Func.isBlank" should {
+
+    "return whether a node is a blank node or not" in {
+      import sqlContext.implicits._
+
+      val df = List(
+        "_:a",
+        "a:a",
+        "_:1",
+        "1:1",
+        "foaf:name",
+        "_:name"
+      ).toDF("text")
+
+      val result = df.select(Func.isBlank(df("text"))).collect
+
+      result shouldEqual Array(
+        Row(true),
+        Row(false),
+        Row(true),
+        Row(false),
+        Row(false),
+        Row(true)
+      )
+    }
+  }
+
   "Func.replace" should {
 
     "replace when pattern occurs" in {


### PR DESCRIPTION
This PR adds SparQL isBlank function support to the engine.

Returns true if term is a blank node. Returns false otherwise.

Closes #86 