### PR TITLE
sparql support for graph joins

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -41,7 +41,7 @@ object Engine {
       case DAG.LeftJoin(l, r, filters) => evaluateLeftJoin(l, r, filters)
       case DAG.Union(l, r)             => evaluateUnion(l, r)
       case DAG.Filter(funcs, expr)     => evaluateFilter(funcs, expr)
-      case DAG.Join(l, r)              => notImplemented("Join")
+      case DAG.Join(l, r)              => evaluateJoin(l, r)
       case DAG.Offset(offset, r)       => evaluateOffset(offset, r)
       case DAG.Limit(limit, r)         => evaluateLimit(limit, r)
       case DAG.Distinct(r)             => evaluateDistinct(r)
@@ -71,6 +71,9 @@ object Engine {
       )
     )
   )
+
+  private def evaluateJoin(l: Multiset, r: Multiset): M[Multiset] =
+    l.join(r).pure[M]
 
   private def evaluateUnion(l: Multiset, r: Multiset): M[Multiset] =
     l.union(r).pure[M]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -79,7 +79,9 @@ object Engine {
     l.union(r).pure[M]
 
   private def evaluateScan(graph: String, expr: Multiset): M[Multiset] = {
-    val df = expr.dataframe.filter(expr.dataframe(GRAPH_VARIABLE.s) === graph)
+    val df = expr.dataframe
+      .filter(expr.dataframe(GRAPH_VARIABLE.s) === graph)
+      .withColumn(GRAPH_VARIABLE.s, lit(""))
     expr.copy(dataframe = df).pure[M]
   }
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -7,8 +7,11 @@ import cats.syntax.all._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
 
+import com.gsk.kg.engine.Multiset.filterGraph
+import com.gsk.kg.sparqlparser.StringVal.GRAPH_VARIABLE
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 
 /** A [[Multiset]], as expressed in SparQL terms.
@@ -37,23 +40,89 @@ final case class Multiset(
     * @param other
     * @return the join result of both multisets
     */
-  def join(other: Multiset): Multiset =
+  def join(other: Multiset): Multiset = {
     (this, other) match {
-      case (a, b) if a.isEmpty => b
-      case (a, b) if b.isEmpty => a
-      case (Multiset(aBindings, aDF), Multiset(bBindings, bDF))
-          if aBindings.intersect(bBindings).isEmpty =>
-        val df = aDF
-          .as("a")
-          .crossJoin(bDF.as("b"))
-        Multiset(aBindings.union(bBindings), df)
-      case (a, b) =>
-        val common = a.bindings.intersect(b.bindings)
-        val df = a.dataframe
-          .as("a")
-          .join(b.dataframe.as("b"), common.map(_.s).toSeq)
-        Multiset(a.bindings.union(b.bindings), df)
+      case (l, r) if l.isEmpty => r
+      case (l, r) if r.isEmpty => l
+      case (l, r)
+          if (filterGraph(l).bindings intersect filterGraph(
+            r
+          ).bindings).isEmpty =>
+        Multiset.graphAgnostic(l, r) { (left, right) =>
+          val df = left.dataframe.as("a").crossJoin(right.dataframe.as("b"))
+          Multiset(left.bindings union right.bindings, df)
+        }
+      case (l, r) =>
+        Multiset.graphAgnostic(l, r) { (left, right) =>
+          val df = left.dataframe.join(
+            right.dataframe,
+            (left.bindings intersect right.bindings).toSeq.map(_.s),
+            "inner"
+          )
+          Multiset(left.bindings union right.bindings, df)
+        }
     }
+  }
+
+  /** A left join returns all values from the left relation and the matched values from the right relation,
+    * or appends NULL if there is no match. It is also referred to as a left outer join.
+    * @param other
+    * @return
+    */
+  def leftJoin(other: Multiset): Result[Multiset] = Multiset
+    .graphAgnostic(this, other) {
+      case (l, r) if l.isEmpty => l
+      case (l, r) if r.isEmpty => l
+      case (Multiset(lBindings, lDF), Multiset(rBindings, rDF)) =>
+        val df =
+          lDF.join(rDF, (lBindings intersect rBindings).toSeq.map(_.s), "left")
+        Multiset(lBindings union rBindings, df)
+    }
+    .asRight
+
+  /** Perform a union between [[this]] and [[other]], as described in
+    * SparQL Algebra doc.
+    *
+    * =Spec=
+    *
+    * Defn: Union
+    * Let Ω1 and Ω2 be multisets of mappings. We define:
+    * Union(Ω1, Ω2) = { μ | μ in Ω1 or μ in Ω2 }
+    * card[Union(Ω1, Ω2)](μ) = card[Ω1](μ) + card[Ω2](μ)
+    *
+    * @param other
+    * @return the Union of both multisets
+    */
+  def union(other: Multiset): Multiset = Multiset.graphAgnostic(this, other) {
+    case (a, b) if a.isEmpty => b
+    case (a, b) if b.isEmpty => a
+    case (Multiset(aBindings, aDF), Multiset(bBindings, bDF))
+        if aDF.columns == bDF.columns =>
+      Multiset(
+        aBindings.union(bBindings),
+        aDF.union(bDF)
+      )
+    case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) =>
+      val colsA     = aDF.columns.toSet
+      val colsB     = bDF.columns.toSet
+      val colsUnion = colsA.union(colsB)
+
+      def genColumns(current: Set[String], total: Set[String]): Seq[Column] = {
+        total.toList.sorted.map {
+          case x if current.contains(x) => col(x)
+          case x                        => lit(null).as(x) // scalastyle:ignore
+        }
+      }
+
+      val bindingsUnion = aBindings union bBindings
+      val selectionA    = aDF.select(genColumns(colsA, colsUnion): _*)
+      val selectionB    = bDF.select(genColumns(colsB, colsUnion): _*)
+
+      Multiset(
+        bindingsUnion,
+        selectionA.unionByName(selectionB)
+      )
+  }
 
   /** Return wether both the dataframe & bindings are empty
     *
@@ -71,54 +140,6 @@ final case class Multiset(
       bindings.intersect(vars.toSet),
       dataframe.select(vars.map(v => dataframe(v.s)): _*)
     )
-
-  /** Perform a union between [[this]] and [[other]], as described in
-    * SparQL Algebra doc.
-    *
-    * =Spec=
-    *
-    * Defn: Union
-    * Let Ω1 and Ω2 be multisets of mappings. We define:
-    * Union(Ω1, Ω2) = { μ | μ in Ω1 or μ in Ω2 }
-    * card[Union(Ω1, Ω2)](μ) = card[Ω1](μ) + card[Ω2](μ)
-    *
-    * @param other
-    * @return the Union of both multisets
-    */
-  def union(other: Multiset): Multiset =
-    (this, other) match {
-      case (a, b) if a.isEmpty => b
-      case (a, b) if b.isEmpty => a
-      case (Multiset(aBindings, aDF), Multiset(bBindings, bDF))
-          if aDF.columns == bDF.columns =>
-        Multiset(
-          aBindings.union(bBindings),
-          aDF.union(bDF)
-        )
-      case (Multiset(aBindings, aDF), Multiset(bBindings, bDF)) =>
-        val colsA     = aDF.columns.toSet
-        val colsB     = bDF.columns.toSet
-        val colsUnion = colsA.union(colsB)
-
-        def genColumns(
-            current: Set[String],
-            total: Set[String]
-        ): Seq[Column] = {
-          total.toList.sorted.map {
-            case x if current.contains(x) => col(x)
-            case x                        => lit(null).as(x) // scalastyle:ignore
-          }
-        }
-
-        val bindingsUnion = aBindings union bBindings
-        val selectionA    = aDF.select(genColumns(colsA, colsUnion): _*)
-        val selectionB    = bDF.select(genColumns(colsB, colsUnion): _*)
-
-        Multiset(
-          bindingsUnion,
-          selectionA.union(selectionB)
-        )
-    }
 
   /** Add a new column to the multiset, with the given binding
     *
@@ -184,21 +205,6 @@ final case class Multiset(
     this.copy(dataframe = filtered).asRight
   }
 
-  /** A left join returns all values from the left relation and the matched values from the right relation,
-    * or appends NULL if there is no match. It is also referred to as a left outer join.
-    * @param r
-    * @return
-    */
-  def leftJoin(r: Multiset): Result[Multiset] = {
-    val cols: Seq[String] = (this.bindings intersect r.bindings).toSeq.map(_.s)
-    this
-      .copy(
-        bindings = this.bindings union r.bindings,
-        dataframe = this.dataframe.join(r.dataframe, cols, "left")
-      )
-      .asRight
-  }
-
   /** Eliminates duplicates from the dataframe that matches the same variable binding
     * @return
     */
