### PR TITLE
added support for negated isBlank

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -128,7 +128,7 @@ object ExpressionF {
       case LT(l, r)        => M.liftF[Result, DataFrame, Column](EngineError.UnknownFunction("LT").asLeft[Column])
       case OR(l, r)        => M.liftF[Result, DataFrame, Column](EngineError.UnknownFunction("OR").asLeft[Column])
       case AND(l, r)       => M.liftF[Result, DataFrame, Column](EngineError.UnknownFunction("AND").asLeft[Column])
-      case NEGATE(s)       => M.liftF[Result, DataFrame, Column](EngineError.UnknownFunction("NEGATE").asLeft[Column])
+      case NEGATE(s)       => Func.negate(s).pure[M]
 
       case URI(s)                   => Func.iri(s).pure[M]
       case CONCAT(appendTo, append) => Func.concat(appendTo, append).pure[M]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -5,6 +5,19 @@ import org.apache.spark.sql.functions.{concat => cc, _}
 
 object Func {
 
+  /**
+    * Negates all rows of a column
+    * @param s
+    * @return
+    */
+  def negate(s: Column): Column =
+    not(s)
+
+  /**
+    * Returns a column with 'true' or 'false' rows indicating whether a column has blank nodes
+    * @param col
+    * @return
+    */
   def isBlank(col: Column): Column =
     when(regexp_extract(col, "^_:.*$", 0) =!= "", true)
       .otherwise(false)

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
@@ -2,7 +2,7 @@ package com.gsk.kg.engine
 
 import org.scalatest.matchers.should.Matchers
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{AnalysisException, Row}
 import org.scalatest.wordspec.AnyWordSpec
 
 class FuncSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
@@ -10,6 +10,41 @@ class FuncSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
   override implicit def reuseContextIfPossible: Boolean = true
 
   override implicit def enableHiveSupport: Boolean = false
+
+  "Func.negate" should {
+
+    "return the input boolean column negated" in {
+      import sqlContext.implicits._
+
+      val df = List(
+        true,
+        false
+      ).toDF("boolean")
+
+      val result = df.select(Func.negate(df("boolean"))).collect
+
+      result shouldEqual Array(
+        Row(false),
+        Row(true)
+      )
+    }
+
+    "fail when the input column contain values that are not boolean values" in {
+      import sqlContext.implicits._
+
+      val df = List(
+        "a",
+        null
+      ).toDF("boolean")
+
+      val caught = intercept[AnalysisException] {
+        df.select(Func.negate(df("boolean"))).collect
+      }
+
+      caught.getMessage should contain
+        "cannot resolve '(NOT `boolean`)' due to data type mismatch"
+    }
+  }
 
   "Func.isBlank" should {
 


### PR DESCRIPTION
This PR adds support for !isBlank, it also adds support for any query expression that is parsed by the engine as a NOT operation in our DAG.

Closes #88 