### PR TITLE
Make the console more usable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,6 +155,9 @@ lazy val `bellman-spark-engine` = project
     )
   )
   .settings(
+    scalacOptions in (Compile, console) ~= {
+      _.filterNot(Set("-Ywarn-unused-import", "-Ywarn-unused:imports"))
+    },
     initialCommands in console := """
     import cats._
     import cats.implicits._
@@ -170,6 +173,19 @@ lazy val `bellman-spark-engine` = project
     import com.gsk.kg.engine._
     import com.gsk.kg.engine.DAG._
     import com.gsk.kg.engine.optimizer._
+
+    import org.apache.spark._
+    import org.apache.spark.sql._
+
+    val spark = SparkSession.builder()
+      .appName("Spark Local")
+      .master("local")
+      .config("spark.driver.host", "localhost")
+      .getOrCreate()
+
+    implicit val sc: SQLContext = spark.sqlContext
+
+    import sc.implicits._
     """
   )
   .dependsOn(`bellman-algebra-parser`)


### PR DESCRIPTION
- avoid warning on unused code in the console

- add initial commands that initialize Spark