@@ -209,10 +215,47 @@ final case class Multiset(
       )
       .asRight
   }
-
 }
 
 object Multiset {
+
+  private val filterGraph: Multiset => Multiset = { m =>
+    if (m.isEmpty) {
+      m
+    } else {
+      m.copy(
+        bindings = m.bindings.filter(_.s != GRAPH_VARIABLE.s),
+        dataframe = m.dataframe.drop(GRAPH_VARIABLE.s)
+      )
+    }
+  }
+
+  private val addDefaultGraph: Multiset => Multiset = { m =>
+    if (m.isEmpty) {
+      m
+    } else {
+      m.copy(
+        bindings = m.bindings + VARIABLE(GRAPH_VARIABLE.s),
+        dataframe = m.dataframe.withColumn(GRAPH_VARIABLE.s, lit(""))
+      )
+    }
+  }
+
+  /** This methods is a utility to perform operations like [[union]], [[join]], [[leftJoin]] on Multisets without
+    * taking into account graph bindings and graph columns on dataframes by:
+    * removing from bindings and dataframe -> operate -> adding binding and column to final dataframe as default graph
+    * @param right
+    * @param left
+    * @param f
+    * @return
+    */
+  private def graphAgnostic(right: Multiset, left: Multiset)(
+      f: (Multiset, Multiset) => Multiset
+  ): Multiset =
+    addDefaultGraph(f(filterGraph(right), filterGraph(left)))
+
+  lazy val empty: Multiset =
+    Multiset(Set.empty, SparkSession.builder().getOrCreate().emptyDataFrame)
 
   implicit val semigroup: Semigroup[Multiset] = new Semigroup[Multiset] {
     def combine(x: Multiset, y: Multiset): Multiset = x.join(y)

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -666,9 +666,53 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
     }
 
-    "perform query with FILTER modifier" which {
+    "perform query with !ISBLANK function" should {
 
-      "with single condition" should {
+      "execute and obtain expected results" in {
+        import sqlContext.implicits._
+
+        val df: DataFrame = List(
+          ("_:a", "http://xmlns.com/foaf/0.1/name", "Alice", ""),
+          (
+            "_:a",
+            "http://xmlns.com/foaf/0.1/mbox",
+            "mailto:alice@work.example",
+            ""
+          ),
+          ("_:b", "http://xmlns.com/foaf/0.1/name", "_:bob", ""),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/mbox",
+            "mailto:bob@work.example",
+            ""
+          )
+        ).toDF("s", "p", "o", "g")
+
+        val query =
+          """
+            |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?name ?mbox
+            |WHERE {
+            |   ?x foaf:name ?name ;
+            |      foaf:mbox  ?mbox .
+            |   FILTER (!isBlank(?name))
+            |}
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 1
+        result.right.get.collect shouldEqual Array(
+          Row("\"Alice\"", "mailto:alice@work.example")
+        )
+      }
+    }
+
+    "perform query with FILTER modifier" when {
+
+      "single condition" should {
 
         "execute and obtain expected results" in {
 
@@ -915,7 +959,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
       }
 
-      "with multiple conditions" should {
+      "multiple conditions" should {
 
         // TODO: Un-ignore when binary logical operations implemented
         "execute and obtain expected results when multiple conditions" ignore {
@@ -1020,7 +1064,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
       }
 
-      "with logical operation EQUALS" should {
+      "logical operation EQUALS" should {
 
         "execute on simple literal" in {
           import sqlContext.implicits._
@@ -1201,7 +1245,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
       }
 
-      "with logical operation NOT EQUALS" should {
+      "logical operation NOT EQUALS" should {
 
         "execute on simple literal" in {
           import sqlContext.implicits._
@@ -1381,7 +1425,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
       }
 
-      "with logical operation GT" should {
+      "logical operation GT" should {
 
         "execute on simple literal" in {
           import sqlContext.implicits._
@@ -1560,7 +1604,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
       }
 
-      "with logical operation LT" should {
+      "logical operation LT" should {
 
         "execute on simple literal" in {
           import sqlContext.implicits._
@@ -1744,7 +1788,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
       }
 
-      "with logical operation GTE" should {
+      "logical operation GTE" should {
 
         "execute on simple literal" in {
           import sqlContext.implicits._
@@ -1937,7 +1981,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
       }
 
-      "with logical operation LTE" should {
+      "logical operation LTE" should {
 
         "execute on simple literal" in {
           import sqlContext.implicits._
@@ -2597,50 +2641,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
     }
 
-    "perform query with !ISBLANK function" should {
-
-      "execute and obtain expected results" in {
-        import sqlContext.implicits._
-
-        val df: DataFrame = List(
-          ("_:a", "http://xmlns.com/foaf/0.1/name", "Alice", ""),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:alice@work.example",
-            ""
-          ),
-          ("_:b", "http://xmlns.com/foaf/0.1/name", "_:bob", ""),
-          (
-            "_:b",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:bob@work.example",
-            ""
-          )
-        ).toDF("s", "p", "o", "g")
-
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-            |
-            |SELECT ?name ?mbox
-            |WHERE {
-            |   ?x foaf:name ?name ;
-            |      foaf:mbox  ?mbox .
-            |   FILTER (!isBlank(?name))
-            |}
-            |""".stripMargin
-
-        val result = Compiler.compile(df, query)
-
-        result shouldBe a[Right[_, _]]
-        result.right.get.collect.length shouldEqual 1
-        result.right.get.collect shouldEqual Array(
-          Row("\"Alice\"", "mailto:alice@work.example")
-        )
-      }
-    }
-
     "perform query with DISTINCT modifier" should {
 
       "execute and obtain expected results" in {
@@ -2673,275 +2673,429 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
     }
 
-    "perform query with GRAPH expression" should {
+    "perform query with GRAPH expression on default and named graphs" when {
 
-      "execute and obtain expected results with one graph specified" in {
-        import sqlContext.implicits._
+      "simple specific graph" should {
 
-        val df: DataFrame = List(
-          // Default graph
-          (
-            "http://example.org/bob",
-            "http://purl.org/dc/elements/1.1/publisher",
-            "Bob Hacker",
-            ""
-          ),
-          (
-            "http://example.org/alice",
-            "http://purl.org/dc/elements/1.1/publisher",
-            "Alice Hacker",
-            ""
-          ),
-          // Alice graph
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/name",
-            "Alice",
-            "http://example.org/alice"
-          ),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:alice@work.example.org",
-            "http://example.org/alice"
-          ),
-          // Bob graph
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/name",
-            "Bob",
-            "http://example.org/bob"
-          ),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:bob@oldcorp.example.org",
-            "http://example.org/bob"
+        "execute and obtain expected results with one graph specified" in {
+          import sqlContext.implicits._
+
+          val df: DataFrame = List(
+            // Default graph
+            (
+              "http://example.org/bob",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Bob Hacker",
+              ""
+            ),
+            (
+              "http://example.org/alice",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Alice Hacker",
+              ""
+            ),
+            // Alice graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Alice",
+              "http://example.org/alice"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:alice@work.example.org",
+              "http://example.org/alice"
+            ),
+            // Bob graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Bob",
+              "http://example.org/bob"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:bob@oldcorp.example.org",
+              "http://example.org/bob"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+              |PREFIX dc: <http://purl.org/dc/elements/1.1/>
+              |PREFIX ex: <http://example.org/>
+              |
+              |SELECT ?mbox
+              |FROM <http://example.org/dft.ttl>
+              |FROM NAMED <http://example.org/alice>
+              |FROM NAMED <http://example.org/bob>
+              |WHERE
+              |{
+              |   GRAPH ex:alice { ?x foaf:mbox ?mbox }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query)
+
+          result shouldBe a[Right[_, _]]
+          result.right.get.collect.length shouldEqual 1
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("mailto:alice@work.example.org")
           )
-        ).toDF("s", "p", "o", "g")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-            |PREFIX dc: <http://purl.org/dc/elements/1.1/>
-            |PREFIX ex: <http://example.org/>
-            |
-            |SELECT ?mbox
-            |FROM <http://example.org/dft.ttl>
-            |FROM NAMED <http://example.org/alice>
-            |FROM NAMED <http://example.org/bob>
-            |WHERE
-            |{
-            |   GRAPH ex:alice { ?x foaf:mbox ?mbox }
-            |}
-            |""".stripMargin
-
-        val result = Compiler.compile(df, query)
-
-        result shouldBe a[Right[_, _]]
-        result.right.get.collect.length shouldEqual 1
-        result.right.get.collect.toSet shouldEqual Set(
-          Row("mailto:alice@work.example.org")
-        )
       }
 
-      "execute and obtain expected results with multiple graphs specified" in {
-        import sqlContext.implicits._
+      "multiple specific graphs" should {
 
-        val df: DataFrame = List(
-          // Default graph
-          (
-            "http://example.org/bob",
-            "http://purl.org/dc/elements/1.1/publisher",
-            "Bob Hacker",
-            ""
-          ),
-          (
-            "http://example.org/alice",
-            "http://purl.org/dc/elements/1.1/publisher",
-            "Alice Hacker",
-            ""
-          ),
-          (
-            "http://example.org/charles",
-            "http://purl.org/dc/elements/1.1/publisher",
-            "Charles Hacker",
-            ""
-          ),
-          // Alice graph
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/name",
-            "Alice",
-            "http://example.org/alice"
-          ),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:alice@work.example.org",
-            "http://example.org/alice"
-          ),
-          // Bob graph
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/name",
-            "Bob",
-            "http://example.org/bob"
-          ),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:bob@oldcorp.example.org",
-            "http://example.org/bob"
-          ),
-          // Charles graph
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/name",
-            "Charles",
-            "http://example.org/charles"
-          ),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:charles@work.example.org",
-            "http://example.org/charles"
+        "execute and obtain expected results when UNION on two named graphs with common variable bindings" in {
+          import sqlContext.implicits._
+
+          val df: DataFrame = List(
+            // Default graph
+            (
+              "http://example.org/bob",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Bob Hacker",
+              ""
+            ),
+            (
+              "http://example.org/alice",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Alice Hacker",
+              ""
+            ),
+            (
+              "http://example.org/charles",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Charles Hacker",
+              ""
+            ),
+            // Alice graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Alice",
+              "http://example.org/alice"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:alice@work.example.org",
+              "http://example.org/alice"
+            ),
+            // Bob graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Bob",
+              "http://example.org/bob"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:bob@oldcorp.example.org",
+              "http://example.org/bob"
+            ),
+            // Charles graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Charles",
+              "http://example.org/charles"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:charles@work.example.org",
+              "http://example.org/charles"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+              |PREFIX dc: <http://purl.org/dc/elements/1.1/>
+              |PREFIX ex: <http://example.org/>
+              |
+              |SELECT ?x ?y ?mbox
+              |FROM <http://example.org/dft.ttl>
+              |FROM NAMED <http://example.org/alice>
+              |FROM NAMED <http://example.org/bob>
+              |FROM NAMED <http://example.org/charles>
+              |WHERE
+              |{
+              |   { GRAPH ex:alice { ?x foaf:mbox ?mbox } }
+              |   UNION
+              |   { GRAPH ex:bob { ?y foaf:mbox ?mbox } }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query)
+
+          result shouldBe a[Right[_, _]]
+          result.right.get.collect.length shouldEqual 2
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("_:a", null, "mailto:alice@work.example.org"),
+            Row(null, "_:a", "mailto:bob@oldcorp.example.org")
           )
-        ).toDF("s", "p", "o", "g")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-            |PREFIX dc: <http://purl.org/dc/elements/1.1/>
-            |PREFIX ex: <http://example.org/>
-            |
-            |SELECT ?mbox
-            |FROM <http://example.org/dft.ttl>
-            |FROM NAMED <http://example.org/alice>
-            |FROM NAMED <http://example.org/bob>
-            |FROM NAMED <http://example.org/charles>
-            |WHERE
-            |{
-            |   { GRAPH ex:alice { ?x foaf:mbox ?mbox } }
-            |   UNION
-            |   { GRAPH ex:bob { ?y foaf:mbox ?mbox } }
-            |}
-            |""".stripMargin
+        "execute and obtain expected results when JOIN on two named graphs with common variable bindings" in {
+          import sqlContext.implicits._
 
-        val result = Compiler.compile(df, query)
+          val df: DataFrame = List(
+            // Default graph
+            (
+              "http://example.org/bob",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Bob Hacker",
+              ""
+            ),
+            (
+              "http://example.org/alice",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Alice Hacker",
+              ""
+            ),
+            // Alice graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Alice",
+              "http://example.org/alice"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:same@work.example.org",
+              "http://example.org/alice"
+            ),
+            // Bob graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Bob",
+              "http://example.org/bob"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:same@work.example.org",
+              "http://example.org/bob"
+            )
+          ).toDF("s", "p", "o", "g")
 
-        result shouldBe a[Right[_, _]]
-        result.right.get.collect.length shouldEqual 2
-        result.right.get.collect.toSet shouldEqual Set(
-          Row("mailto:alice@work.example.org"),
-          Row("mailto:bob@oldcorp.example.org")
-        )
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+              |PREFIX dc: <http://purl.org/dc/elements/1.1/>
+              |PREFIX ex: <http://example.org/>
+              |
+              |SELECT ?x ?mbox
+              |FROM <http://example.org/dft.ttl>
+              |FROM NAMED <http://example.org/alice>
+              |FROM NAMED <http://example.org/bob>
+              |WHERE
+              |{
+              |   GRAPH ex:alice { ?x foaf:mbox ?mbox . }
+              |   GRAPH ex:bob { ?x foaf:mbox ?mbox . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query)
+
+          result.right.get.show()
+
+          result shouldBe a[Right[_, _]]
+          result.right.get.collect.length shouldEqual 1
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("_:a", "mailto:same@work.example.org")
+          )
+        }
+
+        "execute and obtain expected results when JOIN on two named graphs with no common variable bindings" in {
+          import sqlContext.implicits._
+
+          val df: DataFrame = List(
+            // Default graph
+            (
+              "http://example.org/bob",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Bob Hacker",
+              ""
+            ),
+            (
+              "http://example.org/alice",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Alice Hacker",
+              ""
+            ),
+            // Alice graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Alice",
+              "http://example.org/alice"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:alice@work.example.org",
+              "http://example.org/alice"
+            ),
+            // Bob graph
+            (
+              "_:b",
+              "http://xmlns.com/foaf/0.1/name",
+              "Bob",
+              "http://example.org/bob"
+            ),
+            (
+              "_:b",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:bob@work.example.org",
+              "http://example.org/bob"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+              |PREFIX dc: <http://purl.org/dc/elements/1.1/>
+              |PREFIX ex: <http://example.org/>
+              |
+              |SELECT ?x ?y
+              |FROM <http://example.org/dft.ttl>
+              |FROM NAMED <http://example.org/alice>
+              |FROM NAMED <http://example.org/bob>
+              |WHERE
+              |{
+              |   GRAPH ex:alice { ?x foaf:mbox <mailto:alice@work.example.org> . }
+              |   GRAPH ex:bob { ?y foaf:mbox <mailto:bob@work.example.org> . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query)
+
+          result shouldBe a[Right[_, _]]
+          result.right.get.collect.length shouldEqual 1
+          result.right.get.collect.toSet shouldEqual Set(Row("_:a", "_:b"))
+        }
       }
 
-      // TODO: Un-ignore when JOIN implemented and named graphs support for variables
-      "execute and obtain expected results when referenced graph is a variable instead of a specified graph" ignore {
-        import sqlContext.implicits._
+      "graph variable" should {
 
-        val df: DataFrame = List(
-          // Default graph
-          (
-            "http://example.org/bob",
-            "http://purl.org/dc/elements/1.1/publisher",
-            "Bob Hacker",
-            ""
-          ),
-          (
-            "http://example.org/alice",
-            "http://purl.org/dc/elements/1.1/publisher",
-            "Alice Hacker",
-            ""
-          ),
-          (
-            "http://example.org/charles",
-            "http://purl.org/dc/elements/1.1/publisher",
-            "Charles Hacker",
-            ""
-          ),
-          // Alice graph
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/name",
-            "Alice",
-            "http://example.org/alice"
-          ),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:alice@work.example.org",
-            "http://example.org/alice"
-          ),
-          // Bob graph
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/name",
-            "Bob",
-            "http://example.org/bob"
-          ),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:bob@oldcorp.example.org",
-            "http://example.org/bob"
-          ),
-          // Charles graph
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/name",
-            "Charles",
-            "http://example.org/charles"
-          ),
-          (
-            "_:a",
-            "http://xmlns.com/foaf/0.1/mbox",
-            "mailto:charles@work.example.org",
-            "http://example.org/charles"
+        // TODO: Un-ignore when JOIN implemented and named graphs support for variables
+        "execute and obtain expected results when referenced graph is a variable instead of a specified graph" ignore {
+          import sqlContext.implicits._
+
+          val df: DataFrame = List(
+            // Default graph
+            (
+              "http://example.org/bob",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Bob Hacker",
+              ""
+            ),
+            (
+              "http://example.org/alice",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Alice Hacker",
+              ""
+            ),
+            (
+              "http://example.org/charles",
+              "http://purl.org/dc/elements/1.1/publisher",
+              "Charles Hacker",
+              ""
+            ),
+            // Alice graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Alice",
+              "http://example.org/alice"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:alice@work.example.org",
+              "http://example.org/alice"
+            ),
+            // Bob graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Bob",
+              "http://example.org/bob"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:bob@oldcorp.example.org",
+              "http://example.org/bob"
+            ),
+            // Charles graph
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/name",
+              "Charles",
+              "http://example.org/charles"
+            ),
+            (
+              "_:a",
+              "http://xmlns.com/foaf/0.1/mbox",
+              "mailto:charles@work.example.org",
+              "http://example.org/charles"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+              |PREFIX dc: <http://purl.org/dc/elements/1.1/>
+              |PREFIX ex: <http://example.org/>
+              |
+              |SELECT ?who ?g ?mbox
+              |FROM <http://example.org/dft.ttl>
+              |FROM NAMED <http://example.org/alice>
+              |FROM NAMED <http://example.org/bob>
+              |FROM NAMED <http://example.org/charles>
+              |WHERE
+              |{
+              |   ?g dc:publisher ?who .
+              |   GRAPH ?g { ?x foaf:mbox ?mbox }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query)
+
+          result.right.get.show()
+
+          result shouldBe a[Right[_, _]]
+          result.right.get.collect.length shouldEqual 3
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "\"Alice Hacker\"",
+              "http://example.org/alice",
+              "mailto:alice@work.example.org"
+            ),
+            Row(
+              "\"Bob Hacker\"",
+              "http://example.org/bob",
+              "mailto:bob@oldcorp.example.org"
+            ),
+            Row(
+              "\"Charles Hacker\"",
+              "http://example.org/charles",
+              "mailto:charles@work.example.org"
+            )
           )
