### PR TITLE
Engine configuration

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -47,7 +47,7 @@ Disable.ifSynthetic = [
 ]
 
 DisableSyntax {
-  noDefaultArgs = false
+  noDefaultArgs = true
   noFinalVal = true
   noFinalize = true
   noImplicitConversion = true

--- a/build.sbt
+++ b/build.sbt
@@ -193,8 +193,8 @@ lazy val `bellman-spark-engine` = project
       .config("spark.driver.host", "localhost")
       .getOrCreate()
       
-    implicit val config = ConfigSource.default.loadOrThrow[Config]
     implicit val sc: SQLContext = spark.sqlContext
+    val config = ConfigSource.default.loadOrThrow[Config]
 
     import sc.implicits._
     

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,8 @@ lazy val Versions = Map(
   "discipline"           -> "1.1.2",
   "discipline-scalatest" -> "2.0.1",
   "reftree"              -> "1.4.0",
-  "shims"                -> "2.1.0"
+  "shims"                -> "2.1.0",
+  "pureconfig"           -> "0.14.0"
 )
 
 inThisBuild(
@@ -90,10 +91,11 @@ lazy val compilerPlugins = Seq(
 
 lazy val commonDependencies = Seq(
   libraryDependencies ++= Seq(
-    "org.typelevel"     %% "cats-core"     % Versions("cats"),
-    "io.higherkindness" %% "droste-core"   % Versions("droste"),
-    "io.higherkindness" %% "droste-macros" % Versions("droste"),
-    "org.scalatest"     %% "scalatest"     % Versions("scalatest") % Test
+    "org.typelevel"         %% "cats-core"     % Versions("cats"),
+    "io.higherkindness"     %% "droste-core"   % Versions("droste"),
+    "io.higherkindness"     %% "droste-macros" % Versions("droste"),
+    "com.github.pureconfig" %% "pureconfig"    % Versions("pureconfig"),
+    "org.scalatest"         %% "scalatest"     % Versions("scalatest") % Test
   )
 )
 
@@ -170,6 +172,7 @@ lazy val `bellman-spark-engine` = project
     import higherkindness.droste.data.prelude._
     import higherkindness.droste.syntax.all._
 
+    import com.gsk.kg.config.Config
     import com.gsk.kg.sparql.syntax.all._
     import com.gsk.kg.sparqlparser._
     import com.gsk.kg.engine.data._
@@ -180,16 +183,21 @@ lazy val `bellman-spark-engine` = project
 
     import org.apache.spark._
     import org.apache.spark.sql._
+    
+    import pureconfig.generic.auto._
+    import pureconfig._
 
     val spark = SparkSession.builder()
       .appName("Spark Local")
       .master("local")
       .config("spark.driver.host", "localhost")
       .getOrCreate()
-
+      
+    implicit val config = ConfigSource.default.loadOrThrow[Config]
     implicit val sc: SQLContext = spark.sqlContext
 
     import sc.implicits._
+    
     """
   )
   .dependsOn(`bellman-algebra-parser` % "compile->compile;test->test")

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/syntax/package.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/syntax/package.scala
@@ -3,10 +3,13 @@ package com.gsk.kg.engine
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SQLContext
 
+import com.gsk.kg.config.Config
+
 package object syntax {
 
   implicit class SparQLSyntaxOnDataFrame(private val df: DataFrame)(implicit
-      sc: SQLContext
+      sc: SQLContext,
+      config: Config
   ) {
     def sparql(query: String): DataFrame =
       Compiler.compile(df, query).right.get

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/syntax/package.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/syntax/package.scala
@@ -12,7 +12,7 @@ package object syntax {
       config: Config
   ) {
     def sparql(query: String): DataFrame =
-      Compiler.compile(df, query).right.get
+      Compiler.compile(df, query, config).right.get
   }
 
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -66,7 +66,7 @@ class CompilerSpec
           |}
           |""".stripMargin
 
-      val result = Compiler.compile(df, query)
+      val result = Compiler.compile(df, query, config)
 
       result shouldBe a[Right[_, _]]
       result.right.get.collect().length shouldEqual 4
@@ -108,7 +108,7 @@ class CompilerSpec
       val inputDF  = readNTtoDF("fixtures/reference-q1-input.nt")
       val outputDF = readNTtoDF("fixtures/reference-q1-output.nt")
 
-      val result = Compiler.compile(inputDF, query)
+      val result = Compiler.compile(inputDF, query, config)
 
       result shouldBe a[Right[_, _]]
       result.right.get.collect.toSet shouldEqual outputDF
@@ -131,7 +131,11 @@ class CompilerSpec
             }
             """
 
-        Compiler.compile(df, query).right.get.collect() shouldEqual Array(
+        Compiler
+          .compile(df, query, config)
+          .right
+          .get
+          .collect() shouldEqual Array(
           Row(
             "\"test\"",
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
@@ -155,7 +159,11 @@ class CompilerSpec
             }
             """
 
-        Compiler.compile(df, query).right.get.collect() shouldEqual Array(
+        Compiler
+          .compile(df, query, config)
+          .right
+          .get
+          .collect() shouldEqual Array(
           Row("\"test\"", "\"source\"")
         )
       }
@@ -179,7 +187,11 @@ class CompilerSpec
       }
       """
 
-        Compiler.compile(df, query).right.get.collect() shouldEqual Array(
+        Compiler
+          .compile(df, query, config)
+          .right
+          .get
+          .collect() shouldEqual Array(
           Row("\"test\"", "http://id.gsk.com/dm/1.0/Document"),
           Row("\"test\"", "\"source\"")
         )
@@ -201,7 +213,11 @@ class CompilerSpec
       }
       """
 
-        Compiler.compile(df, query).right.get.collect() shouldEqual Array(
+        Compiler
+          .compile(df, query, config)
+          .right
+          .get
+          .collect() shouldEqual Array(
           Row("\"test\"", "http://id.gsk.com/dm/1.0/Document", null, null),
           Row(null, null, "\"test\"", "\"source\"")
         )
@@ -223,7 +239,11 @@ class CompilerSpec
         }
         """
 
-        Compiler.compile(df, query).right.get.collect() shouldEqual Array(
+        Compiler
+          .compile(df, query, config)
+          .right
+          .get
+          .collect() shouldEqual Array(
           Row(
             "\"test\"",
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
@@ -261,7 +281,8 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query).right.get.collect().toSet
+        val result =
+          Compiler.compile(df, query, config).right.get.collect().toSet
         result shouldEqual Set(
           Row(
             "\"doesmatch\"",
@@ -319,7 +340,12 @@ class CompilerSpec
       }
       """
 
-        Compiler.compile(df, query).right.get.collect().toSet shouldEqual Set(
+        Compiler
+          .compile(df, query, config)
+          .right
+          .get
+          .collect()
+          .toSet shouldEqual Set(
           Row(
             "\"test\"",
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
@@ -354,7 +380,7 @@ class CompilerSpec
             |LIMIT   2
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
@@ -382,7 +408,7 @@ class CompilerSpec
             |LIMIT   0
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 0
@@ -407,7 +433,7 @@ class CompilerSpec
             |LIMIT   2147483648
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Left[_, _]]
         result.left.get shouldEqual EngineError.NumericTypesDoNotMatch(
@@ -436,7 +462,7 @@ class CompilerSpec
             |OFFSET 1
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
@@ -464,7 +490,7 @@ class CompilerSpec
             |OFFSET 0
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 3
@@ -493,7 +519,7 @@ class CompilerSpec
             |OFFSET 5
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 0
@@ -532,7 +558,7 @@ class CompilerSpec
             |}LIMIT 10
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.toSet shouldEqual Set(
@@ -563,7 +589,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 4
@@ -595,7 +621,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Left[_, _]]
           result.left.get shouldEqual EngineError.FunctionError(
@@ -647,7 +673,7 @@ class CompilerSpec
             |""".stripMargin
         }
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 1
@@ -690,7 +716,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 1
@@ -726,7 +752,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -755,7 +781,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -785,7 +811,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -871,7 +897,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -928,7 +954,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -970,7 +996,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -998,7 +1024,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1028,7 +1054,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 3
@@ -1061,7 +1087,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1101,7 +1127,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1129,7 +1155,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1157,7 +1183,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1205,7 +1231,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect should have length 2
@@ -1237,7 +1263,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1277,7 +1303,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1305,7 +1331,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1333,7 +1359,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1381,7 +1407,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect should have length 1
@@ -1412,7 +1438,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1450,7 +1476,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1479,7 +1505,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1507,7 +1533,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 0
@@ -1554,7 +1580,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect should have length 2
@@ -1586,7 +1612,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1626,7 +1652,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1655,7 +1681,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1683,7 +1709,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1732,7 +1758,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect should have length 2
@@ -1766,7 +1792,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -1813,7 +1839,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -1843,7 +1869,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -1872,7 +1898,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -1920,7 +1946,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect should have length 3
@@ -1954,7 +1980,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -2001,7 +2027,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -2031,7 +2057,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -2060,7 +2086,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -2110,7 +2136,7 @@ class CompilerSpec
               |
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect should have length 3
@@ -2181,7 +2207,7 @@ class CompilerSpec
             }
             """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 6
@@ -2276,7 +2302,7 @@ class CompilerSpec
       LIMIT 1
       """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
@@ -2349,7 +2375,7 @@ class CompilerSpec
       }
       """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         val arrayResult = result.right.get.collect
         result shouldBe a[Right[_, _]]
@@ -2430,7 +2456,7 @@ class CompilerSpec
       }
       """
 
-        val result      = Compiler.compile(df, query)
+        val result      = Compiler.compile(df, query, config)
         val resultDF    = result.right.get
         val arrayResult = resultDF.collect
 
@@ -2482,7 +2508,7 @@ class CompilerSpec
             |       }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 3
@@ -2527,7 +2553,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
@@ -2568,7 +2594,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
@@ -2599,7 +2625,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
@@ -2674,7 +2700,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -2747,7 +2773,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -2820,7 +2846,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -2916,7 +2942,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -2987,7 +3013,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -3057,7 +3083,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -3145,7 +3171,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -3235,7 +3261,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -3294,7 +3320,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3364,7 +3390,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3434,7 +3460,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3506,7 +3532,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3578,7 +3604,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3673,7 +3699,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 3
@@ -3775,7 +3801,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3874,7 +3900,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3973,7 +3999,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -4078,7 +4104,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 1
@@ -4180,7 +4206,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 3
@@ -4301,7 +4327,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 4
@@ -4419,7 +4445,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)
+          val result = Compiler.compile(df, query, config)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 0
@@ -4457,7 +4483,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Right[_, _]]
         result.right.get.collect().length shouldEqual 4
@@ -4490,7 +4516,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Left[_, _]]
         result.left.get shouldEqual EngineError.InvalidInputDataFrame(
@@ -4515,7 +4541,7 @@ class CompilerSpec
             |}
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result shouldBe a[Left[_, _]]
         result.left.get shouldEqual EngineError.InvalidInputDataFrame(
@@ -4563,7 +4589,7 @@ class CompilerSpec
           } GROUP BY ?a
           """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect.toSet shouldEqual Set(
           Row("http://uri.com/subject/a1"),
@@ -4609,7 +4635,7 @@ class CompilerSpec
           } GROUP BY ?a
           """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect.toSet shouldEqual Set(
           Row("http://uri.com/subject/a1", 2),
@@ -4635,7 +4661,7 @@ class CompilerSpec
           } GROUP BY ?a
           """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect.toSet shouldEqual Set(
           Row("http://uri.com/subject/a1", 1.5),
@@ -4661,7 +4687,7 @@ class CompilerSpec
           } GROUP BY ?a
           """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect.toSet shouldEqual Set(
           Row("http://uri.com/subject/a1", 0),
@@ -4687,7 +4713,7 @@ class CompilerSpec
           } GROUP BY ?a
           """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect.toSet shouldEqual Set(
           Row("http://uri.com/subject/a1", 0),
@@ -4713,7 +4739,7 @@ class CompilerSpec
           } GROUP BY ?a
           """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect.toSet shouldEqual Set(
           Row("http://uri.com/subject/a1", 3.0),
@@ -4759,7 +4785,7 @@ class CompilerSpec
           } GROUP BY ?a
           """
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect should have length 3
       }
@@ -4780,7 +4806,7 @@ class CompilerSpec
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect().length shouldEqual 0
         result.right.get.collect().toSet shouldEqual Set()
@@ -4802,7 +4828,7 @@ class CompilerSpec
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query, config)
 
         result.right.get.collect().length shouldEqual 2
         result.right.get.collect().toSet shouldEqual Set(
@@ -4824,8 +4850,9 @@ class CompilerSpec
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)(
-          sqlContext,
+        val result = Compiler.compile(
+          df,
+          query,
           config.copy(isDefaultGraphExclusive = false)
         )
 
@@ -4850,8 +4877,9 @@ class CompilerSpec
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)(
-          sqlContext,
+        val result = Compiler.compile(
+          df,
+          query,
           config.copy(isDefaultGraphExclusive = false)
         )
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -3294,10 +3294,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)(
-            sqlContext,
-            config.copy(isDefaultGraphExclusive = true)
-          )
+          val result = Compiler.compile(df, query)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3367,10 +3364,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)(
-            sqlContext,
-            config.copy(isDefaultGraphExclusive = true)
-          )
+          val result = Compiler.compile(df, query)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3440,10 +3434,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)(
-            sqlContext,
-            config.copy(isDefaultGraphExclusive = true)
-          )
+          val result = Compiler.compile(df, query)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3515,10 +3506,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)(
-            sqlContext,
-            config.copy(isDefaultGraphExclusive = true)
-          )
+          val result = Compiler.compile(df, query)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3590,10 +3578,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)(
-            sqlContext,
-            config.copy(isDefaultGraphExclusive = true)
-          )
+          val result = Compiler.compile(df, query)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3790,10 +3775,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)(
-            sqlContext,
-            config.copy(isDefaultGraphExclusive = true)
-          )
+          val result = Compiler.compile(df, query)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3892,10 +3874,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)(
-            sqlContext,
-            config.copy(isDefaultGraphExclusive = true)
-          )
+          val result = Compiler.compile(df, query)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3994,10 +3973,7 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query)(
-            sqlContext,
-            config.copy(isDefaultGraphExclusive = true)
-          )
+          val result = Compiler.compile(df, query)
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -4804,10 +4780,7 @@ class CompilerSpec
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)(
-          sqlContext,
-          config.copy(isDefaultGraphExclusive = true)
-        )
+        val result = Compiler.compile(df, query)
 
         result.right.get.collect().length shouldEqual 0
         result.right.get.collect().toSet shouldEqual Set()
