### PR TITLE
format localized strings correctly

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/RdfFormatter.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/RdfFormatter.scala
@@ -34,8 +34,18 @@ object RdfFormatter {
       case RDFNum(num) => num
       case RDFBoolean(bool) => bool
       case RDFDataTypeLiteral(lit) => lit
+      case RDFLocalizedString(str) => str
       case str => s""""$str""""
     }).getOrElse(null) // scalastyle:off
+
+  object RDFLocalizedString {
+    def unapply(str: String): Option[String] =
+      if (str.startsWith("\"") && str.contains("\"@") && !str.endsWith("\"")) {
+        Some(str)
+      } else {
+        None
+      }
+  }
 
   object RDFDataTypeLiteral {
     def unapply(str: String): Option[String] =

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/RdfFormatterSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/RdfFormatterSpec.scala
@@ -39,6 +39,18 @@ class RdfFormatterSpec
     }
   }
 
+  "RDFLocalizedString" should "match localized strings correctly" in {
+    val localizedStringGen: Gen[String] =
+      for {
+        str <- Gen.alphaStr
+        lang <- Gen.oneOf("en", "es", "cn", "fr")
+      } yield s""""$str"@$lang"""
+
+    forAll(localizedStringGen) { str =>
+      RDFLocalizedString.unapply(str) shouldBe a[Some[_]]
+    }
+  }
+
   "formatField" should "not raises exceptions when formatting" in {
     val gen = Gen.oneOf(
       uriGen.map(_.toString()),


### PR DESCRIPTION
Identify correctly localized strings so that they get formatted without extra quotes surrounding them.

Closes #134