-        ).toDF("s", "p", "o", "g")
-
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-            |PREFIX dc: <http://purl.org/dc/elements/1.1/>
-            |PREFIX ex: <http://example.org/>
-            |
-            |SELECT ?who ?g ?mbox
-            |FROM <http://example.org/dft.ttl>
-            |FROM NAMED <http://example.org/alice>
-            |FROM NAMED <http://example.org/bob>
-            |FROM NAMED <http://example.org/charles>
-            |WHERE
-            |{
-            |   ?g dc:publisher ?who .
-            |   GRAPH ?g { ?x foaf:mbox ?mbox }
-            |}
-            |""".stripMargin
-
-        val result = Compiler.compile(df, query)
-
-        result shouldBe a[Right[_, _]]
-        result.right.get.collect.length shouldEqual 3
-        result.right.get.collect.toSet shouldEqual Set(
-          Row(
-            "Alice Hacker",
-            "http://example.org/alice",
-            "mailto:alice@work.example.org"
-          ),
-          Row(
-            "Bob Hacker",
-            "http://example.org/bob",
-            "mailto:bob@oldcorp.example.org"
-          ),
-          Row(
-            "Charles Hacker",
-            "http://example.org/charles",
-            "mailto:charles@work.example.org"
-          )
-        )
+        }
       }
     }
   }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -30,7 +30,8 @@ class MultisetSpec
       val empty = Multiset.empty
       val nonEmpty = Multiset(
         Set(VARIABLE("d"), VARIABLE(GRAPH_VARIABLE.s)),
-        Seq(("test1", ""), ("test2", "")).toDF("d", GRAPH_VARIABLE.s)
+        Seq(("test1", "graph1"), ("test2", "graph2"))
+          .toDF("d", GRAPH_VARIABLE.s)
       )
 
       empty.join(nonEmpty) should equalsMultiset(nonEmpty)
@@ -41,7 +42,8 @@ class MultisetSpec
       val empty = Multiset.empty
       val nonEmpty = Multiset(
         Set(VARIABLE("d"), VARIABLE(GRAPH_VARIABLE.s)),
-        Seq(("test1", ""), ("test2", "")).toDF("d", GRAPH_VARIABLE.s)
+        Seq(("test1", "graph1"), ("test2", "graph2"))
+          .toDF("d", GRAPH_VARIABLE.s)
       )
 
       nonEmpty.join(empty) should equalsMultiset(nonEmpty)
@@ -51,19 +53,22 @@ class MultisetSpec
       import sqlContext.implicits._
       val variables = Set(VARIABLE("d"), VARIABLE(GRAPH_VARIABLE.s))
       val df1 = List(
-        ("test1", ""),
-        ("test2", "")
+        ("test1", "graph1"),
+        ("test2", "graph2")
       ).toDF("d", GRAPH_VARIABLE.s)
       val df2 = List(
-        ("test1", ""),
-        ("test3", "")
+        ("test1", "graph1"),
+        ("test3", "graph3")
       ).toDF("d", GRAPH_VARIABLE.s)
 
       val ms1 = Multiset(variables, df1)
       val ms2 = Multiset(variables, df2)
 
       ms1.join(ms2) should equalsMultiset(
-        Multiset(variables, List(("test1", "")).toDF("d", GRAPH_VARIABLE.s))
+        Multiset(
+          variables,
+          List(("test1", "graph1")).toDF("d", GRAPH_VARIABLE.s)
+        )
       )
     }
 
@@ -76,19 +81,19 @@ class MultisetSpec
 
       val ms1 = Multiset(
         Set(d, e, graph),
-        List(("test1", "234", "graph1"), ("test2", "123", "graph1"))
+        List(("test1", "234", "graph1"), ("test2", "123", "graph2"))
           .toDF(d.s, e.s, graph.s)
       )
       val ms2 = Multiset(
         Set(d, f, graph),
-        List(("test1", "hello", "graph2"), ("test3", "goodbye", "graph2"))
+        List(("test1", "hello", "graph1"), ("test3", "goodbye", "graph2"))
           .toDF(d.s, f.s, graph.s)
       )
 
       ms1.join(ms2) should equalsMultiset(
         Multiset(
           Set(d, e, f, graph),
-          List(("test1", "234", "hello", "")).toDF("d", "e", "f", graph.s)
+          List(("test1", "234", "hello", "graph1")).toDF("d", "e", "f", graph.s)
         )
       )
     }
@@ -113,8 +118,8 @@ class MultisetSpec
       val ms2 = Multiset(
         Set(d, e, f, graph),
         List(
-          ("test1", "234", "hello", "graph3"),
-          ("test3", "e2", "goodbye", "graph4")
+          ("test1", "234", "hello", "graph1"),
+          ("test3", "e2", "goodbye", "graph3")
         )
           .toDF(d.s, e.s, f.s, graph.s)
       )
@@ -122,17 +127,14 @@ class MultisetSpec
       val result = ms1.join(ms2)
       val expectedResult = Multiset(
         Set(d, e, f, g, h, graph),
-        List(("test1", "234", "g1", "h1", "hello", ""))
+        List(("test1", "234", "g1", "h1", "hello", "graph1"))
           .toDF("d", "e", "g", "h", "f", graph.s)
       )
-
-      result.dataframe.show()
-      expectedResult.dataframe.show()
 
       result should equalsMultiset(expectedResult)
     }
 
-    "perform a union when there's no shared bindings between multisets" in {
+    "perform a cartesian product when there's no shared bindings between multisets" in {
       import sqlContext.implicits._
       val d     = VARIABLE("d")
       val e     = VARIABLE("e")
@@ -160,10 +162,14 @@ class MultisetSpec
         Multiset(
           Set(d, e, f, g, h, i, graph),
           List(
-            ("test1", "234", "g1", "test1", "234", "hello", ""),
-            ("test1", "234", "g1", "test3", "e2", "goodbye", ""),
-            ("test2", "123", "g2", "test1", "234", "hello", ""),
-            ("test2", "123", "g2", "test3", "e2", "goodbye", "")
+            ("test1", "234", "g1", "test1", "234", "hello", "graph1"),
+            ("test1", "234", "g1", "test1", "234", "hello", "graph2"),
+            ("test1", "234", "g1", "test3", "e2", "goodbye", "graph1"),
+            ("test1", "234", "g1", "test3", "e2", "goodbye", "graph2"),
+            ("test2", "123", "g2", "test1", "234", "hello", "graph1"),
+            ("test2", "123", "g2", "test1", "234", "hello", "graph2"),
+            ("test2", "123", "g2", "test3", "e2", "goodbye", "graph1"),
+            ("test2", "123", "g2", "test3", "e2", "goodbye", "graph2")
           ).toDF("d", "e", "g", "h", "f", "i", graph.s)
         )
       )
@@ -187,7 +193,8 @@ class MultisetSpec
       val leftEmpty = Multiset.empty
       val rightNonEmpty = Multiset(
         Set(VARIABLE("d"), VARIABLE(GRAPH_VARIABLE.s)),
-        Seq(("test1", ""), ("test2", "")).toDF("d", GRAPH_VARIABLE.s)
+        Seq(("test1", "graph1"), ("test2", "graph1"))
+          .toDF("d", GRAPH_VARIABLE.s)
       )
 
       val result = leftEmpty.leftJoin(rightNonEmpty)
@@ -201,7 +208,8 @@ class MultisetSpec
       val rightEmpty = Multiset.empty
       val leftNonEmpty = Multiset(
         Set(VARIABLE("d"), VARIABLE(GRAPH_VARIABLE.s)),
-        Seq(("test1", ""), ("test2", "")).toDF("d", GRAPH_VARIABLE.s)
+        Seq(("test1", "graph1"), ("test2", "graph1"))
+          .toDF("d", GRAPH_VARIABLE.s)
       )
 
       val result = leftNonEmpty.leftJoin(rightEmpty)
@@ -214,12 +222,12 @@ class MultisetSpec
       import sqlContext.implicits._
       val variables = Set(VARIABLE("d"), VARIABLE(GRAPH_VARIABLE.s))
       val leftDf = List(
-        ("test1", ""),
-        ("test2", "")
+        ("test1", "graph1"),
+        ("test2", "graph1")
       ).toDF("d", GRAPH_VARIABLE.s)
       val rightDf = List(
-        ("test1", ""),
-        ("test3", "")
+        ("test1", "graph2"),
+        ("test3", "graph2")
       ).toDF("d", GRAPH_VARIABLE.s)
 
       val left  = Multiset(variables, leftDf)
@@ -231,7 +239,8 @@ class MultisetSpec
       result.right.get should equalsMultiset(
         Multiset(
           variables,
-          List(("test1", ""), ("test2", "")).toDF("d", GRAPH_VARIABLE.s)
+          List(("test1", "graph1"), ("test2", "graph1"))
+            .toDF("d", GRAPH_VARIABLE.s)
         )
       )
     }
@@ -261,8 +270,8 @@ class MultisetSpec
         Multiset(
           Set(d, e, f, graph),
           List(
-            ("test1", "234", "hello", ""),
-            ("test2", "123", null, "")
+            ("test1", "234", "hello", "graph1"),
+            ("test2", "123", null, "graph1")
           ).toDF("d", "e", "f", graph.s)
         )
       )
@@ -298,13 +307,10 @@ class MultisetSpec
       val expectedResult = Multiset(
         Set(d, e, f, g, h, graph),
         List(
-          ("test1", "234", "g1", "h1", "hello", ""),
-          ("test2", "123", "g2", "h2", null, "")
+          ("test1", "234", "g1", "h1", "hello", "graph1"),
+          ("test2", "123", "g2", "h2", null, "graph2")
         ).toDF("d", "e", "g", "h", "f", graph.s)
       )
-
-      result.right.get.dataframe.show()
-      expectedResult.dataframe.show()
 
       result shouldBe a[Right[_, _]]
       result.right.get should equalsMultiset(expectedResult)
@@ -326,7 +332,8 @@ class MultisetSpec
       val left = Multiset.empty
       val right = Multiset(
         Set(VARIABLE("a"), VARIABLE(GRAPH_VARIABLE.s)),
-        List(("A", ""), ("B", ""), ("C", "")).toDF("a", GRAPH_VARIABLE.s)
+        List(("A", "graph1"), ("B", "graph2"), ("C", "graph3"))
+          .toDF("a", GRAPH_VARIABLE.s)
       )
 
       left.union(right) should equalsMultiset(right)
@@ -337,7 +344,8 @@ class MultisetSpec
 
       val left = Multiset(
         Set(VARIABLE("a"), VARIABLE(GRAPH_VARIABLE.s)),
-        List(("A", ""), ("B", ""), ("C", "")).toDF("a", GRAPH_VARIABLE.s)
+        List(("A", "graph1"), ("B", "graph2"), ("C", "graph3"))
+          .toDF("a", GRAPH_VARIABLE.s)
       )
       val right = Multiset.empty
 
@@ -350,20 +358,27 @@ class MultisetSpec
 
       val left = Multiset(
         variables,
-        List(("test1", ""), ("test2", "")).toDF("d", GRAPH_VARIABLE.s)
+        List(("test1", "graph1"), ("test2", "graph1"))
+          .toDF("d", GRAPH_VARIABLE.s)
       )
       val right = Multiset(
         variables,
-        List(("test1", ""), ("test3", "")).toDF("d", GRAPH_VARIABLE.s)
+        List(("test2", "graph2"), ("test3", "graph2"))
+          .toDF("d", GRAPH_VARIABLE.s)
       )
 
-      left.union(right) should equalsMultiset(
-        Multiset(
-          variables,
-          List(("test1", ""), ("test2", ""), ("test1", ""), ("test3", ""))
-            .toDF("d", GRAPH_VARIABLE.s)
-        )
+      val result = left.union(right)
+      val expectedResult = Multiset(
+        variables,
+        List(
+          ("test1", "graph1"),
+          ("test2", "graph1"),
+          ("test2", "graph2"),
+          ("test3", "graph2")
+        ).toDF("d", GRAPH_VARIABLE.s)
       )
+
+      result should equalsMultiset(expectedResult)
     }
 
     "union two multisets when they share one binding" in {
@@ -375,11 +390,12 @@ class MultisetSpec
 
       val left = Multiset(
         Set(d, e, graph),
-        List(("test1", "234", ""), ("test2", "123", "")).toDF(d.s, e.s, graph.s)
+        List(("test1", "234", "graph1"), ("test2", "123", "graph1"))
+          .toDF(d.s, e.s, graph.s)
       )
       val right = Multiset(
         Set(d, f),
-        List(("test1", "hello", ""), ("test3", "goodbye", ""))
+        List(("test1", "hello", "graph2"), ("test3", "goodbye", "graph2"))
           .toDF(d.s, f.s, graph.s)
       )
 
@@ -387,10 +403,10 @@ class MultisetSpec
         Multiset(
           Set(d, e, f, graph),
           List(
-            ("test1", "234", null, ""),
-            ("test2", "123", null, ""),
-            ("test1", null, "hello", ""),
-            ("test3", null, "goodbye", "")
+            ("test1", "234", null, "graph1"),
+            ("test2", "123", null, "graph1"),
+            ("test1", null, "hello", "graph2"),
+            ("test3", null, "goodbye", "graph2")
           ).toDF("d", "e", "f", graph.s)
         )
       )
@@ -407,12 +423,18 @@ class MultisetSpec
 
       val left = Multiset(
         Set(d, e, g, h, graph),
-        List(("test1", "234", "g1", "h1", ""), ("test2", "123", "g2", "h2", ""))
+        List(
+          ("test1", "234", "g1", "h1", "graph1"),
+          ("test2", "123", "g2", "h2", "graph1")
+        )
           .toDF(d.s, e.s, g.s, h.s, graph.s)
       )
       val right = Multiset(
         Set(d, e, f, graph),
-        List(("test1", "234", "hello", ""), ("test3", "e2", "goodbye", ""))
+        List(
+          ("test1", "234", "hello", "graph2"),
+          ("test3", "e2", "goodbye", "graph2")
+        )
           .toDF(d.s, e.s, f.s, graph.s)
       )
 
@@ -420,15 +442,12 @@ class MultisetSpec
       val expectedResult = Multiset(
         Set(d, e, f, g, h, graph),
         List(
-          ("test1", "234", "g1", "h1", null, ""),
-          ("test2", "123", "g2", "h2", null, ""),
-          ("test1", "234", null, null, "hello", ""),
-          ("test3", "e2", null, null, "goodbye", "")
+          ("test1", "234", "g1", "h1", null, "graph1"),
+          ("test2", "123", "g2", "h2", null, "graph1"),
+          ("test1", "234", null, null, "hello", "graph2"),
+          ("test3", "e2", null, null, "goodbye", "graph2")
         ).toDF("d", "e", "g", "h", "f", graph.s)
       )
-
-      result.dataframe.show
-      expectedResult.dataframe.show
 
       result should equalsMultiset(expectedResult)
     }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/utils/MultisetMatchers.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/utils/MultisetMatchers.scala
@@ -1,0 +1,39 @@
+package com.gsk.kg.engine.utils
+
+import com.gsk.kg.engine.Multiset
+
+import org.scalatest.matchers.MatchResult
+import org.scalatest.matchers.Matcher
+import org.scalatest.matchers.should.Matchers
+
+trait MultisetMatchers extends Matchers {
+
+  def equalsMultiset(right: Multiset): Matcher[Multiset] =
+    equalsBindings(right) and equalsDataframe(right)
+
+  def equalsBindings(right: Multiset): Matcher[Multiset] =
+    new Matcher[Multiset] {
+      override def apply(left: Multiset): MatchResult = MatchResult(
+        left.bindings === right.bindings,
+        "{0} bindings are different than {1}",
+        "{0} bindings are equal as {1}",
+        Vector(left.bindings, right.bindings),
+        Vector(left.bindings, right.bindings)
+      )
+    }
+
+  def equalsDataframe(right: Multiset): Matcher[Multiset] =
+    new Matcher[Multiset] {
+      override def apply(left: Multiset): MatchResult = {
+        lazy val leftCollected  = left.dataframe.collect().map(_.toSeq.toSet)
+        lazy val rightCollected = right.dataframe.collect().map(_.toSeq.toSet)
+        MatchResult(
+          leftCollected === rightCollected,
+          "{0} dataframes are different {1}",
+          "{0} dataframes are equal {1}",
+          Vector(leftCollected, rightCollected),
+          Vector(leftCollected, rightCollected)
+        )
+      }
+    }
+}


### PR DESCRIPTION
This PR add support for joining two graphs. Example:

```
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX dc: <http://purl.org/dc/elements/1.1/>
PREFIX ex: <http://example.org/>

SELECT ?x ?mbox
FROM <http://example.org/dft.ttl>
FROM NAMED <http://example.org/alice>
FROM NAMED <http://example.org/bob>
WHERE
{
   GRAPH ex:alice { ?x foaf:mbox ?mbox . }
   GRAPH ex:bob { ?x foaf:mbox ?mbox . }
}
```

It also adds some missing test on `Multiset` operations.