### PR TITLE
added support for variables on graph statement

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Compiler.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Compiler.scala
@@ -9,11 +9,11 @@ import higherkindness.droste.Basis
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SQLContext
 
+import com.gsk.kg.Graphs
 import com.gsk.kg.engine.analyzer.Analyzer
 import com.gsk.kg.engine.optimizer.Optimizer
 import com.gsk.kg.sparqlparser.Query
 import com.gsk.kg.sparqlparser.QueryConstruct
-import com.gsk.kg.sparqlparser.StringVal
 
 object Compiler {
 
@@ -59,10 +59,10 @@ object Compiler {
 
   /** parser converts strings to our [[Query]] ADT
     */
-  val parser: Phase[(String, Boolean), (Query, List[StringVal])] =
+  val parser: Phase[(String, Boolean), (Query, Graphs)] =
     Arrow[Phase].lift(QueryConstruct.parse)
 
-  def optimizer[T: Basis[DAG, *]]: Phase[(T, List[StringVal]), T] =
+  def optimizer[T: Basis[DAG, *]]: Phase[(T, Graphs), T] =
     Optimizer.optimize
 
   def staticAnalysis[T: Basis[DAG, *]]: Phase[T, T] =

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -96,7 +96,9 @@ object Engine {
     )
   )
 
-  private def evaluateJoin(l: Multiset, r: Multiset): M[Multiset] =
+  private def evaluateJoin(l: Multiset, r: Multiset)(implicit
+      sc: SQLContext
+  ): M[Multiset] =
     l.join(r).pure[M]
 
   private def evaluateUnion(l: Multiset, r: Multiset): M[Multiset] =
@@ -116,6 +118,7 @@ object Engine {
       quads: ChunkedList[Expr.Quad]
   )(implicit sc: SQLContext): M[Multiset] = {
     import sc.implicits._
+
     M.get[Result, DataFrame].map { df =>
       Foldable[ChunkedList].fold(
         quads.mapChunks { chunk =>

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -416,7 +416,6 @@ object Multiset {
 
     // Generates a schema for the final DF (needed for the flatMap)
     val resultSchema = innerWithMergedGraphColunns
-      .drop(leftGraphCol, rightGraphCol)
       .withColumn(GRAPH_VARIABLE.s, lit(""))
       .schema
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -46,24 +46,16 @@ final case class Multiset(
   def join(other: Multiset): Multiset = (this, other) match {
     case (l, r) if l.isEmpty => r
     case (l, r) if r.isEmpty => l
-    case (l, r) if noCommonBindings(l, r) && containsGraphVariables(l, r) =>
-      Multiset(
-        l.bindings union r.bindings,
-        crossJoinWithGraphsColumns(l.dataframe, r.dataframe)
-      )
     case (l, r) if noCommonBindings(l, r) =>
       Multiset(
         l.bindings union r.bindings,
         l.dataframe.crossJoin(r.dataframe)
       )
     case (l, r) =>
-      val df = l.dataframe.join(
-        r.dataframe,
-        (l.bindings intersect r.bindings).toSeq
-          .map(_.s),
-        "inner"
+      Multiset(
+        l.bindings union r.bindings,
+        innerJoinWithGraphsColumn(l.dataframe, r.dataframe)
       )
-      Multiset(l.bindings union r.bindings, df)
   }
 
   /** A left join returns all values from the left relation and the matched values from the right relation,
@@ -273,15 +265,15 @@ object Multiset {
   /** This methods is a utility to perform operations like [[union]], [[join]], [[leftJoin]] on Multisets without
     * taking into account graph bindings and graph columns on dataframes by:
     * removing from bindings and dataframe -> operate -> adding binding and column to final dataframe as default graph
-    * @param right
     * @param left
+    * @param right
     * @param f
     * @return
     */
-  private def graphAgnostic(right: Multiset, left: Multiset)(
+  private def graphAgnostic(left: Multiset, right: Multiset)(
       f: (Multiset, Multiset) => Multiset
   ): Multiset =
-    addDefaultGraph(f(filterGraph(right), filterGraph(left)))
+    addDefaultGraph(f(filterGraph(left), filterGraph(right)))
 
   /** This method performs a cross join between graphs by merging the graph columns of each dataframes into an array
     * column, this way we generate new rows for each graph that is in the array. Eg:
@@ -359,6 +351,88 @@ object Multiset {
       val index  = r.fieldIndex(GRAPH_VARIABLE.s)
       val graphs = r.getSeq[String](index)
       graphs.distinct.map(g => Row.fromSeq(r.toSeq.dropRight(1) :+ g))
+    }(RowEncoder(resultSchema))
+
+    // Needed to keep Schema information on each Row. We will have GenericRowWithSchema instead of GenericRow
+    SparkSession
+      .builder()
+      .getOrCreate()
+      .sqlContext
+      .sparkSession
+      .createDataFrame(result.toJavaRDD, resultSchema)
+  }
+
+  /** This method performs a inner join between graphs by merging the graph columns of each dataframes into an array
+    * column, if they have same graph then the graph is preserved, if not it is added as if in the default graph. Eg:
+    * Initial dataframes:
+    * l.dataframe = List(
+    *   ("a", "graph1"),
+    *   ("b", "graph1"),
+    *   ("c", "graph1")
+    * ).toDF("?x", "*g")
+    * r.dataframe = List(
+    *   ("b", "graph1"),
+    *   ("c", "graph2"),
+    *   ("d", "graph2")
+    * ).toDF("?x", "*g")
+    *
+    * Step1:
+    * step1Dataframe = List(
+    *   ("b", "graph1", "graph1"),
+    *   ("c", "graph1", "graph2")
+    * ).toDF("?x", "*l", "*r")
+    *
+    * Step2:
+    * step2Dataframe = List(
+    *   ("b", List("graph1", "graph1")),
+    *   ("c", List("graph1", "graph2"))
+    * ).toDF("?x", "*g")
+    *
+    * Final:
+    * final = List(
+    *  ("b", "graph1"),
+    *  ("c", ""),
+    * ).toDF("?x", "*g")
+    *
+    * IMPORTANT!: This method could have some performance issues as it traverses entire dataframe, and should be revisited
+    * for performance improvements.
+    * @param l
+    * @param r
+    * @return
+    */
+  def innerJoinWithGraphsColumn(l: DataFrame, r: DataFrame): DataFrame = {
+    val leftGraphCol  = "*l"
+    val rightGraphCol = "*r"
+
+    val renamedLeft =
+      l.as("l").withColumnRenamed(GRAPH_VARIABLE.s, leftGraphCol)
+    val renamedRight =
+      r.as("r").withColumnRenamed(GRAPH_VARIABLE.s, rightGraphCol)
+
+    val intersect = renamedLeft.columns intersect renamedRight.columns
+    val innerJoin = renamedLeft.join(renamedRight, intersect, "inner")
+
+    // Merges the *l and *r columns into a *g column with Array(l, r)
+    val innerWithMergedGraphColunns = innerJoin
+      .withColumn(GRAPH_VARIABLE.s, array(leftGraphCol, rightGraphCol))
+      .drop(leftGraphCol, rightGraphCol)
+
+    // Generates a schema for the final DF (needed for the flatMap)
+    val resultSchema = innerWithMergedGraphColunns
+      .drop(leftGraphCol, rightGraphCol)
+      .withColumn(GRAPH_VARIABLE.s, lit(""))
+      .schema
+
+    // For each element on the array of *g column if all the graphs are the same we assign the graph
+    // if not we assign default graph
+    val result = innerWithMergedGraphColunns.map { r =>
+      val index  = r.fieldIndex(GRAPH_VARIABLE.s)
+      val graphs = r.getSeq[String](index)
+      if (graphs.forall(_ == graphs.head)) {
+        Row.fromSeq(r.toSeq.dropRight(1) :+ graphs.head)
+      } else {
+        Row.fromSeq(r.toSeq.dropRight(1) :+ "")
+      }
     }(RowEncoder(resultSchema))
 
     // Needed to keep Schema information on each Row. We will have GenericRowWithSchema instead of GenericRow

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -52,7 +52,9 @@ object FindUnboundVariables {
           declared <- State.get
         } yield (used diff declared) ++ r
       case Scan(graph, expr) =>
-        Set.empty.pure[ST]
+        State
+          .modify[Set[VARIABLE]](x => x + VARIABLE(graph))
+          .flatMap(_ => expr.pure[ST])
       case Project(variables, r) =>
         for {
           declared <- State.get

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimize/Optimizer.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimize/Optimizer.scala
@@ -6,17 +6,17 @@ import cats.implicits._
 
 import higherkindness.droste.Basis
 
+import com.gsk.kg.Graphs
 import com.gsk.kg.engine.optimize.GraphsPushdown
-import com.gsk.kg.sparqlparser.StringVal
 
 object Optimizer {
 
-  def graphsPushdownPhase[T: Basis[DAG, *]]: Phase[(T, List[StringVal]), T] =
-    Phase { case (t, defaults) =>
-      GraphsPushdown[T].apply(t, defaults).pure[M]
+  def graphsPushdownPhase[T: Basis[DAG, *]]: Phase[(T, Graphs), T] =
+    Phase { case (t, graphs) =>
+      GraphsPushdown[T].apply(t, graphs).pure[M]
     }
 
-  def optimize[T: Basis[DAG, *]]: Phase[(T, List[StringVal]), T] =
+  def optimize[T: Basis[DAG, *]]: Phase[(T, Graphs), T] =
     graphsPushdownPhase >>>
       Arrow[Phase].lift(CompactBGPs[T]) >>>
       Arrow[Phase].lift(RemoveNestedProject[T])

--- a/modules/parser/src/main/scala/com/gsk/kg/Graphs.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/Graphs.scala
@@ -1,0 +1,5 @@
+package com.gsk.kg
+
+import com.gsk.kg.sparqlparser.StringVal
+
+final case class Graphs(default: List[StringVal], named: List[StringVal])

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
@@ -4,6 +4,7 @@ import org.apache.jena.query.QueryFactory
 import org.apache.jena.sparql.algebra.Algebra
 import org.apache.jena.sparql.core.{Quad => JenaQuad}
 
+import com.gsk.kg.Graphs
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.Query._
 import com.gsk.kg.sparqlparser.StringVal._
@@ -17,12 +18,11 @@ object QueryConstruct {
 
   final case class SparqlParsingError(s: String) extends Exception(s)
 
-  def parse(input: (String, Boolean)): (Query, List[StringVal]) = {
+  def parse(input: (String, Boolean)): (Query, Graphs) = {
     val sparql      = input._1
     val isExclusive = input._2
-
-    val query    = QueryFactory.create(sparql)
-    val compiled = Algebra.compile(query)
+    val query       = QueryFactory.create(sparql)
+    val compiled    = Algebra.compile(query)
     val parsed = fastparse.parse(
       compiled.toString,
       ExprParser.parser(_),
@@ -41,19 +41,22 @@ object QueryConstruct {
     } else {
       Nil
     }
+    val namedGraphs =
+      query.getNamedGraphURIs.asScala.toList.map(URIVAL)
+    val graphs = Graphs(defaultGraphs, namedGraphs)
 
     if (query.isConstructType) {
       val template = query.getConstructTemplate
       val vars     = getVars(query)
       val bgp      = toBGP(template.getQuads.asScala)
-      (Construct(vars, bgp, algebra), defaultGraphs)
+      (Construct(vars, bgp, algebra), graphs)
     } else if (query.isSelectType) {
       val vars = getVars(query)
-      (Select(vars, algebra), defaultGraphs)
+      (Select(vars, algebra), graphs)
     } else if (query.isDescribeType) {
-      (Describe(getVars(query), algebra), defaultGraphs)
+      (Describe(getVars(query), algebra), graphs)
     } else if (query.isAskType) {
-      (Ask(algebra), defaultGraphs)
+      (Ask(algebra), graphs)
     } else {
       throw SparqlParsingError(
         s"The query type: ${query.queryType()} is not supported yet"

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -452,11 +452,15 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers with TestUtils {
               _,
               Project(_, Graph(specifiedGraph, _))
             ),
-            defaultGraphs
+            graphs
           ) =>
-        defaultGraphs should (have size 2 and contain theSameElementsAs Seq(
+        graphs.default should (have size 2 and contain theSameElementsAs Seq(
           URIVAL("http://example.org/dft.ttl"),
           URIVAL("")
+        ))
+        graphs.named should (have size 2 and contain theSameElementsAs Seq(
+          URIVAL("http://example.org/alice"),
+          URIVAL("http://example.org/bob")
         ))
       case _ =>
         fail
@@ -472,11 +476,15 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers with TestUtils {
               vars,
               Project(_, Join(_, Graph(graphVariable, _)))
             ),
-            defaultGraphs
+            graphs
           ) =>
-        defaultGraphs should (have size 2 and contain theSameElementsAs Seq(
+        graphs.default should (have size 2 and contain theSameElementsAs Seq(
           URIVAL("http://example.org/dft.ttl"),
           URIVAL("")
+        ))
+        graphs.named should (have size 2 and contain theSameElementsAs Seq(
+          URIVAL("http://example.org/alice"),
+          URIVAL("http://example.org/bob")
         ))
         graphVariable shouldEqual vars(1)
       case _ =>

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
@@ -3,6 +3,8 @@ package com.gsk.kg.sparqlparser
 import org.apache.jena.query.QueryFactory
 import org.apache.jena.sparql.algebra.Algebra
 
+import com.gsk.kg.Graphs
+
 import scala.io.Source
 
 trait TestUtils {
@@ -33,7 +35,7 @@ trait TestUtils {
   def parse(
       query: String,
       isExclusive: Boolean = false
-  ): (Query, List[StringVal]) =
+  ): (Query, Graphs) =
     QueryConstruct.parse((query, isExclusive))
 
 }


### PR DESCRIPTION
This PR adds support for use of variables in GRAPH statement. Eg:

```
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX dc: <http://purl.org/dc/elements/1.1/>
PREFIX ex: <http://example.org/>

SELECT ?who ?g ?mbox
FROM <http://example.org/dft.ttl>
FROM NAMED <http://example.org/alice>
FROM NAMED <http://example.org/bob>
FROM NAMED <http://example.org/charles>
WHERE
{
   ?g dc:publisher ?who .
   GRAPH ?g { ?x foaf:mbox ?mbox }
}
```

Closes #173 