### PR TITLE
added support for default and named graph on parser side

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/DAG.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/DAG.scala
@@ -145,12 +145,12 @@ object DAG {
     * @return
     */
   def fromQuery[T: Basis[DAG, *]]: Query => T = {
-    case Query.Describe(vars, r) =>
+    case Query.Describe(vars, r, _, _) =>
       describeR(vars.toList, fromExpr[T].apply(r))
-    case Query.Ask(r) => askR(fromExpr[T].apply(r))
-    case Query.Construct(vars, bgp, r) =>
+    case Query.Ask(r, _, _) => askR(fromExpr[T].apply(r))
+    case Query.Construct(vars, bgp, r, _, _) =>
       constructR(bgp, fromExpr[T].apply(r))
-    case Query.Select(vars, r) => projectR(vars.toList, fromExpr[T].apply(r))
+    case Query.Select(vars, r, _, _) => projectR(vars.toList, fromExpr[T].apply(r))
   }
 
   def fromExpr[T: Basis[DAG, *]]: Expr => T = scheme.cata(transExpr.algebra)

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -10,10 +10,21 @@ sealed trait Query {
 
 object Query {
   import com.gsk.kg.sparqlparser.Expr.BGP
-  final case class Describe(vars: Seq[VARIABLE], r: Expr) extends Query
-  final case class Ask(r: Expr) extends Query
-  final case class Construct(vars: Seq[VARIABLE], bgp: BGP, r: Expr) extends Query
-  final case class Select(vars: Seq[VARIABLE], r: Expr) extends Query
+  final case class Describe(vars: Seq[VARIABLE], r: Expr,
+                            defaultGraphs: List[StringVal.URIVAL] = List.empty,
+                            namedGraphs: List[StringVal.URIVAL] = List.empty) extends Query
+  final case class Ask(r: Expr,
+                       defaultGraphs: List[StringVal.URIVAL] = List.empty,
+                       namedGraphs: List[StringVal.URIVAL] = List.empty) extends Query
+  final case class Construct(vars: Seq[VARIABLE],
+                             bgp: BGP,
+                             r: Expr,
+                             defaultGraphs: List[StringVal.URIVAL] = List.empty,
+                             namedGraphs: List[StringVal.URIVAL] = List.empty) extends Query
+  final case class Select(vars: Seq[VARIABLE],
+                          r: Expr,
+                          defaultGraphs: List[StringVal.URIVAL] = List.empty,
+                          namedGraphs: List[StringVal.URIVAL] = List.empty) extends Query
 }
 
 @deriveFixedPoint sealed trait Expr

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -90,7 +90,7 @@ object ExprParser {
     p => Join(p._1, p._2)
   }
 
-  def graphParen[_:P]:P[Graph] = P("(" ~ graph ~ StringValParser.urival ~ graphPattern ~ ")").map{
+  def graphParen[_:P]:P[Graph] = P("(" ~ graph ~ (StringValParser.urival | StringValParser.variable) ~ graphPattern ~ ")").map{
     p => Graph(p._1, p._2)
   }
 

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
@@ -10,7 +10,7 @@ class QueryConstructSpec extends AnyFlatSpec {
 
   "Simple Query" should "parse Construct statement with correct number of Triples" in {
     TestUtils.query("/queries/q0-simple-basic-graph-pattern.sparql") match {
-      case Construct(vars, bgp, expr) =>
+      case Construct(vars, bgp, expr, List(), List()) =>
         assert(vars.size == 2 && bgp.triples.size == 2)
       case _ => fail
     }
@@ -19,7 +19,7 @@ class QueryConstructSpec extends AnyFlatSpec {
 
   "Construct" should "result in proper variables, a basic graph pattern, and algebra expression" in {
     TestUtils.query("/queries/q3-union.sparql") match {
-      case Construct(vars, bgp, Union(BGP(triplesL: Seq[Triple]), BGP(triplesR: Seq[Triple]))) =>
+      case Construct(vars, bgp, Union(BGP(triplesL: Seq[Triple]), BGP(triplesR: Seq[Triple])), List(), List()) =>
         val temp = QueryConstruct.getAllVariableNames(bgp)
         val all = vars.map(_.s).toSet
         assert((all -- temp) == Set("?lnk"))
@@ -30,7 +30,7 @@ class QueryConstructSpec extends AnyFlatSpec {
 
   "Construct with Bind" should "contains bind variable" in {
     TestUtils.query("/queries/q4-simple-bind.sparql") match {
-      case Construct(vars, bgp, Extend(l: StringVal, r: StringVal, BGP(triples: Seq[Triple]))) =>
+      case Construct(vars, bgp, Extend(l: StringVal, r: StringVal, BGP(triples: Seq[Triple])), List(), List()) =>
         vars.exists(_.s == "?dbind")
       case _ => fail
     }
@@ -38,7 +38,7 @@ class QueryConstructSpec extends AnyFlatSpec {
 
   "Complex named graph query" should "be captured properly in Construct" in {
     TestUtils.query("/queries/q13-complex-named-graph.sparql") match {
-      case Construct(vars, bgp, expr) =>
+      case Construct(vars, bgp, expr, List(), List()) =>
         assert(vars.size == 13)
         assert(vars.exists(va => va.s == "?ogihw"))
       case _ => fail
@@ -48,7 +48,7 @@ class QueryConstructSpec extends AnyFlatSpec {
   "Complex lit-search query" should "return proper Construct type" in {
     val a = 1
     TestUtils.query("/queries/lit-search-3.sparql") match {
-      case Construct(vars, bgp, expr) =>
+      case Construct(vars, bgp, expr, List(), List()) =>
         assert(bgp.triples.size == 11)
         assert(bgp.triples.head.o.asInstanceOf[BLANK].s == bgp.triples(1).s.asInstanceOf[BLANK].s)
         assert(vars.exists(v => v.s == "?secid"))
@@ -58,7 +58,7 @@ class QueryConstructSpec extends AnyFlatSpec {
 
   "Extra large query" should "return proper Construct type" in {
     TestUtils.query("/queries/lit-search-xlarge.sparql") match {
-      case Construct(vars, bgp, expr) =>
+      case Construct(vars, bgp, expr, List(), List()) =>
         assert(bgp.triples.size == 67)
         assert(bgp.triples.head.s.asInstanceOf[VARIABLE].s == "?Year")
         assert(bgp.triples.last.s.asInstanceOf[VARIABLE].s == "?Predication")
@@ -85,7 +85,12 @@ class QueryConstructSpec extends AnyFlatSpec {
       """
 
     QueryConstruct.parse(query) match {
-      case Construct(vars, bgp, Project(Seq(VARIABLE("?name"), VARIABLE("?person")),Filter(funcs,expr))) => succeed
+      case Construct(vars,
+        bgp,
+        Project(Seq(VARIABLE("?name"), VARIABLE("?person")),
+        Filter(funcs,expr)),
+        List(),
+        List()) => succeed
       case _ => fail
     }
   }
@@ -116,7 +121,9 @@ class QueryConstructSpec extends AnyFlatSpec {
             BGP(
               mutable.ArrayBuffer(
                 Triple(VARIABLE("?de"),URIVAL("http://gsk-kg.rdip.gsk.com/dm/1.0/predEntityClass"),VARIABLE("??0")),
-                Triple(VARIABLE("??0"),URIVAL("http://gsk-kg.rdip.gsk.com/dm/1.0/predClass"),VARIABLE("?et"))))))) =>
+                Triple(VARIABLE("??0"),URIVAL("http://gsk-kg.rdip.gsk.com/dm/1.0/predClass"),VARIABLE("?et")))))),
+        List(),
+        List()) =>
         succeed
       case _ => fail
     }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamples.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamples.scala
@@ -454,4 +454,43 @@ object QuerySamples {
         BIND(URI(CONCAT("http://lit-search-api/node/predication#", ?predid)) as ?pred)
     }
     """
+
+  // Query that combines FROM and FROM NAMED graph to default graph and
+  // FROM NAMED as named graphs in the same query. It uses GRAPH expression
+  // with a specific URI so it will match that specific graph
+  val q36 =
+  """
+    |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    |PREFIX dc: <http://purl.org/dc/elements/1.1/>
+    |PREFIX ex: <http://example.org/>
+    |
+    |SELECT ?who ?mbox
+    |FROM <http://example.org/dft.ttl>
+    |FROM NAMED <http://example.org/alice>
+    |FROM NAMED <http://example.org/bob>
+    |WHERE
+    |{
+    |   GRAPH ex:alice { ?x foaf:mbox ?mbox }
+    |}
+    |""".stripMargin
+
+  // Query that combines FROM for adding graph to default graph and
+  // FROM NAMED as named graphs in the same query. It uses GRAPH expression
+  // with a variable so it can match multiple graphs.
+  val q37 =
+    """
+      |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+      |PREFIX dc: <http://purl.org/dc/elements/1.1/>
+      |PREFIX ex: <http://example.org/>
+      |
+      |SELECT ?who ?g ?mbox
+      |FROM <http://example.org/dft.ttl>
+      |FROM NAMED <http://example.org/alice>
+      |FROM NAMED <http://example.org/bob>
+      |WHERE
+      |{
+      |   ?g dc:publisher ?who .
+      |   GRAPH ?g { ?x foaf:mbox ?mbox }
+      |}
+      |""".stripMargin
 }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -1,14 +1,15 @@
 package com.gsk.kg.sparqlparser
 import com.gsk.kg.sparqlparser.Expr._
-import com.gsk.kg.sparqlparser.Conditional._
 import com.gsk.kg.sparqlparser.Query.{Construct, Describe, Select}
 import com.gsk.kg.sparqlparser.BuildInFunc._
 import com.gsk.kg.sparqlparser.StringVal._
 import org.apache.jena.query.QueryFactory
 import org.apache.jena.sparql.algebra.{Algebra, Op}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
-class QuerySamplesTestSpec extends AnyFlatSpec {
+class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   def showAlgebra(q: String): Op = {
     val query = QueryFactory.create(q)
@@ -186,7 +187,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q15
     val q = QueryConstruct.parse(query)
     q match {
-      case Describe(_, OpNil()) =>
+      case Describe(_, OpNil(), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -197,7 +198,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q16
     val q = QueryConstruct.parse(query)
     q match {
-      case Describe(vars, Project(vs, Filter(_,_))) =>
+      case Describe(vars, Project(vs, Filter(_,_)), List(), List()) =>
         assert(vars == vs)
         succeed
       case _ =>
@@ -209,7 +210,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q17
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(vs, Filter(_,_)))=>
+      case Select(vars, Project(vs, Filter(_,_)), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -220,7 +221,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q18
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(vs, Filter(_,_)))=>
+      case Select(vars, Project(vs, Filter(_,_)), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -231,7 +232,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q19
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Distinct(Project(vs, Filter(_,_))))=>
+      case Select(vars, Distinct(Project(vs, Filter(_,_))), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -242,7 +243,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q20
     val q = QueryConstruct.parse(query)
     q match {
-      case Construct(vars, _, Extend(to,REPLACE(_,_,_),r))=>
+      case Construct(vars, _, Extend(to,REPLACE(_,_,_),r), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -253,7 +254,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q21
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(vs, BGP(ts)))=>
+      case Select(vars, Project(vs, BGP(ts)), List(), List()) =>
         assert(ts.size == 21)
       case _ =>
         fail
@@ -266,7 +267,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q22
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, OffsetLimit(None, Some(10),Project(_,Filter(_,_))))=>
+      case Select(vars, OffsetLimit(None, Some(10),Project(_,Filter(_,_))), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -277,7 +278,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q23
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, OffsetLimit(None, Some(10),Distinct(Project(vs,_))))=>
+      case Select(vars, OffsetLimit(None, Some(10),Distinct(Project(vs,_))), List(), List()) =>
         assert(vs.size == 3)
       case _ =>
         fail
@@ -288,7 +289,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q24
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(_,Filter(_,_))) =>
+      case Select(vars, Project(_,Filter(_,_)), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -299,7 +300,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q25
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(_,Filter(_,_))) =>
+      case Select(vars, Project(_,Filter(_,_)), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -310,7 +311,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q26
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Distinct(Project(_,_)))=>
+      case Select(vars, Distinct(Project(_,_)), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -321,7 +322,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q27
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(vs,_))=>
+      case Select(vars, Project(vs,_), List(), List()) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
       case _ =>
         fail
@@ -332,7 +333,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q28
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(_,_))=>
+      case Select(vars, Project(_,_), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -343,7 +344,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q29
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(_,_))=>
+      case Select(vars, Project(_,_), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -354,7 +355,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q30
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(_,Filter(_,_)))=>
+      case Select(vars, Project(_,Filter(_,_)), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -365,7 +366,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q31
     val q = QueryConstruct.parse(query)
     q match {
-      case Construct(vars, bgp, BGP(_))=>
+      case Construct(vars, bgp, BGP(_), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -376,7 +377,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q32
     val q = QueryConstruct.parse(query)
     q match {
-      case Construct(vars, bgp, BGP(_))=>
+      case Construct(vars, bgp, BGP(_), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -387,7 +388,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q33
     val q = QueryConstruct.parse(query)
     q match {
-      case Select(vars, Project(_,_))=>
+      case Select(vars, Project(_,_), List(), List()) =>
         succeed
       case _ =>
         fail
@@ -398,7 +399,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q34
     val q = QueryConstruct.parse(query)
     q match {
-      case Construct(vars, bgp, Union(BGP(_),BGP(_)))=>
+      case Construct(vars, bgp, Union(BGP(_),BGP(_)), List(), List())=>
         succeed
       case _ =>
         fail
@@ -409,8 +410,39 @@ class QuerySamplesTestSpec extends AnyFlatSpec {
     val query = QuerySamples.q35
     val q = QueryConstruct.parse(query)
     q match {
-      case Construct(vars, bgp, Extend(to, from, e))=>
+      case Construct(vars, bgp, Extend(to, from, e), List(), List())=>
         assert(to == VARIABLE("?pred"))
+      case _ =>
+        fail
+    }
+  }
+
+  "Query with default and named graphs to match on specific graph" should "parse" in {
+    val query = QuerySamples.q36
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(_, Project(_, Graph(specifiedGraph, _)), defaultGraphs, namedGraphs) =>
+        defaultGraphs should (have size 1 and contain(
+          URIVAL("http://example.org/dft.ttl")))
+        namedGraphs should (have size 2 and contain allElementsOf
+          List(URIVAL("http://example.org/alice"), URIVAL("http://example.org/bob")))
+        specifiedGraph shouldEqual namedGraphs.head
+      case _ =>
+        fail
+    }
+  }
+
+
+  "Query with default and named graphs to match on multiple graphs" should "parse" in {
+    val query = QuerySamples.q37
+    val q = QueryConstruct.parse(query)
+    q match {
+      case Select(vars, Project(_, Join(_, Graph(graphVariable, _))), defaultGraphs, namedGraphs) =>
+        defaultGraphs should (have size 1 and contain(
+          URIVAL("http://example.org/dft.ttl")))
+        namedGraphs should (have size 2 and contain allElementsOf
+          List(URIVAL("http://example.org/alice"), URIVAL("http://example.org/bob")))
+        graphVariable shouldEqual vars(1)
       case _ =>
         fail
     }


### PR DESCRIPTION
This PR add support for parsing queries that contains:
* `FROM` for default graphs
* `FROM NAMED` for named graphs
* `GRAPH` on where clause with URI and with variable

The default and named graphs URIs are passed as List of URIs to the engine through the `Construct`, `Select`, `Ask` and `Describe` expressions.

The graph to query (URI or VARIABLE) on `where` statement is passed to the engine through the Graph expression. 

Closes #130
Closes #131 