### PR TITLE
fixed query interpolator and dataframe sparql method

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/syntax/package.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/syntax/package.scala
@@ -8,11 +8,23 @@ import com.gsk.kg.config.Config
 package object syntax {
 
   implicit class SparQLSyntaxOnDataFrame(private val df: DataFrame)(implicit
-      sc: SQLContext,
-      config: Config
+      sc: SQLContext
   ) {
-    def sparql(query: String): DataFrame =
+
+    /** Compile query with dataframe with provided configuration
+      * @param query
+      * @param config
+      * @return
+      */
+    def sparql(query: String, config: Config): DataFrame =
       Compiler.compile(df, query, config).right.get
+
+    /** Compile query with dataframe with default configuration
+      * @param query
+      * @return
+      */
+    def sparql(query: String): DataFrame =
+      sparql(query, Config.default)
   }
 
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/syntax/SyntaxSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/syntax/SyntaxSpec.scala
@@ -19,7 +19,7 @@ class SyntaxSpec
 
   override implicit def enableHiveSupport: Boolean = false
 
-  "df.sparql" should "run a SparQL query on a Spark DataFrame" in {
+  "df.sparql" should "run a SparQL query on a Spark DataFrame with default configuration" in {
     import sqlContext.implicits._
 
     val df: DataFrame = List(
@@ -45,6 +45,50 @@ class SyntaxSpec
         ?d <http://id.gsk.com/dm/1.0/docSource> ?src
       }
       """
+    )
+
+    result.collect.toSet shouldEqual Set(
+      Row(
+        "\"test\"",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://id.gsk.com/dm/1.0/Document"
+      ),
+      Row(
+        "\"test\"",
+        "http://id.gsk.com/dm/1.0/docSource",
+        "\"source\""
+      )
+    )
+
+  }
+
+  it should "run a SparQL query on a Spark DataFrame with provided configuration" in {
+    import sqlContext.implicits._
+
+    val df: DataFrame = List(
+      (
+        "test",
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        "http://id.gsk.com/dm/1.0/Document",
+        ""
+      ),
+      ("test", "http://id.gsk.com/dm/1.0/docSource", "source", "")
+    ).toDF("s", "p", "o", "g")
+
+    val result: DataFrame = df.sparql(
+      """
+      CONSTRUCT
+      {
+        ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.gsk.com/dm/1.0/Document> .
+        ?d <http://id.gsk.com/dm/1.0/docSource> ?src
+      }
+      WHERE
+      {
+        ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.gsk.com/dm/1.0/Document> .
+        ?d <http://id.gsk.com/dm/1.0/docSource> ?src
+      }
+      """,
+      config
     )
 
     result.collect.toSet shouldEqual Set(

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
@@ -8,7 +8,12 @@ trait Interpolators {
 
   implicit class SparqlQueryInterpolator(sc: StringContext) {
 
-    def sparql(args: Any*)(config: Config): Query = {
+    /** This method uses a default configuration, if a custom configuration wanted to be provided
+      * we recommend using the method [[QueryConstruct.parse()]] instead.
+      * @param args
+      * @return
+      */
+    def sparql(args: Any*): Query = {
       val strings     = sc.parts.iterator
       val expressions = args.iterator
       val buf         = new StringBuilder(strings.next())
@@ -16,7 +21,7 @@ trait Interpolators {
         buf.append(expressions.next())
         buf.append(strings.next())
       }
-      QueryConstruct.parse(buf.toString(), config)._1
+      QueryConstruct.parse(buf.toString(), Config.default)._1
     }
 
   }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/InterpolatorsSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/InterpolatorsSpec.scala
@@ -1,0 +1,23 @@
+package com.gsk.kg.sparqlparser
+
+import com.gsk.kg.sparql.syntax.Interpolators._
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class InterpolatorsSpec extends AnyWordSpec with Matchers {
+
+  "Sparql interpolator" should {
+
+    "interpolate with default config" in {
+
+      val query = sparql"""
+        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        SELECT ?s ?o
+        WHERE { ?s foaf:name ?o }
+      """
+
+      query shouldBe a[Query]
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes:
- Query parse interpolator `sparql`, that now uses a default configuration. If a custom configuration what to be provided `QueryConstruct.parse` should be used instead.
- Dataframe `sparql` method. Now we have two methods one with default configuration and one with provided configuration, so we have backward compatibility.

Closes #218 
Closes #225 