### PR TITLE
added sparql optional support

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -3,21 +3,14 @@ package com.gsk.kg.engine
 import cats.Foldable
 import cats.data.NonEmptyList
 import cats.instances.all._
-import cats.syntax.EitherSyntax
 import cats.syntax.either._
 import cats.syntax.applicative._
 import org.apache.spark.sql.{Column, DataFrame, SQLContext}
-import org.apache.spark.sql.functions._
-import com.gsk.kg.engine._
 import com.gsk.kg.sparqlparser._
 import com.gsk.kg.sparqlparser.Expr.fixedpoint._
 import higherkindness.droste._
 import com.gsk.kg.sparqlparser.StringVal
 import com.gsk.kg.engine.Multiset._
-import com.gsk.kg.engine.Predicate.None
-import com.gsk.kg.sparqlparser.Query
-import com.gsk.kg.sparqlparser.Query.Construct
-import com.gsk.kg.sparqlparser.BuildInFunc._
 import com.gsk.kg.sparqlparser.StringVal._
 import com.gsk.kg.sparqlparser.Expression
 
@@ -59,10 +52,10 @@ object Engine {
   }
 
   private def evaluateLeftJoin(l: Multiset, r: Multiset, filters: List[Expression]): M[Multiset] = {
-    if (filters.isEmpty) {
-      M.liftF[Result, DataFrame, Multiset](l.leftJoin(r))
-    } else {
-      evaluateFilter(NonEmptyList.fromListUnsafe(filters), r).flatMapF(l.leftJoin)
+    NonEmptyList.fromList(filters).map { nelFilters =>
+      evaluateFilter(nelFilters, r).flatMapF(l.leftJoin)
+    }.getOrElse {
+      M.liftF(l.leftJoin(r))
     }
   }
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -168,9 +168,28 @@ final case class Multiset(
     this.copy(dataframe = df).asRight
   }
 
+  /**
+    * Filter restrict the set of solutions according to a given expression.
+    * @param col
+    * @return
+    */
   def filter(col: Column): Result[Multiset] = {
     val filtered = dataframe.filter(col)
     this.copy(dataframe = filtered).asRight
+  }
+
+  /**
+    * A left join returns all values from the left relation and the matched values from the right relation,
+    * or appends NULL if there is no match. It is also referred to as a left outer join.
+    * @param r
+    * @return
+    */
+  def leftJoin(r: Multiset): Result[Multiset] = {
+    val cols: Seq[String] = (this.bindings intersect r.bindings).toSeq.map(_.s)
+    this.copy(
+      bindings = this.bindings union r.bindings,
+      dataframe = this.dataframe.join(r.dataframe, cols, "left")
+    ).asRight
   }
 
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -818,6 +818,106 @@ class CompilerSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
     )
   }
 
+  it should "query a real DF with OPTIONAL and obtain expected results with simple optional" in {
+
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("_:a", "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://xmlns.com/foaf/0.1/Person"),
+      ("_:a", "http://xmlns.com/foaf/0.1/name", "Alice"),
+      ("_:a", "http://xmlns.com/foaf/0.1/mbox", "mailto:alice@example.com"),
+      ("_:a", "http://xmlns.com/foaf/0.1/mbox", "mailto:alice@work.example"),
+      ("_:b", "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "http://xmlns.com/foaf/0.1/Person"),
+      ("_:b", "http://xmlns.com/foaf/0.1/name", "Bob")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        |SELECT ?name ?mbox
+        |WHERE  { ?x foaf:name  ?name .
+        |         OPTIONAL { ?x  foaf:mbox  ?mbox }
+        |       }
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Right[_, _]]
+    result.right.get.collect.length shouldEqual 3
+    result.right.get.collect.toSet shouldEqual Set(
+      Row("\"Alice\"", "mailto:alice@example.com"),
+      Row("\"Alice\"", "mailto:alice@work.example"),
+      Row("\"Bob\"", null)
+    )
+  }
+
+  it should "query a real DF with OPTIONAL and obtain expected results with constraints in optional" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("_:book1", "http://purl.org/dc/elements/1.1/title", "SPARQL Tutorial"),
+      ("_:book1", "http://example.org/ns#price", "42"),
+      ("_:book2", "http://purl.org/dc/elements/1.1/title", "The Semantic Web"),
+      ("_:book2", "http://example.org/ns#price", "_:23")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+        |PREFIX  ns:  <http://example.org/ns#>
+        |
+        |SELECT  ?title ?price
+        |WHERE   {
+        |   ?x dc:title ?title .
+        |   OPTIONAL {
+        |     ?x ns:price ?price
+        |     FILTER(isBlank(?price))
+        |   }
+        |}
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Right[_, _]]
+    result.right.get.collect.length shouldEqual 2
+    result.right.get.collect.toSet shouldEqual Set(
+      Row("\"SPARQL Tutorial\"", null),
+      Row("\"The Semantic Web\"", "_:23")
+    )
+  }
+
+  it should "query a real DF with OPTIONAL and obtain expected results with multiple optionals" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      ("_:a", "http://xmlns.com/foaf/0.1/name", "Alice"),
+      ("_:a", "http://xmlns.com/foaf/0.1/homepage", "http://work.example.org/alice/"),
+      ("_:b", "http://xmlns.com/foaf/0.1/name", "Bob"),
+      ("_:b", "http://xmlns.com/foaf/0.1/mbox", "mailto:bob@work.example")
+    ).toDF("s", "p", "o")
+
+    val query =
+      """
+        |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        |
+        |SELECT ?name ?mbox ?hpage
+        |WHERE  {
+        |   ?x foaf:name  ?name .
+        |   OPTIONAL { ?x foaf:mbox ?mbox } .
+        |   OPTIONAL { ?x foaf:homepage ?hpage }
+        |}
+        |""".stripMargin
+
+    val result = Compiler.compile(df, query)
+
+    result shouldBe a[Right[_, _]]
+    result.right.get.collect.length shouldEqual 2
+    result.right.get.collect.toSet shouldEqual Set(
+      Row("\"Alice\"", null, "http://work.example.org/alice/"),
+      Row("\"Bob\"", "mailto:bob@work.example", null)
+    )
+  }
+
   private def readNTtoDF(path: String) = {
     import sqlContext.implicits._
     import scala.collection.JavaConverters._


### PR DESCRIPTION
This PR adds SparQL support for OPTIONAL operation. It performs a left outer join in Spark and also applies, in case they exist, filters on the right side of the join.

Closes #87 