### PR TITLE
bring back support for SPO DataFrames

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/EngineError.scala
@@ -13,4 +13,5 @@ object EngineError {
   final case class FunctionError(description: String) extends EngineError
   final case class AnalyzerError(errors: NonEmptyChain[String])
       extends EngineError
+  final case class InvalidInputDataFrame(msg: String) extends EngineError
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
@@ -71,5 +71,5 @@ object QueryConstruct {
   }
 
   def toBGP(quads: Iterable[JenaQuad]): BGP =
-    BGP(quads.flatMap(Quad(_)).toSeq)
+    BGP(quads.flatMap(Quad(_).toIterable).toSeq)
 }


### PR DESCRIPTION
Now we're performing a validation before running the Spark job so that
we can check that received DF is either 3 or 4 cols wide, otherwise we
raise an error.

IN case of a 3 col DF, we manually add the `g` one.

Closes #167