@@ -4829,10 +4802,7 @@ class CompilerSpec
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)(
-          sqlContext,
-          config.copy(isDefaultGraphExclusive = true)
-        )
+        val result = Compiler.compile(df, query)
 
         result.right.get.collect().length shouldEqual 2
         result.right.get.collect().toSet shouldEqual Set(
@@ -4854,7 +4824,10 @@ class CompilerSpec
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query)(
+          sqlContext,
+          config.copy(isDefaultGraphExclusive = false)
+        )
 
         result.right.get.collect().length shouldEqual 2
         result.right.get.collect().toSet shouldEqual Set(
@@ -4877,7 +4850,10 @@ class CompilerSpec
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query)
+        val result = Compiler.compile(df, query)(
+          sqlContext,
+          config.copy(isDefaultGraphExclusive = false)
+        )
 
         result.right.get.collect().length shouldEqual 2
         result.right.get.collect().toSet shouldEqual Set(

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -3790,7 +3790,10 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query, isExclusive = true)
+          val result = Compiler.compile(df, query)(
+            sqlContext,
+            config.copy(isDefaultGraphExclusive = true)
+          )
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3889,7 +3892,10 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query, isExclusive = true)
+          val result = Compiler.compile(df, query)(
+            sqlContext,
+            config.copy(isDefaultGraphExclusive = true)
+          )
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3988,7 +3994,10 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query, isExclusive = true)
+          val result = Compiler.compile(df, query)(
+            sqlContext,
+            config.copy(isDefaultGraphExclusive = true)
+          )
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -6,11 +6,19 @@ import org.apache.jena.riot.lang.CollectorStreamTriples
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 
+import com.gsk.kg.sparqlparser.TestConfig
+
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
+class CompilerSpec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
 
   override implicit def reuseContextIfPossible: Boolean = true
 
