### PR TITLE
Added support for inclusive/exclusive default graph with inclusive as default value

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -47,7 +47,7 @@ Disable.ifSynthetic = [
 ]
 
 DisableSyntax {
-  noDefaultArgs = true
+  noDefaultArgs = false
   noFinalVal = true
   noFinalize = true
   noImplicitConversion = true

--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val `bellman-spark-engine` = project
     import sc.implicits._
     """
   )
-  .dependsOn(`bellman-algebra-parser`)
+  .dependsOn(`bellman-algebra-parser` % "compile->compile;test->test")
 
 addCommandAlias(
   "ci-test",

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Compiler.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Compiler.scala
@@ -17,11 +17,11 @@ import com.gsk.kg.sparqlparser.StringVal
 
 object Compiler {
 
-  def compile(df: DataFrame, query: String)(implicit
-      sc: SQLContext
+  def compile(df: DataFrame, query: String, isExclusive: Boolean = false)(
+      implicit sc: SQLContext
   ): Result[DataFrame] =
     compiler(df)
-      .run(query)
+      .run((query, isExclusive))
       .runA(df)
 
   /** Put together all phases of the compiler
@@ -32,7 +32,7 @@ object Compiler {
     */
   def compiler(df: DataFrame)(implicit
       sc: SQLContext
-  ): Phase[String, DataFrame] =
+  ): Phase[(String, Boolean), DataFrame] =
     parser >>>
       transformToGraph.first >>>
       optimizer >>>
@@ -59,7 +59,7 @@ object Compiler {
 
   /** parser converts strings to our [[Query]] ADT
     */
-  val parser: Phase[String, (Query, List[StringVal])] =
+  val parser: Phase[(String, Boolean), (Query, List[StringVal])] =
     Arrow[Phase].lift(QueryConstruct.parse)
 
   def optimizer[T: Basis[DAG, *]]: Phase[(T, List[StringVal]), T] =

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -3367,7 +3367,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, isExclusive = true)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3438,7 +3438,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, isExclusive = true)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3509,7 +3509,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, isExclusive = true)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3582,7 +3582,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, isExclusive = true)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3655,7 +3655,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, isExclusive = true)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -4123,9 +4123,9 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
     }
 
-    "default graph" should {
+    "inclusive/exclusive default graph" should {
 
-      "exclusive engine with no explicit FROM" in {
+      "exclude graphs when no explicit FROM" ignore {
         import sqlContext.implicits._
 
         val df: DataFrame = List(
@@ -4139,14 +4139,13 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, isExclusive = true)
 
-        result.right.get.show(false)
         result.right.get.collect().length shouldEqual 0
         result.right.get.collect().toSet shouldEqual Set()
       }
 
-      "exclusive engine with explicit FROM" in {
+      "exclude graphs when explicit FROM" ignore {
         import sqlContext.implicits._
 
         val df: DataFrame = List(
@@ -4162,9 +4161,55 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
+        val result = Compiler.compile(df, query, isExclusive = true)
+
+        result.right.get.collect().length shouldEqual 2
+        result.right.get.collect().toSet shouldEqual Set(
+          Row("_:s1", "\"p1\"", "\"o1\""),
+          Row("_:s2", "\"p2\"", "\"o2\"")
+        )
+      }
+
+      "include graphs when no explicit FROM" in {
+        import sqlContext.implicits._
+
+        val df: DataFrame = List(
+          ("_:s1", "p1", "o1", "http://example.org/graph1"),
+          ("_:s2", "p2", "o2", "http://example.org/graph2")
+        ).toDF("s", "p", "o", "g")
+
+        val query =
+          """
+            |SELECT ?s ?p ?o
+            |WHERE { ?s ?p ?o }
+            |""".stripMargin
+
         val result = Compiler.compile(df, query)
 
-        result.right.get.show(false)
+        result.right.get.collect().length shouldEqual 2
+        result.right.get.collect().toSet shouldEqual Set(
+          Row("_:s1", "\"p1\"", "\"o1\""),
+          Row("_:s2", "\"p2\"", "\"o2\"")
+        )
+      }
+
+      "include graphs when explicit FROM" in {
+        import sqlContext.implicits._
+
+        val df: DataFrame = List(
+          ("_:s1", "p1", "o1", "http://example.org/graph1"),
+          ("_:s2", "p2", "o2", "http://example.org/graph2")
+        ).toDF("s", "p", "o", "g")
+
+        val query =
+          """
+            |SELECT ?s ?p ?o
+            |FROM <http://example.org/graph1>
+            |WHERE { ?s ?p ?o }
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query)
+
         result.right.get.collect().length shouldEqual 2
         result.right.get.collect().toSet shouldEqual Set(
           Row("_:s1", "\"p1\"", "\"o1\""),

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/analyzer/AnalyzerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/analyzer/AnalyzerSpec.scala
@@ -7,13 +7,13 @@ import higherkindness.droste.syntax.all._
 
 import com.gsk.kg.engine.DAG
 import com.gsk.kg.engine.EngineError
-import com.gsk.kg.sparqlparser.QueryConstruct
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class AnalyzerSpec extends AnyFlatSpec with Matchers {
+class AnalyzerSpec extends AnyFlatSpec with Matchers with TestUtils {
 
   "Analyzer.findUnboundVariables" should "find unbound variables in CONSTRUCT queries" in {
     val q =
@@ -24,7 +24,7 @@ class AnalyzerSpec extends AnyFlatSpec with Matchers {
         | ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o
         |}
         |""".stripMargin
-    val (query, _) = QueryConstruct.parse(q)
+    val (query, _) = parse(q)
 
     val dag = DAG.fromQuery.apply(query)
 
@@ -46,7 +46,7 @@ class AnalyzerSpec extends AnyFlatSpec with Matchers {
         | <http://purl.obolibrary.org/obo/CLO_0037232> <http://www.w3.org/2000/01/rdf-schema#subClassOf> ?derived_node .
         |}
         |""".stripMargin
-    val (query, _) = QueryConstruct.parse(q)
+    val (query, _) = parse(q)
 
     val dag = DAG.fromQuery.apply(query)
 
@@ -72,7 +72,7 @@ class AnalyzerSpec extends AnyFlatSpec with Matchers {
         | BIND(REPLACE(?lit, "b", "Z") AS ?lit2)
         |}
         |""".stripMargin
-    val (query, _) = QueryConstruct.parse(q)
+    val (query, _) = parse(q)
 
     val dag = DAG.fromQuery.apply(query)
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/data/TreeRepSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/data/TreeRepSpec.scala
@@ -3,12 +3,12 @@ package data
 
 import cats.instances.string._
 
-import com.gsk.kg.sparqlparser.QueryConstruct
+import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class TreeRepSpec extends AnyFlatSpec with Matchers {
+class TreeRepSpec extends AnyFlatSpec with Matchers with TestUtils {
 
   "TreeRep.draw" should "generate a tree representation" in {
 
@@ -79,7 +79,7 @@ class TreeRepSpec extends AnyFlatSpec with Matchers {
         | BIND(URI(CONCAT("http://lit-search-api/node/doc#", ?docid)) as ?Document) .
         |}
         |""".stripMargin
-    val (query, _) = QueryConstruct.parse(q)
+    val (query, _) = parse(q)
 
     val dag = DAG.fromQuery.apply(query)
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/CompactBGPsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/CompactBGPsSpec.scala
@@ -1,5 +1,6 @@
 package com.gsk.kg.engine
 package optimizer
+
 import cats.Traverse
 
 import higherkindness.droste.data.Fix
@@ -9,7 +10,7 @@ import com.gsk.kg.engine.DAG.Project
 import com.gsk.kg.engine.data.ChunkedList
 import com.gsk.kg.engine.optics._
 import com.gsk.kg.sparqlparser.Expr.Quad
-import com.gsk.kg.sparqlparser.QueryConstruct
+import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -18,7 +19,8 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 class CompactBGPsSpec
     extends AnyFlatSpec
     with Matchers
-    with ScalaCheckDrivenPropertyChecks {
+    with ScalaCheckDrivenPropertyChecks
+    with TestUtils {
 
   type T = Fix[DAG]
 
@@ -34,7 +36,7 @@ class CompactBGPsSpec
         | ?d dm:source "potato"
         |}
         |""".stripMargin
-    val (query, _) = QueryConstruct.parse(q)
+    val (query, _) = parse(q)
 
     val dag: T = DAG.fromQuery.apply(query)
     countChunksInBGP(dag) shouldEqual 2
@@ -56,7 +58,7 @@ class CompactBGPsSpec
         | ?d dm:source "potato" .
         |}
         |""".stripMargin
-    val (query, _) = QueryConstruct.parse(q)
+    val (query, _) = parse(q)
 
     val dag: T       = DAG.fromQuery.apply(query)
     val optimized: T = CompactBGPs[T].apply(dag)

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/GraphsPushdownSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/GraphsPushdownSpec.scala
@@ -6,15 +6,15 @@ import com.gsk.kg.engine.DAG
 import com.gsk.kg.engine.DAG._
 import com.gsk.kg.engine.data.ChunkedList
 import com.gsk.kg.sparqlparser.Expr
-import com.gsk.kg.sparqlparser.QueryConstruct
 import com.gsk.kg.sparqlparser.StringVal.GRAPH_VARIABLE
 import com.gsk.kg.sparqlparser.StringVal.URIVAL
+import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class GraphsPushdownSpec extends AnyWordSpec with Matchers {
+class GraphsPushdownSpec extends AnyWordSpec with Matchers with TestUtils {
 
   type T = Fix[DAG]
 
@@ -49,7 +49,7 @@ class GraphsPushdownSpec extends AnyWordSpec with Matchers {
             | }
             |}
             |""".stripMargin
-        val (query, defaultGraphs) = QueryConstruct.parse(q)
+        val (query, defaultGraphs) = parse(q)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -88,7 +88,7 @@ class GraphsPushdownSpec extends AnyWordSpec with Matchers {
             | }
             |}
             |""".stripMargin
-        val (query, defaultGraphs) = QueryConstruct.parse(q)
+        val (query, defaultGraphs) = parse(q)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -149,7 +149,7 @@ class GraphsPushdownSpec extends AnyWordSpec with Matchers {
             | }
             |}
             |""".stripMargin
-        val (query, defaultGraphs) = QueryConstruct.parse(q)
+        val (query, defaultGraphs) = parse(q)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -215,7 +215,7 @@ class GraphsPushdownSpec extends AnyWordSpec with Matchers {
             | }
             |}
             |""".stripMargin
-        val (query, defaultGraphs) = QueryConstruct.parse(q)
+        val (query, defaultGraphs) = parse(q)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -283,7 +283,7 @@ class GraphsPushdownSpec extends AnyWordSpec with Matchers {
             | }
             |}
             |""".stripMargin
-        val (query, defaultGraphs) = QueryConstruct.parse(q)
+        val (query, defaultGraphs) = parse(q)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -351,7 +351,7 @@ class GraphsPushdownSpec extends AnyWordSpec with Matchers {
             | ?x foaf:name ?name .
             |}
             |""".stripMargin
-        val (query, defaultGraphs) = QueryConstruct.parse(q)
+        val (query, defaultGraphs) = parse(q)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/RemoveNestedProjectSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/RemoveNestedProjectSpec.scala
@@ -4,7 +4,7 @@ package optimizer
 import higherkindness.droste.data.Fix
 
 import com.gsk.kg.engine.DAG.Project
-import com.gsk.kg.sparqlparser.QueryConstruct
+import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -13,7 +13,8 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 class RemoveNestedProjectSpec
     extends AnyFlatSpec
     with Matchers
-    with ScalaCheckDrivenPropertyChecks {
+    with ScalaCheckDrivenPropertyChecks
+    with TestUtils {
 
   type T = Fix[DAG]
 
@@ -29,7 +30,7 @@ class RemoveNestedProjectSpec
         | ?d dm:source "potato"
         |}
         |""".stripMargin
-    val (query, _) = QueryConstruct.parse(q)
+    val (query, _) = parse(q)
 
     val dag: T = DAG.fromQuery.apply(query)
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
@@ -7,7 +7,7 @@ trait Interpolators {
 
   implicit class SparqlQueryInterpolator(sc: StringContext) {
 
-    def sparql(args: Any*): Query = {
+    def sparql(args: Any*)(isExclusive: Boolean = false): Query = {
       val strings     = sc.parts.iterator
       val expressions = args.iterator
       val buf         = new StringBuilder(strings.next())
@@ -15,7 +15,7 @@ trait Interpolators {
         buf.append(expressions.next())
         buf.append(strings.next())
       }
-      QueryConstruct.parse(buf.toString())._1
+      QueryConstruct.parse(buf.toString(), isExclusive)._1
     }
 
   }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
@@ -7,11 +7,11 @@ import com.gsk.kg.sparqlparser.StringVal._
 
 import org.scalatest.flatspec.AnyFlatSpec
 
-class ExprParserSpec extends AnyFlatSpec {
+class ExprParserSpec extends AnyFlatSpec with TestUtils {
 
   "Basic Graph Pattern" should "parse correct number of Triples" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q0-simple-basic-graph-pattern.sparql"),
+      sparql2Algebra("/queries/q0-simple-basic-graph-pattern.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -22,7 +22,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Single optional" should "result in single leftjoin" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q1-single-leftjoin.sparql"),
+      sparql2Algebra("/queries/q1-single-leftjoin.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -33,7 +33,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Double optional" should "result in nested leftjoin" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q2-nested-leftjoins.sparql"),
+      sparql2Algebra("/queries/q2-nested-leftjoins.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -44,7 +44,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Single Union" should "result in a single nested union" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q3-union.sparql"),
+      sparql2Algebra("/queries/q3-union.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -54,7 +54,7 @@ class ExprParserSpec extends AnyFlatSpec {
   }
   "Single Bind" should "result in a successful extend instruction" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q4-simple-bind.sparql"),
+      sparql2Algebra("/queries/q4-simple-bind.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -66,7 +66,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Single union plus bind" should "result in a successful extend and union instruction" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q5-union-plus-bind.sparql"),
+      sparql2Algebra("/queries/q5-union-plus-bind.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -81,7 +81,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Nested leftjoin, nested union, multiple binds" should "result in successful nestings" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q6-nested-leftjoin-union-bind.sparql"),
+      sparql2Algebra("/queries/q6-nested-leftjoin-union-bind.sparql"),
       ExprParser.parser(_)
     )
 
@@ -111,7 +111,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Nested bind" should "Result in correct nesting of bind" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q7-nested-bind.sparql"),
+      sparql2Algebra("/queries/q7-nested-bind.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -127,7 +127,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Filter over simple BGP" should "Result in correct nesting of filter and BGP" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q8-filter-simple-basic-graph.sparql"),
+      sparql2Algebra("/queries/q8-filter-simple-basic-graph.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -138,7 +138,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Multiple filters over simple BGP" should "Result in correct nesting of filters and BGP" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra(
+      sparql2Algebra(
         "/queries/q9-double-filter-simple-basic-graph.sparql"
       ),
       ExprParser.parser(_)
@@ -158,7 +158,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Complex filters" should "Result in the correct nesting" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q10-complex-filter.sparql"),
+      sparql2Algebra("/queries/q10-complex-filter.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -193,7 +193,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Simple named graph query" should "Return correct named graph algebra" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q11-simple-named-graph.sparql"),
+      sparql2Algebra("/queries/q11-simple-named-graph.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -205,7 +205,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Double named graph query" should "Return correct named graph algebra" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q12-double-named-graph.sparql"),
+      sparql2Algebra("/queries/q12-double-named-graph.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -220,7 +220,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Complex named graph query" should "Return correct named graph algebra" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q13-complex-named-graph.sparql"),
+      sparql2Algebra("/queries/q13-complex-named-graph.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -264,7 +264,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Simple nested string function query" should "return proper nested type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q15-string-functions-nested.sparql"),
+      sparql2Algebra("/queries/q15-string-functions-nested.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -285,7 +285,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Nested filter function" should "return proper nested types" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q17-filter-nested.sparql"),
+      sparql2Algebra("/queries/q17-filter-nested.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -318,7 +318,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Simple > FILTER query" should "return the proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q18-filter-gt.sparql"),
+      sparql2Algebra("/queries/q18-filter-gt.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -333,7 +333,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "Simple < FILTER query" should "return the proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q19-filter-lt.sparql"),
+      sparql2Algebra("/queries/q19-filter-lt.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -348,7 +348,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   "GroupBy query" should "return the proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q38-groupby.sparql"),
+      sparql2Algebra("/queries/q38-groupby.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -364,7 +364,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   it should "capture all variables" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q39-groupby-two-vars.sparql"),
+      sparql2Algebra("/queries/q39-groupby-two-vars.sparql"),
       ExprParser.parser(_)
     )
     p.get.value match {
@@ -379,7 +379,7 @@ class ExprParserSpec extends AnyFlatSpec {
 
   it should "capture aggregate functions correctly" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra(
+      sparql2Algebra(
         "/queries/q40-groupby-aggregate-functions.sparql"
       ),
       ExprParser.parser(_)
@@ -423,87 +423,87 @@ class ExprParserSpec extends AnyFlatSpec {
    */
   "Complex nested string function query" should "return proper nested type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra(
+      sparql2Algebra(
         "/queries/q16-string-functions-nested-complex.sparql"
       ),
       ExprParser.parser(_)
     )
-    val output = TestUtils.readOutputFile("/queries/output/q16-output.txt")
+    val output = readOutputFile("/queries/output/q16-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
 
   "Full query1" should "return proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/lit-search-1.sparql"),
+      sparql2Algebra("/queries/lit-search-1.sparql"),
       ExprParser.parser(_)
     )
     val output =
-      TestUtils.readOutputFile("/queries/output/lit-search-1-output.txt")
+      readOutputFile("/queries/output/lit-search-1-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
   "Full query2" should "return proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/lit-search-2.sparql"),
+      sparql2Algebra("/queries/lit-search-2.sparql"),
       ExprParser.parser(_)
     )
     val output =
-      TestUtils.readOutputFile("/queries/output/lit-search-2-output.txt")
+      readOutputFile("/queries/output/lit-search-2-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
   "Full query3" should "return proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/lit-search-3.sparql"),
+      sparql2Algebra("/queries/lit-search-3.sparql"),
       ExprParser.parser(_)
     )
     val output =
-      TestUtils.readOutputFile("/queries/output/lit-search-3-output.txt")
+      readOutputFile("/queries/output/lit-search-3-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
   "Full query4" should "return proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/lit-search-4.sparql"),
+      sparql2Algebra("/queries/lit-search-4.sparql"),
       ExprParser.parser(_)
     )
     val output =
-      TestUtils.readOutputFile("/queries/output/lit-search-4-output.txt")
+      readOutputFile("/queries/output/lit-search-4-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
   "Full query5" should "return proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/lit-search-5.sparql"),
+      sparql2Algebra("/queries/lit-search-5.sparql"),
       ExprParser.parser(_)
     )
     val output =
-      TestUtils.readOutputFile("/queries/output/lit-search-5-output.txt")
+      readOutputFile("/queries/output/lit-search-5-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
   "Full query6" should "return proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/lit-search-6.sparql"),
+      sparql2Algebra("/queries/lit-search-6.sparql"),
       ExprParser.parser(_)
     )
     val output =
-      TestUtils.readOutputFile("/queries/output/lit-search-6-output.txt")
+      readOutputFile("/queries/output/lit-search-6-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
 
   "Extra large query" should "return proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/lit-search-xlarge.sparql"),
+      sparql2Algebra("/queries/lit-search-xlarge.sparql"),
       ExprParser.parser(_)
     )
     val output =
-      TestUtils.readOutputFile("/queries/output/lit-search-xlarge-output.txt")
+      readOutputFile("/queries/output/lit-search-xlarge-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
 
   "Document query" should "return the proper type" in {
     val p = fastparse.parse(
-      TestUtils.sparql2Algebra("/queries/q20-document.sparql"),
+      sparql2Algebra("/queries/q20-document.sparql"),
       ExprParser.parser(_)
     )
     val output =
-      TestUtils.readOutputFile("/queries/output/q20-document-output.txt")
+      readOutputFile("/queries/output/q20-document-output.txt")
     assert(output.trim == p.get.value.toString.trim)
   }
 }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
@@ -8,10 +8,10 @@ import scala.collection.mutable
 
 import org.scalatest.flatspec.AnyFlatSpec
 
-class QueryConstructSpec extends AnyFlatSpec {
+class QueryConstructSpec extends AnyFlatSpec with TestUtils {
 
   "Simple Query" should "parse Construct statement with correct number of Triples" in {
-    TestUtils.query("/queries/q0-simple-basic-graph-pattern.sparql") match {
+    query("/queries/q0-simple-basic-graph-pattern.sparql") match {
       case Construct(vars, bgp, expr) =>
         assert(vars.size == 2 && bgp.quads.size == 2)
       case _ => fail
@@ -19,7 +19,7 @@ class QueryConstructSpec extends AnyFlatSpec {
   }
 
   "Construct" should "result in proper variables, a basic graph pattern, and algebra expression" in {
-    TestUtils.query("/queries/q3-union.sparql") match {
+    query("/queries/q3-union.sparql") match {
       case Construct(
             vars,
             bgp,
@@ -33,7 +33,7 @@ class QueryConstructSpec extends AnyFlatSpec {
   }
 
   "Construct with Bind" should "contains bind variable" in {
-    TestUtils.query("/queries/q4-simple-bind.sparql") match {
+    query("/queries/q4-simple-bind.sparql") match {
       case Construct(
             vars,
             bgp,
@@ -45,7 +45,7 @@ class QueryConstructSpec extends AnyFlatSpec {
   }
 
   "Complex named graph query" should "be captured properly in Construct" in {
-    TestUtils.query("/queries/q13-complex-named-graph.sparql") match {
+    query("/queries/q13-complex-named-graph.sparql") match {
       case Construct(vars, bgp, expr) =>
         assert(vars.size == 13)
         assert(vars.exists(va => va.s == "?ogihw"))
@@ -55,7 +55,7 @@ class QueryConstructSpec extends AnyFlatSpec {
 
   "Complex lit-search query" should "return proper Construct type" in {
     val a = 1
-    TestUtils.query("/queries/lit-search-3.sparql") match {
+    query("/queries/lit-search-3.sparql") match {
       case Construct(vars, bgp, expr) =>
         assert(bgp.quads.size == 11)
         assert(
@@ -69,7 +69,7 @@ class QueryConstructSpec extends AnyFlatSpec {
   }
 
   "Extra large query" should "return proper Construct type" in {
-    TestUtils.query("/queries/lit-search-xlarge.sparql") match {
+    query("/queries/lit-search-xlarge.sparql") match {
       case Construct(vars, bgp, expr) =>
         assert(bgp.quads.size == 67)
         assert(bgp.quads.head.s.asInstanceOf[VARIABLE].s == "?Year")
@@ -96,7 +96,7 @@ class QueryConstructSpec extends AnyFlatSpec {
         }
       """
 
-    QueryConstruct.parse(query) match {
+    parse(query) match {
       case (
             Construct(
               vars,
@@ -126,7 +126,7 @@ class QueryConstructSpec extends AnyFlatSpec {
         |} LIMIT 10
         |""".stripMargin
 
-    val x = QueryConstruct.parse(query)
+    val x = parse(query)
 
     x match {
       case (

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
-class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
+class QuerySamplesTestSpec extends AnyFlatSpec with Matchers with TestUtils {
 
   def showAlgebra(q: String): Op = {
     val query = QueryFactory.create(q)
@@ -192,7 +192,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Test simple describe query" should "parse" in {
     val query = QuerySamples.q15
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Describe(_, OpNil()), _) =>
         succeed
@@ -203,7 +203,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Test describe query" should "parse" in {
     val query = QuerySamples.q16
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Describe(vars, Project(vs, Filter(_, _))), _) =>
         assert(vars == vs)
@@ -215,7 +215,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Tests str conversion and logical operators" should "parse" in {
     val query = QuerySamples.q17
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(vs, Filter(_, _))), _) =>
         succeed
@@ -226,7 +226,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Tests FILTER positioning with graph sub-patterns" should "parse" in {
     val query = QuerySamples.q18
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(vs, Filter(_, _))), _) =>
         succeed
@@ -237,7 +237,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Test for FILTER in different positions" should "parse" in {
     val query = QuerySamples.q19
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Distinct(Project(vs, Filter(_, _)))), _) =>
         succeed
@@ -248,7 +248,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Test CONSTRUCT and string replacement" should "parse" in {
     val query = QuerySamples.q20
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (
             Construct(
@@ -266,7 +266,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Test document query" should "parse" in {
     val query = QuerySamples.q21
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(vs, BGP(ts))), _) =>
         assert(ts.size == 21)
@@ -279,7 +279,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Get a sample of triples joining non-blank nodes" should "parse" in {
     val query = QuerySamples.q22
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (
             Select(
@@ -296,7 +296,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Check DISTINCT works" should "parse" in {
     val query = QuerySamples.q23
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (
             Select(
@@ -313,7 +313,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Get class parent-child relations" should "parse" in {
     val query = QuerySamples.q24
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(_, Filter(_, _))), _) =>
         succeed
@@ -324,7 +324,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Get class parent-child relations with optional labels" should "parse" in {
     val query = QuerySamples.q25
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(_, Filter(_, _))), _) =>
         succeed
@@ -335,7 +335,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Get all labels in file" should "parse" in {
     val query = QuerySamples.q26
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Distinct(Project(_, _))), _) =>
         succeed
@@ -346,7 +346,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Get label of owl:Thing" should "parse" in {
     val query = QuerySamples.q27
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(vs, _)), _) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
@@ -357,7 +357,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Get label of owl:Thing with prefix" should "parse" in {
     val query = QuerySamples.q28
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(_, _)), _) =>
         succeed
@@ -368,7 +368,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Get label of owl:Thing with explanatory comment" should "parse" in {
     val query = QuerySamples.q29
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(_, _)), _) =>
         succeed
@@ -379,7 +379,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Get label of owl:Thing with regex to remove poor label if present" should "parse" in {
     val query = QuerySamples.q30
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(_, Filter(_, _))), _) =>
         succeed
@@ -390,7 +390,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Construct a graph where everything which is a Thing is asserted to exist" should "parse" in {
     val query = QuerySamples.q31
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Construct(vars, bgp, BGP(_)), _) =>
         succeed
@@ -401,7 +401,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Construct a graph where all the terms derived from a species have a new relation" should "parse" in {
     val query = QuerySamples.q32
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Construct(vars, bgp, BGP(_)), _) =>
         succeed
@@ -412,7 +412,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Detect punned relations in an ontology" should "parse" in {
     val query = QuerySamples.q33
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Select(vars, Project(_, _)), _) =>
         succeed
@@ -423,7 +423,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Construct a triple where the predicate is derived" should "parse" in {
     val query = QuerySamples.q34
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Construct(vars, bgp, Union(BGP(_), BGP(_))), _) =>
         succeed
@@ -434,7 +434,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Query to convert schema of predications" should "parse" in {
     val query = QuerySamples.q35
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query)
     q match {
       case (Construct(vars, bgp, Extend(to, from, e)), _) =>
         assert(to == VARIABLE("?pred"))
@@ -445,7 +445,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Query with default and named graphs to match on specific graph" should "parse" in {
     val query = QuerySamples.q36
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query, isExclusive = true)
     q match {
       case (
             Select(
@@ -465,7 +465,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers {
 
   "Query with default and named graphs to match on multiple graphs" should "parse" in {
     val query = QuerySamples.q37
-    val q     = QueryConstruct.parse(query)
+    val q     = parse(query, isExclusive = true)
     q match {
       case (
             Select(

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ShortQueryTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ShortQueryTestSpec.scala
@@ -5,7 +5,7 @@ import com.gsk.kg.sparqlparser.StringVal._
 
 import org.scalatest.flatspec.AnyFlatSpec
 
-class ShortQueryTestSpec extends AnyFlatSpec {
+class ShortQueryTestSpec extends AnyFlatSpec with TestUtils {
 
   "test filtered left join with multiple filters" should "pass" in {
 
@@ -32,7 +32,7 @@ class ShortQueryTestSpec extends AnyFlatSpec {
     }
 
     """
-    val query = QueryConstruct.parse(q)
+    val query = parse(q)
     query._1.r match {
       case FilteredLeftJoin(BGP(_), Extend(to, from, _), funcs) =>
         assert(funcs.size == 2)
@@ -54,7 +54,7 @@ class ShortQueryTestSpec extends AnyFlatSpec {
           ?doc lita:contextText "cde" .
         }
       """
-    val query = QueryConstruct.parse(q)
+    val query = parse(q)
     query._1.r match {
       case Project(vs, BGP(triples)) =>
         assert(triples(0).o == BOOL("true"))

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
@@ -5,7 +5,7 @@ import org.apache.jena.sparql.algebra.Algebra
 
 import scala.io.Source
 
-object TestUtils {
+trait TestUtils {
 
   def sparql2Algebra(fileLoc: String): String = {
     val path   = getClass.getResource(fileLoc).getPath
@@ -20,14 +20,20 @@ object TestUtils {
     QueryConstruct.parseADT(q)
   }
 
-  def query(fileLoc: String): Query = {
+  def query(fileLoc: String, isExclusive: Boolean = false): Query = {
     val q = readOutputFile(fileLoc)
-    QueryConstruct.parse(q)._1
+    parse(q, isExclusive)._1
   }
 
   def readOutputFile(fileLoc: String): String = {
     val path = getClass.getResource(fileLoc).getPath
     Source.fromFile(path).mkString
   }
+
+  def parse(
+      query: String,
+      isExclusive: Boolean = false
+  ): (Query, List[StringVal]) =
+    QueryConstruct.parse((query, isExclusive))
 
 }


### PR DESCRIPTION
This PR sets the behavior of the engine as inclusive for default graphs and also allows to change and test exclusive behavior easily.

In the future it can be retrieved from some type of configuration.

Closes #200 