### PR TITLE
added sparql filter expression support

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -134,7 +134,7 @@ object ExpressionF {
       case CONCAT(appendTo, append) => Func.concat(appendTo, append).pure[M]
       case STR(s)                   => s.pure[M]
       case STRAFTER(s, f)           => Func.strafter(s, f).pure[M]
-      case ISBLANK(s)               => Func.isBlank(s).pure[M] //M.liftF[Result, DataFrame, Column](EngineError.UnknownFunction("ISBLANK").asLeft[Column])
+      case ISBLANK(s)               => Func.isBlank(s).pure[M]
       case REPLACE(st, pattern, by) => Func.replace(st, pattern, by).pure[M]
 
       case STRING(s)   => lit(s).pure[M]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -168,6 +168,11 @@ final case class Multiset(
     this.copy(dataframe = df).asRight
   }
 
+  def filter(col: Column): Result[Multiset] = {
+    val filtered = dataframe.filter(col)
+    this.copy(dataframe = filtered).asRight
+  }
+
 }
 
 object Multiset {

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -53,7 +53,7 @@ object ToTree extends LowPriorityToTreeInstances0 {
             Node("LeftJoin", Stream(l, r) #::: filters.map(_.toTree).toStream)
           case DAG.Union(l, r) => Node("Union", Stream(l, r))
           case DAG.Filter(funcs, expr) =>
-            Node("Filter", funcs.map(_.toTree).toStream #::: Stream(expr))
+            Node("Filter", funcs.map(_.toTree).toList.toStream #::: Stream(expr))
           case DAG.Join(l, r) => Node("Join", Stream(l, r))
           case DAG.Offset(offset, r) =>
             Node(


### PR DESCRIPTION
This PR add SparQL FILTER support.

It restricts the solution of a graph according to a given constraint. This is done by eliminate any solutions that, when evaluated  into the expression, either result in an effective boolean value of false or produce an error.

Closes #83 