@@ -29,7 +37,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
   "Compiler" when {
 
     "format data type literals correctly" in {
-      import sqlContext.implicits._
 
       val df: DataFrame = List(
         (
@@ -113,7 +120,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with BGPs" should {
 
       "will execute operations in the dataframe" in {
-        import sqlContext.implicits._
 
         val df = dfList.toDF("s", "p", "o", "g")
         val query =
@@ -136,7 +142,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "will execute with two dependent BGPs" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = dfList.toDF("s", "p", "o", "g")
 
@@ -159,7 +164,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with UNION statement" should {
 
       "execute with the same bindings" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = (("does", "not", "match", "") :: dfList)
           .toDF("s", "p", "o", "g")
@@ -182,7 +186,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute with different bindings" in {
-        import sqlContext.implicits._
 
         val df: DataFrame =
           (("does", "not", "match", "") :: dfList).toDF("s", "p", "o", "g")
@@ -208,7 +211,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform with CONSTRUCT statement" should {
 
       "execute with a single triple pattern" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = dfList.toDF("s", "p", "o", "g")
 
@@ -231,7 +233,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute with more than one triple pattern" in {
-        import sqlContext.implicits._
 
         val positive = List(
           (
@@ -286,7 +287,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute with more than one triple pattern with common bindings" in {
-        import sqlContext.implicits._
 
         val negative = List(
           (
@@ -337,7 +337,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with LIMIT modifier" should {
 
       "execute with limit greater than 0" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("a", "b", "c", ""),
@@ -366,7 +365,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute with limit equal to 0 and obtain no results" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("a", "b", "c", ""),
@@ -392,7 +390,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute with limit greater than Java MAX INTEGER and obtain an error" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("a", "b", "c", ""),
@@ -422,7 +419,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with OFFSET modifier" should {
 
       "execute with offset greater than 0 and obtain a non empty set" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("a", "b", "c", ""),
@@ -451,7 +447,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute with offset equal to 0 and obtain same elements as the original set" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("a", "b", "c", ""),
@@ -481,7 +476,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute with offset greater than the number of elements of the dataframe and obtain an empty set" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("a", "b", "c", ""),
@@ -510,7 +504,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with Blank nodes" should {
 
       "execute and obtain expected results" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           (
@@ -551,7 +544,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with REPLACE function" should {
 
       "execute and obtain expected results" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("example", "http://xmlns.com/foaf/0.1/lit", "abcd", ""),
@@ -587,7 +579,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       // this can be done probably at the Engine level
       "execute and obtain an expected error, " +
         "because the pattern matches the zero-length string" ignore {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("example", "http://xmlns.com/foaf/0.1/lit", "abracadabra", "")
@@ -616,7 +607,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with ISBLANK function" should {
 
       "execute and obtain expected results" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           (
@@ -670,7 +660,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with !ISBLANK function" should {
 
       "execute and obtain expected results" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("_:a", "http://xmlns.com/foaf/0.1/name", "Alice", ""),
@@ -717,8 +706,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         "execute and obtain expected results" in {
 
-          import sqlContext.implicits._
-
           val df: DataFrame = List(
             ("a", "b", "c", ""),
             ("team", "http://xmlns.com/foaf/0.1/name", "Anthony", ""),
@@ -748,8 +735,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         "execute and obtain expected results when condition has embedded functions" in {
 
-          import sqlContext.implicits._
-
           val df: DataFrame = List(
             ("a", "b", "c", ""),
             ("team", "http://xmlns.com/foaf/0.1/name", "Anthony", ""),
@@ -778,8 +763,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when double filter" in {
-
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("a", "b", "c", ""),
@@ -812,8 +795,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when filter over all select statement" in {
-
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             (
@@ -902,8 +883,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         // TODO: Un-ignore when implemented EQUALS and GT
         "execute and obtain expected results when complex filter" ignore {
 
-          import sqlContext.implicits._
-
           val df: DataFrame = List(
             ("_:a", "http://xmlns.com/foaf/0.1/name", "Alice", ""),
             (
@@ -965,8 +944,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         // TODO: Un-ignore when binary logical operations implemented
         "execute and obtain expected results when multiple conditions" ignore {
 
-          import sqlContext.implicits._
-
           val df: DataFrame = List(
             ("a", "b", "c", ""),
             ("team", "http://xmlns.com/foaf/0.1/name", "Anthony", ""),
@@ -1001,7 +978,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when there is AND condition" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("team", "http://xmlns.com/foaf/0.1/name", "_:", ""),
@@ -1032,7 +1008,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when there is OR condition" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("team", "http://xmlns.com/foaf/0.1/name", "_:", ""),
@@ -1068,7 +1043,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "logical operation EQUALS" should {
 
         "execute on simple literal" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:a", "http://xmlns.com/foaf/0.1/name", "Henry", ""),
@@ -1098,7 +1072,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Add support for string syntactic sugar, see: https://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0003.html
         "execute on strings" ignore {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             (
@@ -1138,7 +1111,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on numbers" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Perico", "http://xmlns.com/foaf/0.1/age", 15, ""),
@@ -1167,7 +1139,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on booleans" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", true, ""),
@@ -1196,7 +1167,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on datetimes" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", "true", ""),
@@ -1249,7 +1219,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "logical operation NOT EQUALS" should {
 
         "execute on simple literal" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:a", "http://xmlns.com/foaf/0.1/name", "Henry", ""),
@@ -1279,7 +1248,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Add support for string syntactic sugar, see: https://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0003.html
         "execute on strings" ignore {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             (
@@ -1319,7 +1287,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on numbers" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Perico", "http://xmlns.com/foaf/0.1/age", 15, ""),
@@ -1348,7 +1315,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on booleans" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", true, ""),
@@ -1377,7 +1343,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on dateTimes" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", "true", ""),
@@ -1429,7 +1394,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "logical operation GT" should {
 
         "execute on simple literal" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:a", "http://xmlns.com/foaf/0.1/name", "Anthony", ""),
@@ -1459,7 +1423,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Add support for string syntactic sugar, see: https://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0003.html
         "execute on strings" ignore {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             (
@@ -1497,7 +1460,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on numbers" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Bob", "http://xmlns.com/foaf/0.1/age", 15, ""),
@@ -1527,7 +1489,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on booleans" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", true, ""),
@@ -1555,7 +1516,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Implement Date Time support issue
         "execute on dateTimes" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", "true", ""),
@@ -1608,7 +1568,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "logical operation LT" should {
 
         "execute on simple literal" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:a", "http://xmlns.com/foaf/0.1/name", "Anthony", ""),
@@ -1638,7 +1597,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Add support for string syntactic sugar, see: https://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0003.html
         "execute on strings" ignore {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             (
@@ -1678,7 +1636,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on numbers" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Bob", "http://xmlns.com/foaf/0.1/age", 15, ""),
@@ -1708,7 +1665,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on booleans" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", true, ""),
@@ -1738,7 +1694,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Implement Date Time support issue
         "execute on dateTimes" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", "true", ""),
@@ -1792,7 +1747,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "logical operation GTE" should {
 
         "execute on simple literal" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:a", "http://xmlns.com/foaf/0.1/name", "Anthony", ""),
@@ -1824,7 +1778,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Add support for string syntactic sugar, see: https://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0003.html
         "execute on strings" ignore {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             (
@@ -1871,7 +1824,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on numbers" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Bob", "http://xmlns.com/foaf/0.1/age", 15, ""),
@@ -1902,7 +1854,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on booleans" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", true, ""),
@@ -1931,7 +1882,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on dateTimes" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", "true", ""),
@@ -1985,7 +1935,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "logical operation LTE" should {
 
         "execute on simple literal" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:a", "http://xmlns.com/foaf/0.1/name", "Anthony", ""),
@@ -2017,7 +1966,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Add support for string syntactic sugar, see: https://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0003.html
         "execute on strings" ignore {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             (
@@ -2064,7 +2012,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on numbers" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Bob", "http://xmlns.com/foaf/0.1/age", 15, ""),
@@ -2095,7 +2042,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute on booleans" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", true, ""),
@@ -2126,7 +2072,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         // TODO: Implement Date Time support issue
         "execute on dateTimes" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             ("_:Martha", "http://xmlns.com/foaf/0.1/isFemale", "true", ""),
@@ -2181,7 +2126,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with CONSTRUCT statement" should {
 
       "execute and apply default ordering CONSTRUCT queries" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           (
@@ -2276,7 +2220,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute and make sense in the LIMIT cause when there's no ORDER BY" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           (
@@ -2352,7 +2295,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute and work correctly with blank nodes in templates with a single blank label" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           (
@@ -2433,7 +2375,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute and work correctly with blank nodes in templates with more than one blank label" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           (
@@ -2503,8 +2444,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
       "execute and obtain expected results with simple optional" in {
 
-        import sqlContext.implicits._
-
         val df: DataFrame = List(
           (
             "_:a",
@@ -2555,7 +2494,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute and obtain expected results with constraints in optional" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           (
@@ -2600,7 +2538,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "execute and obtain expected results with multiple optionals" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("_:a", "http://xmlns.com/foaf/0.1/name", "Alice", ""),
@@ -2645,7 +2582,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with DISTINCT modifier" should {
 
       "execute and obtain expected results" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("_:a", "http://xmlns.com/foaf/0.1/name", "Alice", ""),
@@ -2679,7 +2615,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "simple specific graph" should {
 
         "execute and obtain expected results with one graph specified" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -2749,7 +2684,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results with one graph specified and UNION inside GRAPH statement" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -2824,7 +2758,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results with one graph specified and JOIN inside GRAPH statement" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -2902,7 +2835,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "multiple specific named graphs" should {
 
         "execute and obtain expected results when UNION with common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -2995,7 +2927,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when JOIN with common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -3066,7 +2997,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when JOIN with no common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -3135,7 +3065,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when OPTIONAL with common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -3226,7 +3155,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when OPTIONAL with no common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -3320,7 +3248,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       "mixing default and named graph" should {
 
         "execute and obtain expected results when UNION with common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph - Alice
@@ -3367,7 +3294,10 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query, isExclusive = true)
+          val result = Compiler.compile(df, query)(
+            sqlContext,
+            config.copy(isDefaultGraphExclusive = true)
+          )
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3378,7 +3308,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when JOIN with common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph - Alice
@@ -3438,7 +3367,10 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query, isExclusive = true)
+          val result = Compiler.compile(df, query)(
+            sqlContext,
+            config.copy(isDefaultGraphExclusive = true)
+          )
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3449,7 +3381,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when JOIN with no common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph - Alice
@@ -3509,7 +3440,10 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query, isExclusive = true)
+          val result = Compiler.compile(df, query)(
+            sqlContext,
+            config.copy(isDefaultGraphExclusive = true)
+          )
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3520,7 +3454,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when OPTIONAL with common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph - Alice
@@ -3582,7 +3515,10 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query, isExclusive = true)
+          val result = Compiler.compile(df, query)(
+            sqlContext,
+            config.copy(isDefaultGraphExclusive = true)
+          )
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3593,7 +3529,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when OPTIONAL with no common variable bindings" in {
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph - Alice
@@ -3655,7 +3590,10 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
               |}
               |""".stripMargin
 
-          val result = Compiler.compile(df, query, isExclusive = true)
+          val result = Compiler.compile(df, query)(
+            sqlContext,
+            config.copy(isDefaultGraphExclusive = true)
+          )
 
           result shouldBe a[Right[_, _]]
           result.right.get.collect.length shouldEqual 2
@@ -3775,8 +3713,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         "execute and obtain expected results when GRAPH with variable, one named graph and common variables" in {
 
-          import sqlContext.implicits._
-
           val df: DataFrame = List(
             // Default graph
             (
@@ -3876,8 +3812,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
         "execute and obtain expected results when GRAPH with variable, two named graph and common variables" in {
 
-          import sqlContext.implicits._
-
           val df: DataFrame = List(
             // Default graph
             (
@@ -3976,8 +3910,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
         }
 
         "execute and obtain expected results when GRAPH with variable, two named graph and no common variables" in {
-
-          import sqlContext.implicits._
 
           val df: DataFrame = List(
             // Default graph
@@ -4513,7 +4445,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
     "dealing with three column dataframes" should {
       "add the last column automatically" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           (
@@ -4557,7 +4488,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
 
     "dealing with wider or narrower datasets" should {
       "discard narrow ones before firing the Spark job" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           "example",
@@ -4584,7 +4514,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "discard wide ones before running the spark job" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("example", "example", "example", "example", "example")
@@ -4613,7 +4542,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "perform query with GROUP BY" should {
 
       "operate correctly when only GROUP BY appears" in {
-        import sqlContext.implicits._
 
         val df = List(
           (
@@ -4660,7 +4588,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "operate correctly there's GROUP BY and a COUNT function" in {
-        import sqlContext.implicits._
 
         val df = List(
           (
@@ -4707,7 +4634,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "operate correctly there's GROUP BY and a AVG function" in {
-        import sqlContext.implicits._
 
         val df = List(
           ("http://uri.com/subject/a1", "1", "http://uri.com/object"),
@@ -4734,7 +4660,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "operate correctly there's GROUP BY and a MIN function" in {
-        import sqlContext.implicits._
 
         val df = List(
           ("http://uri.com/subject/a1", "0", "http://uri.com/object"),
@@ -4761,7 +4686,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "operate correctly there's GROUP BY and a MAX function" in {
-        import sqlContext.implicits._
 
         val df = List(
           ("http://uri.com/subject/a1", "0", "http://uri.com/object"),
@@ -4788,7 +4712,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "operate correctly there's GROUP BY and a SUM function" in {
-        import sqlContext.implicits._
 
         val df = List(
           ("http://uri.com/subject/a1", "2", "http://uri.com/object"),
@@ -4815,7 +4738,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "operate correctly there's GROUP BY and a SAMPLE function" in {
-        import sqlContext.implicits._
 
         val df = List(
           (
@@ -4861,7 +4783,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
     "inclusive/exclusive default graph" should {
 
       "exclude graphs when no explicit FROM" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("_:s1", "p1", "o1", "http://example.org/graph1"),
@@ -4874,7 +4795,10 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query, isExclusive = true)
+        val result = Compiler.compile(df, query)(
+          sqlContext,
+          config.copy(isDefaultGraphExclusive = true)
+        )
 
         result.right.get.collect().length shouldEqual 0
         result.right.get.collect().toSet shouldEqual Set()
@@ -4896,7 +4820,10 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
             |WHERE { ?s ?p ?o }
             |""".stripMargin
 
-        val result = Compiler.compile(df, query, isExclusive = true)
+        val result = Compiler.compile(df, query)(
+          sqlContext,
+          config.copy(isDefaultGraphExclusive = true)
+        )
 
         result.right.get.collect().length shouldEqual 2
         result.right.get.collect().toSet shouldEqual Set(
@@ -4906,7 +4833,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "include graphs when no explicit FROM" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("_:s1", "p1", "o1", "http://example.org/graph1"),
@@ -4929,7 +4855,6 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
       }
 
       "include graphs when explicit FROM" in {
-        import sqlContext.implicits._
 
         val df: DataFrame = List(
           ("_:s1", "p1", "o1", "http://example.org/graph1"),
@@ -4955,7 +4880,7 @@ class CompilerSpec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
   }
 
   private def readNTtoDF(path: String) = {
-    import sqlContext.implicits._
+
     import scala.collection.JavaConverters._
 
     val filename                            = s"modules/engine/src/test/resources/$path"

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/analyzer/AnalyzerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/analyzer/AnalyzerSpec.scala
@@ -29,7 +29,7 @@ class AnalyzerSpec
         | ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o
         |}
         |""".stripMargin
-    val (query, _) = parse(q)
+    val (query, _) = parse(q, config)
 
     val dag = DAG.fromQuery.apply(query)
 
@@ -51,7 +51,7 @@ class AnalyzerSpec
         | <http://purl.obolibrary.org/obo/CLO_0037232> <http://www.w3.org/2000/01/rdf-schema#subClassOf> ?derived_node .
         |}
         |""".stripMargin
-    val (query, _) = parse(q)
+    val (query, _) = parse(q, config)
 
     val dag = DAG.fromQuery.apply(query)
 
@@ -77,7 +77,7 @@ class AnalyzerSpec
         | BIND(REPLACE(?lit, "b", "Z") AS ?lit2)
         |}
         |""".stripMargin
-    val (query, _) = parse(q)
+    val (query, _) = parse(q, config)
 
     val dag = DAG.fromQuery.apply(query)
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/analyzer/AnalyzerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/analyzer/AnalyzerSpec.scala
@@ -8,12 +8,17 @@ import higherkindness.droste.syntax.all._
 import com.gsk.kg.engine.DAG
 import com.gsk.kg.engine.EngineError
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+import com.gsk.kg.sparqlparser.TestConfig
 import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class AnalyzerSpec extends AnyFlatSpec with Matchers with TestUtils {
+class AnalyzerSpec
+    extends AnyFlatSpec
+    with Matchers
+    with TestUtils
+    with TestConfig {
 
   "Analyzer.findUnboundVariables" should "find unbound variables in CONSTRUCT queries" in {
     val q =

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/data/TreeRepSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/data/TreeRepSpec.scala
@@ -84,7 +84,7 @@ class TreeRepSpec
         | BIND(URI(CONCAT("http://lit-search-api/node/doc#", ?docid)) as ?Document) .
         |}
         |""".stripMargin
-    val (query, _) = parse(q)
+    val (query, _) = parse(q, config)
 
     val dag = DAG.fromQuery.apply(query)
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/data/TreeRepSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/data/TreeRepSpec.scala
@@ -3,12 +3,17 @@ package data
 
 import cats.instances.string._
 
+import com.gsk.kg.sparqlparser.TestConfig
 import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class TreeRepSpec extends AnyFlatSpec with Matchers with TestUtils {
+class TreeRepSpec
+    extends AnyFlatSpec
+    with Matchers
+    with TestUtils
+    with TestConfig {
 
   "TreeRep.draw" should "generate a tree representation" in {
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/CompactBGPsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/CompactBGPsSpec.scala
@@ -38,7 +38,7 @@ class CompactBGPsSpec
         | ?d dm:source "potato"
         |}
         |""".stripMargin
-    val (query, _) = parse(q)
+    val (query, _) = parse(q, config)
 
     val dag: T = DAG.fromQuery.apply(query)
     countChunksInBGP(dag) shouldEqual 2
@@ -60,7 +60,7 @@ class CompactBGPsSpec
         | ?d dm:source "potato" .
         |}
         |""".stripMargin
-    val (query, _) = parse(q)
+    val (query, _) = parse(q, config)
 
     val dag: T       = DAG.fromQuery.apply(query)
     val optimized: T = CompactBGPs[T].apply(dag)

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/CompactBGPsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/CompactBGPsSpec.scala
@@ -10,6 +10,7 @@ import com.gsk.kg.engine.DAG.Project
 import com.gsk.kg.engine.data.ChunkedList
 import com.gsk.kg.engine.optics._
 import com.gsk.kg.sparqlparser.Expr.Quad
+import com.gsk.kg.sparqlparser.TestConfig
 import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.flatspec.AnyFlatSpec
@@ -20,7 +21,8 @@ class CompactBGPsSpec
     extends AnyFlatSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks
-    with TestUtils {
+    with TestUtils
+    with TestConfig {
 
   type T = Fix[DAG]
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/GraphsPushdownSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/GraphsPushdownSpec.scala
@@ -54,7 +54,7 @@ class GraphsPushdownSpec
             | }
             |}
             |""".stripMargin
-        val (query, graphs) = parse(q)
+        val (query, graphs) = parse(q, config)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -93,7 +93,7 @@ class GraphsPushdownSpec
             | }
             |}
             |""".stripMargin
-        val (query, graphs) = parse(q)
+        val (query, graphs) = parse(q, config)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -154,7 +154,7 @@ class GraphsPushdownSpec
             | }
             |}
             |""".stripMargin
-        val (query, graphs) = parse(q)
+        val (query, graphs) = parse(q, config)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -220,7 +220,7 @@ class GraphsPushdownSpec
             | }
             |}
             |""".stripMargin
-        val (query, graphs) = parse(q)
+        val (query, graphs) = parse(q, config)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -288,7 +288,7 @@ class GraphsPushdownSpec
             | }
             |}
             |""".stripMargin
-        val (query, graphs) = parse(q)
+        val (query, graphs) = parse(q, config)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -356,7 +356,7 @@ class GraphsPushdownSpec
             | ?x foaf:name ?name .
             |}
             |""".stripMargin
-        val (query, graphs) = parse(q)
+        val (query, graphs) = parse(q, config)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {
@@ -395,7 +395,7 @@ class GraphsPushdownSpec
             |   GRAPH ?g { ?x foaf:mbox ?mbox }
             |}
             |""".stripMargin
-        val (query, graphs) = parse(q)
+        val (query, graphs) = parse(q, config)
 
         val dag: T = DAG.fromQuery.apply(query)
         Fix.un(dag) match {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/GraphsPushdownSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/GraphsPushdownSpec.scala
@@ -8,13 +8,18 @@ import com.gsk.kg.engine.data.ChunkedList
 import com.gsk.kg.sparqlparser.Expr
 import com.gsk.kg.sparqlparser.StringVal.GRAPH_VARIABLE
 import com.gsk.kg.sparqlparser.StringVal.URIVAL
+import com.gsk.kg.sparqlparser.TestConfig
 import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class GraphsPushdownSpec extends AnyWordSpec with Matchers with TestUtils {
+class GraphsPushdownSpec
+    extends AnyWordSpec
+    with Matchers
+    with TestUtils
+    with TestConfig {
 
   type T = Fix[DAG]
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/RemoveNestedProjectSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/RemoveNestedProjectSpec.scala
@@ -32,7 +32,7 @@ class RemoveNestedProjectSpec
         | ?d dm:source "potato"
         |}
         |""".stripMargin
-    val (query, _) = parse(q)
+    val (query, _) = parse(q, config)
 
     val dag: T = DAG.fromQuery.apply(query)
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/RemoveNestedProjectSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/RemoveNestedProjectSpec.scala
@@ -4,6 +4,7 @@ package optimizer
 import higherkindness.droste.data.Fix
 
 import com.gsk.kg.engine.DAG.Project
+import com.gsk.kg.sparqlparser.TestConfig
 import com.gsk.kg.sparqlparser.TestUtils
 
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,7 +15,8 @@ class RemoveNestedProjectSpec
     extends AnyFlatSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks
-    with TestUtils {
+    with TestUtils
+    with TestConfig {
 
   type T = Fix[DAG]
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/syntax/SyntaxSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/syntax/SyntaxSpec.scala
@@ -3,11 +3,17 @@ package com.gsk.kg.engine.syntax
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 
+import com.gsk.kg.sparqlparser.TestConfig
+
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class SyntaxSpec extends AnyFlatSpec with Matchers with DataFrameSuiteBase {
+class SyntaxSpec
+    extends AnyFlatSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
 
   override implicit def reuseContextIfPossible: Boolean = true
 

--- a/modules/parser/src/main/resources/application.conf
+++ b/modules/parser/src/main/resources/application.conf
@@ -1,2 +1,2 @@
-is-default-graph-exclusive = false
+is-default-graph-exclusive = true
 strip-question-marks-on-output = false

--- a/modules/parser/src/main/resources/application.conf
+++ b/modules/parser/src/main/resources/application.conf
@@ -1,0 +1,2 @@
+is-default-graph-exclusive = false
+strip-question-marks-on-output = false

--- a/modules/parser/src/main/scala/com/gsk/kg/config/Config.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/config/Config.scala
@@ -1,0 +1,6 @@
+package com.gsk.kg.config
+
+final case class Config(
+    isDefaultGraphExclusive: Boolean,
+    stripQuestionMarksOnOutput: Boolean
+)

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
@@ -8,7 +8,7 @@ trait Interpolators {
 
   implicit class SparqlQueryInterpolator(sc: StringContext) {
 
-    def sparql(args: Any*)(implicit config: Config): Query = {
+    def sparql(args: Any*)(config: Config): Query = {
       val strings     = sc.parts.iterator
       val expressions = args.iterator
       val buf         = new StringBuilder(strings.next())
@@ -16,7 +16,7 @@ trait Interpolators {
         buf.append(expressions.next())
         buf.append(strings.next())
       }
-      QueryConstruct.parse(buf.toString())._1
+      QueryConstruct.parse(buf.toString(), config)._1
     }
 
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
@@ -1,5 +1,6 @@
 package com.gsk.kg.sparql.syntax
 
+import com.gsk.kg.config.Config
 import com.gsk.kg.sparqlparser.Query
 import com.gsk.kg.sparqlparser.QueryConstruct
 
@@ -7,7 +8,7 @@ trait Interpolators {
 
   implicit class SparqlQueryInterpolator(sc: StringContext) {
 
-    def sparql(args: Any*)(isExclusive: Boolean = false): Query = {
+    def sparql(args: Any*)(implicit config: Config): Query = {
       val strings     = sc.parts.iterator
       val expressions = args.iterator
       val buf         = new StringBuilder(strings.next())
@@ -15,7 +16,7 @@ trait Interpolators {
         buf.append(expressions.next())
         buf.append(strings.next())
       }
-      QueryConstruct.parse(buf.toString(), isExclusive)._1
+      QueryConstruct.parse(buf.toString())._1
     }
 
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
@@ -5,6 +5,7 @@ import org.apache.jena.sparql.algebra.Algebra
 import org.apache.jena.sparql.core.{Quad => JenaQuad}
 
 import com.gsk.kg.Graphs
+import com.gsk.kg.config.Config
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.Query._
 import com.gsk.kg.sparqlparser.StringVal._
@@ -18,11 +19,11 @@ object QueryConstruct {
 
   final case class SparqlParsingError(s: String) extends Exception(s)
 
-  def parse(input: (String, Boolean)): (Query, Graphs) = {
-    val sparql      = input._1
-    val isExclusive = input._2
-    val query       = QueryFactory.create(sparql)
-    val compiled    = Algebra.compile(query)
+  def parse(
+      sparql: String
+  )(implicit config: Config): (Query, Graphs) = {
+    val query    = QueryFactory.create(sparql)
+    val compiled = Algebra.compile(query)
     val parsed = fastparse.parse(
       compiled.toString,
       ExprParser.parser(_),
@@ -36,7 +37,7 @@ object QueryConstruct {
         throw SparqlParsingError(s"$sparql parsing failure.")
     }
 
-    val defaultGraphs = if (isExclusive) {
+    val defaultGraphs = if (config.isDefaultGraphExclusive) {
       query.getGraphURIs.asScala.toList.map(URIVAL) :+ URIVAL("")
     } else {
       Nil
@@ -69,8 +70,8 @@ object QueryConstruct {
       VARIABLE(v.toString().replace(".", ""))
     )
 
-  def parseADT(sparql: String, isExclusive: Boolean = false): Expr =
-    parse(sparql, isExclusive)._1.r
+  def parseADT(sparql: String)(implicit config: Config): Expr =
+    parse(sparql)._1.r
 
   def getAllVariableNames(bgp: BGP): Set[String] = {
     bgp.quads.foldLeft(Set.empty[String]) { (acc, q) =>

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
@@ -20,8 +20,9 @@ object QueryConstruct {
   final case class SparqlParsingError(s: String) extends Exception(s)
 
   def parse(
-      sparql: String
-  )(implicit config: Config): (Query, Graphs) = {
+      sparql: String,
+      config: Config
+  ): (Query, Graphs) = {
     val query    = QueryFactory.create(sparql)
     val compiled = Algebra.compile(query)
     val parsed = fastparse.parse(
@@ -70,8 +71,8 @@ object QueryConstruct {
       VARIABLE(v.toString().replace(".", ""))
     )
 
-  def parseADT(sparql: String)(implicit config: Config): Expr =
-    parse(sparql)._1.r
+  def parseADT(sparql: String, config: Config): Expr =
+    parse(sparql, config)._1.r
 
   def getAllVariableNames(bgp: BGP): Set[String] = {
     bgp.quads.foldLeft(Set.empty[String]) { (acc, q) =>

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
 
   "Simple Query" should "parse Construct statement with correct number of Triples" in {
-    query("/queries/q0-simple-basic-graph-pattern.sparql") match {
+    query("/queries/q0-simple-basic-graph-pattern.sparql", config) match {
       case Construct(vars, bgp, expr) =>
         assert(vars.size == 2 && bgp.quads.size == 2)
       case _ => fail
@@ -19,7 +19,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
   }
 
   "Construct" should "result in proper variables, a basic graph pattern, and algebra expression" in {
-    query("/queries/q3-union.sparql") match {
+    query("/queries/q3-union.sparql", config) match {
       case Construct(
             vars,
             bgp,
@@ -33,7 +33,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
   }
 
   "Construct with Bind" should "contains bind variable" in {
-    query("/queries/q4-simple-bind.sparql") match {
+    query("/queries/q4-simple-bind.sparql", config) match {
       case Construct(
             vars,
             bgp,
@@ -45,7 +45,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
   }
 
   "Complex named graph query" should "be captured properly in Construct" in {
-    query("/queries/q13-complex-named-graph.sparql") match {
+    query("/queries/q13-complex-named-graph.sparql", config) match {
       case Construct(vars, bgp, expr) =>
         assert(vars.size == 13)
         assert(vars.exists(va => va.s == "?ogihw"))
@@ -55,7 +55,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
 
   "Complex lit-search query" should "return proper Construct type" in {
     val a = 1
-    query("/queries/lit-search-3.sparql") match {
+    query("/queries/lit-search-3.sparql", config) match {
       case Construct(vars, bgp, expr) =>
         assert(bgp.quads.size == 11)
         assert(
@@ -69,7 +69,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
   }
 
   "Extra large query" should "return proper Construct type" in {
-    query("/queries/lit-search-xlarge.sparql") match {
+    query("/queries/lit-search-xlarge.sparql", config) match {
       case Construct(vars, bgp, expr) =>
         assert(bgp.quads.size == 67)
         assert(bgp.quads.head.s.asInstanceOf[VARIABLE].s == "?Year")
@@ -96,7 +96,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
         }
       """
 
-    parse(query) match {
+    parse(query, config) match {
       case (
             Construct(
               vars,
@@ -126,7 +126,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
         |} LIMIT 10
         |""".stripMargin
 
-    val x = parse(query)
+    val x = parse(query, config)
 
     x match {
       case (

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable
 
 import org.scalatest.flatspec.AnyFlatSpec
 
-class QueryConstructSpec extends AnyFlatSpec with TestUtils {
+class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
 
   "Simple Query" should "parse Construct statement with correct number of Triples" in {
     query("/queries/q0-simple-basic-graph-pattern.sparql") match {

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -14,7 +14,11 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
-class QuerySamplesTestSpec extends AnyFlatSpec with Matchers with TestUtils {
+class QuerySamplesTestSpec
+    extends AnyFlatSpec
+    with Matchers
+    with TestUtils
+    with TestConfig {
 
   def showAlgebra(q: String): Op = {
     val query = QueryFactory.create(q)
@@ -445,7 +449,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers with TestUtils {
 
   "Query with default and named graphs to match on specific graph" should "parse" in {
     val query = QuerySamples.q36
-    val q     = parse(query, isExclusive = true)
+    val q     = parse(query)(config.copy(isDefaultGraphExclusive = true))
     q match {
       case (
             Select(
@@ -469,7 +473,7 @@ class QuerySamplesTestSpec extends AnyFlatSpec with Matchers with TestUtils {
 
   "Query with default and named graphs to match on multiple graphs" should "parse" in {
     val query = QuerySamples.q37
-    val q     = parse(query, isExclusive = true)
+    val q     = parse(query)(config.copy(isDefaultGraphExclusive = true))
     q match {
       case (
             Select(

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -27,7 +27,7 @@ class QuerySamplesTestSpec
 
   "Get a small sample" should "parse" in {
     val query = QuerySamples.q1
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case OffsetLimit(None, Some(20), _) => succeed
       case _ =>
@@ -37,7 +37,7 @@ class QuerySamplesTestSpec
 
   "Find label" should "parse" in {
     val query = QuerySamples.q2
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, BGP(_)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
@@ -48,7 +48,7 @@ class QuerySamplesTestSpec
 
   "Find distinct label" should "parse" in {
     val query = QuerySamples.q3
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Distinct(Project(vs, BGP(_))) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
@@ -59,7 +59,7 @@ class QuerySamplesTestSpec
 
   "Get all relations" should "parse" in {
     val query = QuerySamples.q4
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, BGP(_)) =>
         assert(vs.nonEmpty && vs.size == 2)
@@ -70,7 +70,7 @@ class QuerySamplesTestSpec
 
   "Get parent class" should "parse" in {
     val query = QuerySamples.q5
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, BGP(_)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
@@ -81,7 +81,7 @@ class QuerySamplesTestSpec
 
   "Get parent class with filter" should "parse" in {
     val query = QuerySamples.q6
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, Filter(funcs, r)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
@@ -92,7 +92,7 @@ class QuerySamplesTestSpec
 
   "Test multiple hops" should "parse" in {
     val query = QuerySamples.q7
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, BGP(triples)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?species"))
@@ -104,7 +104,7 @@ class QuerySamplesTestSpec
 
   "Test multiple hops and prefixes" should "parse" in {
     val query = QuerySamples.q8
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, BGP(triples)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?species"))
@@ -116,7 +116,7 @@ class QuerySamplesTestSpec
 
   "Test find label" should "parse" in {
     val query = QuerySamples.q9
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, BGP(triples)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
@@ -127,7 +127,7 @@ class QuerySamplesTestSpec
 
   "Test find parent class" should "parse" in {
     val query = QuerySamples.q10
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, BGP(triples)) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
@@ -139,7 +139,7 @@ class QuerySamplesTestSpec
 
   "Tests hops and distinct" should "parse" in {
     val query = QuerySamples.q11
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Distinct(Project(vs, BGP(triples))) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?parent_name"))
@@ -151,7 +151,7 @@ class QuerySamplesTestSpec
 
   "Tests filter and bind" should "parse" in {
     val query = QuerySamples.q12
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, Filter(funcs, Extend(to, from, BGP(_)))) =>
         assert(vs.nonEmpty && vs.size == 3)
@@ -165,7 +165,7 @@ class QuerySamplesTestSpec
   // ignore for now since for diff position, Jena generates different representations
   "Test BIND in another position in the query" should "parse to same as q12" in {
     val query = QuerySamples.q13
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(
             vs,
@@ -181,7 +181,7 @@ class QuerySamplesTestSpec
 
   "Test union" should "parse" in {
     val query = QuerySamples.q14
-    val expr  = QueryConstruct.parseADT(query)
+    val expr  = QueryConstruct.parseADT(query, config)
     expr match {
       case Project(vs, Union(l, r)) =>
         assert(vs.nonEmpty && vs.size == 3)
@@ -196,7 +196,7 @@ class QuerySamplesTestSpec
 
   "Test simple describe query" should "parse" in {
     val query = QuerySamples.q15
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Describe(_, OpNil()), _) =>
         succeed
@@ -207,7 +207,7 @@ class QuerySamplesTestSpec
 
   "Test describe query" should "parse" in {
     val query = QuerySamples.q16
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Describe(vars, Project(vs, Filter(_, _))), _) =>
         assert(vars == vs)
@@ -219,7 +219,7 @@ class QuerySamplesTestSpec
 
   "Tests str conversion and logical operators" should "parse" in {
     val query = QuerySamples.q17
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(vs, Filter(_, _))), _) =>
         succeed
@@ -230,7 +230,7 @@ class QuerySamplesTestSpec
 
   "Tests FILTER positioning with graph sub-patterns" should "parse" in {
     val query = QuerySamples.q18
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(vs, Filter(_, _))), _) =>
         succeed
@@ -241,7 +241,7 @@ class QuerySamplesTestSpec
 
   "Test for FILTER in different positions" should "parse" in {
     val query = QuerySamples.q19
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Distinct(Project(vs, Filter(_, _)))), _) =>
         succeed
@@ -252,7 +252,7 @@ class QuerySamplesTestSpec
 
   "Test CONSTRUCT and string replacement" should "parse" in {
     val query = QuerySamples.q20
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (
             Construct(
@@ -270,7 +270,7 @@ class QuerySamplesTestSpec
 
   "Test document query" should "parse" in {
     val query = QuerySamples.q21
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(vs, BGP(ts))), _) =>
         assert(ts.size == 21)
@@ -283,7 +283,7 @@ class QuerySamplesTestSpec
 
   "Get a sample of triples joining non-blank nodes" should "parse" in {
     val query = QuerySamples.q22
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (
             Select(
@@ -300,7 +300,7 @@ class QuerySamplesTestSpec
 
   "Check DISTINCT works" should "parse" in {
     val query = QuerySamples.q23
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (
             Select(
@@ -317,7 +317,7 @@ class QuerySamplesTestSpec
 
   "Get class parent-child relations" should "parse" in {
     val query = QuerySamples.q24
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(_, Filter(_, _))), _) =>
         succeed
@@ -328,7 +328,7 @@ class QuerySamplesTestSpec
 
   "Get class parent-child relations with optional labels" should "parse" in {
     val query = QuerySamples.q25
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(_, Filter(_, _))), _) =>
         succeed
@@ -339,7 +339,7 @@ class QuerySamplesTestSpec
 
   "Get all labels in file" should "parse" in {
     val query = QuerySamples.q26
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Distinct(Project(_, _))), _) =>
         succeed
@@ -350,7 +350,7 @@ class QuerySamplesTestSpec
 
   "Get label of owl:Thing" should "parse" in {
     val query = QuerySamples.q27
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(vs, _)), _) =>
         assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
@@ -361,7 +361,7 @@ class QuerySamplesTestSpec
 
   "Get label of owl:Thing with prefix" should "parse" in {
     val query = QuerySamples.q28
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(_, _)), _) =>
         succeed
@@ -372,7 +372,7 @@ class QuerySamplesTestSpec
 
   "Get label of owl:Thing with explanatory comment" should "parse" in {
     val query = QuerySamples.q29
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(_, _)), _) =>
         succeed
@@ -383,7 +383,7 @@ class QuerySamplesTestSpec
 
   "Get label of owl:Thing with regex to remove poor label if present" should "parse" in {
     val query = QuerySamples.q30
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(_, Filter(_, _))), _) =>
         succeed
@@ -394,7 +394,7 @@ class QuerySamplesTestSpec
 
   "Construct a graph where everything which is a Thing is asserted to exist" should "parse" in {
     val query = QuerySamples.q31
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Construct(vars, bgp, BGP(_)), _) =>
         succeed
@@ -405,7 +405,7 @@ class QuerySamplesTestSpec
 
   "Construct a graph where all the terms derived from a species have a new relation" should "parse" in {
     val query = QuerySamples.q32
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Construct(vars, bgp, BGP(_)), _) =>
         succeed
@@ -416,7 +416,7 @@ class QuerySamplesTestSpec
 
   "Detect punned relations in an ontology" should "parse" in {
     val query = QuerySamples.q33
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Select(vars, Project(_, _)), _) =>
         succeed
@@ -427,7 +427,7 @@ class QuerySamplesTestSpec
 
   "Construct a triple where the predicate is derived" should "parse" in {
     val query = QuerySamples.q34
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Construct(vars, bgp, Union(BGP(_), BGP(_))), _) =>
         succeed
@@ -438,7 +438,7 @@ class QuerySamplesTestSpec
 
   "Query to convert schema of predications" should "parse" in {
     val query = QuerySamples.q35
-    val q     = parse(query)
+    val q     = parse(query, config)
     q match {
       case (Construct(vars, bgp, Extend(to, from, e)), _) =>
         assert(to == VARIABLE("?pred"))
@@ -449,7 +449,7 @@ class QuerySamplesTestSpec
 
   "Query with default and named graphs to match on specific graph" should "parse" in {
     val query = QuerySamples.q36
-    val q     = parse(query)(config.copy(isDefaultGraphExclusive = true))
+    val q     = parse(query, config.copy(isDefaultGraphExclusive = true))
     q match {
       case (
             Select(
@@ -473,7 +473,7 @@ class QuerySamplesTestSpec
 
   "Query with default and named graphs to match on multiple graphs" should "parse" in {
     val query = QuerySamples.q37
-    val q     = parse(query)(config.copy(isDefaultGraphExclusive = true))
+    val q     = parse(query, config.copy(isDefaultGraphExclusive = true))
     q match {
       case (
             Select(

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ShortQueryTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ShortQueryTestSpec.scala
@@ -32,7 +32,7 @@ class ShortQueryTestSpec extends AnyFlatSpec with TestUtils with TestConfig {
     }
 
     """
-    val query = parse(q)
+    val query = parse(q, config)
     query._1.r match {
       case FilteredLeftJoin(BGP(_), Extend(to, from, _), funcs) =>
         assert(funcs.size == 2)
@@ -54,7 +54,7 @@ class ShortQueryTestSpec extends AnyFlatSpec with TestUtils with TestConfig {
           ?doc lita:contextText "cde" .
         }
       """
-    val query = parse(q)
+    val query = parse(q, config)
     query._1.r match {
       case Project(vs, BGP(triples)) =>
         assert(triples(0).o == BOOL("true"))

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ShortQueryTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ShortQueryTestSpec.scala
@@ -5,7 +5,7 @@ import com.gsk.kg.sparqlparser.StringVal._
 
 import org.scalatest.flatspec.AnyFlatSpec
 
-class ShortQueryTestSpec extends AnyFlatSpec with TestUtils {
+class ShortQueryTestSpec extends AnyFlatSpec with TestUtils with TestConfig {
 
   "test filtered left join with multiple filters" should "pass" in {
 

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestConfig.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestConfig.scala
@@ -1,0 +1,20 @@
+package com.gsk.kg.sparqlparser
+
+import com.gsk.kg.config.Config
+
+trait TestConfig {
+
+  import pureconfig._
+  import pureconfig.generic.auto._
+
+  private lazy val stringConf =
+    """
+      |{
+      | is-default-graph-exclusive = false,
+      | strip-question-marks-on-output = false
+      |}
+      |""".stripMargin
+
+  implicit lazy val config: Config =
+    ConfigSource.string(stringConf).loadOrThrow[Config]
+}

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestConfig.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestConfig.scala
@@ -10,7 +10,7 @@ trait TestConfig {
   private lazy val stringConf =
     """
       |{
-      | is-default-graph-exclusive = false,
+      | is-default-graph-exclusive = true,
       | strip-question-marks-on-output = false
       |}
       |""".stripMargin

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
@@ -22,14 +22,14 @@ trait TestUtils {
     result
   }
 
-  def queryAlgebra(fileLoc: String)(implicit config: Config): Expr = {
+  def queryAlgebra(fileLoc: String, config: Config): Expr = {
     val q = readOutputFile(fileLoc)
-    QueryConstruct.parseADT(q)
+    QueryConstruct.parseADT(q, config)
   }
 
-  def query(fileLoc: String)(implicit config: Config): Query = {
+  def query(fileLoc: String, config: Config): Query = {
     val q = readOutputFile(fileLoc)
-    parse(q)._1
+    parse(q, config)._1
   }
 
   def readOutputFile(fileLoc: String): String = {
@@ -43,8 +43,9 @@ trait TestUtils {
   }
 
   def parse(
-      query: String
-  )(implicit config: Config): (Query, Graphs) =
-    QueryConstruct.parse(query)
+      query: String,
+      config: Config
+  ): (Query, Graphs) =
+    QueryConstruct.parse(query, config)
 
 }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
@@ -4,6 +4,7 @@ import org.apache.jena.query.QueryFactory
 import org.apache.jena.sparql.algebra.Algebra
 
 import com.gsk.kg.Graphs
+import com.gsk.kg.config.Config
 
 import scala.io.Source
 
@@ -11,31 +12,39 @@ trait TestUtils {
 
   def sparql2Algebra(fileLoc: String): String = {
     val path   = getClass.getResource(fileLoc).getPath
-    val sparql = Source.fromFile(path).mkString
+    val source = Source.fromFile(path)
+    val sparql = source.mkString
 
-    val query = QueryFactory.create(sparql)
-    Algebra.compile(query).toString
+    val query          = QueryFactory.create(sparql)
+    val result: String = Algebra.compile(query).toString
+
+    source.close
+    result
   }
 
-  def queryAlgebra(fileLoc: String): Expr = {
+  def queryAlgebra(fileLoc: String)(implicit config: Config): Expr = {
     val q = readOutputFile(fileLoc)
     QueryConstruct.parseADT(q)
   }
 
-  def query(fileLoc: String, isExclusive: Boolean = false): Query = {
+  def query(fileLoc: String)(implicit config: Config): Query = {
     val q = readOutputFile(fileLoc)
-    parse(q, isExclusive)._1
+    parse(q)._1
   }
 
   def readOutputFile(fileLoc: String): String = {
-    val path = getClass.getResource(fileLoc).getPath
-    Source.fromFile(path).mkString
+    val path   = getClass.getResource(fileLoc).getPath
+    val source = Source.fromFile(path)
+
+    val output = source.mkString
+
+    source.close()
+    output
   }
 
   def parse(
-      query: String,
-      isExclusive: Boolean = false
-  ): (Query, Graphs) =
-    QueryConstruct.parse((query, isExclusive))
+      query: String
+  )(implicit config: Config): (Query, Graphs) =
+    QueryConstruct.parse(query)
 
 }


### PR DESCRIPTION
This PR enables to pass a configuration to the compiler.

It makes use of [pureconfig](https://pureconfig.github.io/), so configuration can be read from HOCON file, Json file, build properties file and also from JVM options passed on startup.

Also it sets the default behaviour of the engine to be `exclusive`.

Closes #210 