### PR TITLE
wrapped parser into engine Result monad

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,7 @@ lazy val bellman = project
   .settings(buildSettings)
   .settings(noPublishSettings)
   .dependsOn(`bellman-algebra-parser`, `bellman-spark-engine`)
-  .aggregate(`bellman-algebra-parser`, `bellman-spark-engine`)
+  .aggregate(`bellman-algebra-parser`, `bellman-spark-engine`, `bellman-site`)
 
 lazy val `bellman-algebra-parser` = project
   .in(file("modules/parser"))
@@ -277,7 +277,11 @@ lazy val `bellman-site` = project
   .settings(
     libraryDependencies += "io.github.stanch" %% "reftree" % Versions("reftree")
   )
+  .settings(
+    Global / excludeLintKeys += scalastyleFailOnWarning
+  )
   .dependsOn(`bellman-spark-engine`, `bellman-algebra-parser`)
+  .disablePlugins(ScalastylePlugin)
   .enablePlugins(MicrositesPlugin)
 
 addCommandAlias(

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Compiler.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Compiler.scala
@@ -15,6 +15,7 @@ import com.gsk.kg.engine.analyzer.Analyzer
 import com.gsk.kg.engine.optimizer.Optimizer
 import com.gsk.kg.sparqlparser.Query
 import com.gsk.kg.sparqlparser.QueryConstruct
+import com.gsk.kg.sparqlparser.Result
 
 object Compiler {
 
@@ -76,7 +77,7 @@ object Compiler {
     */
   private def parser: Phase[String, (Query, Graphs)] =
     Kleisli[M, String, (Query, Graphs)] { query =>
-      M.ask[Result, Config, Log, DataFrame].map { config =>
+      M.ask[Result, Config, Log, DataFrame].flatMapF { config =>
         QueryConstruct.parse(query, config)
       }
     }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -13,6 +13,8 @@ import org.apache.spark.sql.functions._
 
 import com.gsk.kg.engine.Multiset._
 import com.gsk.kg.engine.Multiset.filterGraph
+import com.gsk.kg.sparqlparser.EngineError
+import com.gsk.kg.sparqlparser.Result
 import com.gsk.kg.sparqlparser.StringVal.GRAPH_VARIABLE
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/Analyzer.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/Analyzer.scala
@@ -11,6 +11,8 @@ import higherkindness.droste.Basis
 import org.apache.spark.sql.DataFrame
 
 import com.gsk.kg.config.Config
+import com.gsk.kg.sparqlparser.EngineError
+import com.gsk.kg.sparqlparser.Result
 
 object Analyzer {
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/package.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/package.scala
@@ -7,15 +7,11 @@ import cats.data.ReaderWriterStateT
 import org.apache.spark.sql.DataFrame
 
 import com.gsk.kg.config.Config
+import com.gsk.kg.sparqlparser.Result
 
 package object engine {
 
   type Log = Chain[String]
-
-  /** the type for operations that may fail
-    */
-  type Result[A] = Either[EngineError, A]
-  val Result = Either
 
   type M[A] = ReaderWriterStateT[Result, Config, Log, DataFrame, A]
   val M = ReaderWriterStateT

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -1,12 +1,13 @@
 package com.gsk.kg.engine
 
-import org.apache.jena.query.QueryParseException
 import org.apache.jena.riot.RDFParser
 import org.apache.jena.riot.lang.CollectorStreamTriples
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 
+import com.gsk.kg.sparqlparser.EngineError
+import com.gsk.kg.sparqlparser.EngineError.ParsingError
 import com.gsk.kg.sparqlparser.TestConfig
 
 import java.io.ByteArrayOutputStream
@@ -5024,8 +5025,9 @@ class CompilerSpec
               |}
               |""".stripMargin
 
-          an[QueryParseException] should be thrownBy
-            Compiler.compile(df, query, config)
+          val result = Compiler.compile(df, query, config)
+          result shouldBe a[Left[_, _]]
+          result.left.get shouldBe a[ParsingError]
         }
       }
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -1,6 +1,7 @@
 package com.gsk.kg.engine
 
 import com.gsk.kg.engine.utils.MultisetMatchers
+import com.gsk.kg.sparqlparser.EngineError
 import com.gsk.kg.sparqlparser.StringVal.GRAPH_VARIABLE
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/data/TreeRepSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/data/TreeRepSpec.scala
@@ -2,6 +2,7 @@ package com.gsk.kg.engine
 package data
 
 import cats.instances.string._
+import cats.syntax.either._
 
 import com.gsk.kg.sparqlparser.TestConfig
 import com.gsk.kg.sparqlparser.TestUtils
@@ -84,12 +85,11 @@ class TreeRepSpec
         | BIND(URI(CONCAT("http://lit-search-api/node/doc#", ?docid)) as ?Document) .
         |}
         |""".stripMargin
-    val (query, _) = parse(q, config)
 
-    val dag = DAG.fromQuery.apply(query)
-
-    val result = dag.toTree.drawTree.trim
-    result shouldEqual """
+    parse(q, config)
+      .map { case (query, _) =>
+        val dag = DAG.fromQuery.apply(query)
+        dag.toTree.drawTree.trim shouldEqual """
 Construct
 |
 +- BGP
@@ -159,6 +159,8 @@ Construct
                   +- http://gsk-kg.rdip.gsk.com/dm/1.0/Document
                   |
                   `- List(GRAPH_VARIABLE)""".trim
+      }
+      .getOrElse(fail)
   }
 
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/RemoveNestedProjectSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/optimize/RemoveNestedProjectSpec.scala
@@ -1,6 +1,8 @@
 package com.gsk.kg.engine
 package optimizer
 
+import cats.syntax.either._
+
 import higherkindness.droste.data.Fix
 
 import com.gsk.kg.engine.DAG.Project
@@ -32,23 +34,26 @@ class RemoveNestedProjectSpec
         | ?d dm:source "potato"
         |}
         |""".stripMargin
-    val (query, _) = parse(q, config)
 
-    val dag: T = DAG.fromQuery.apply(query)
+    parse(q, config)
+      .map { case (query, _) =>
+        val dag: T = DAG.fromQuery.apply(query)
 
-    Fix.un(dag) match {
-      case Project(v1, Fix(Project(v2, r))) =>
-        v1 shouldEqual v2
-      case _ => fail()
-    }
+        Fix.un(dag) match {
+          case Project(v1, Fix(Project(v2, r))) =>
+            v1 shouldEqual v2
+          case _ => fail()
+        }
 
-    val optimized = RemoveNestedProject[T].apply(dag)
-    Fix.un(optimized) match {
-      case Project(v1, Fix(Project(v2, r))) =>
-        fail("RemoveNestedProject should have deduplicated Project nodes")
-      case _ => succeed
-    }
+        val optimized = RemoveNestedProject[T].apply(dag)
+        Fix.un(optimized) match {
+          case Project(v1, Fix(Project(v2, r))) =>
+            fail("RemoveNestedProject should have deduplicated Project nodes")
+          case _ => succeed
+        }
 
+      }
+      .getOrElse(fail)
   }
 
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparql/syntax/Interpolators.scala
@@ -1,5 +1,7 @@
 package com.gsk.kg.sparql.syntax
 
+import cats.syntax.either._
+
 import com.gsk.kg.config.Config
 import com.gsk.kg.sparqlparser.Query
 import com.gsk.kg.sparqlparser.QueryConstruct
@@ -21,7 +23,7 @@ trait Interpolators {
         buf.append(expressions.next())
         buf.append(strings.next())
       }
-      QueryConstruct.parse(buf.toString(), Config.default)._1
+      QueryConstruct.parse(buf.toString(), Config.default).map(_._1).right.get
     }
 
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/EngineError.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/EngineError.scala
@@ -1,4 +1,4 @@
-package com.gsk.kg.engine
+package com.gsk.kg.sparqlparser
 
 import cats.data.NonEmptyChain
 
@@ -13,5 +13,7 @@ object EngineError {
   final case class FunctionError(description: String) extends EngineError
   final case class AnalyzerError(errors: NonEmptyChain[String])
       extends EngineError
-  final case class InvalidInputDataFrame(msg: String) extends EngineError
+  final case class InvalidInputDataFrame(msg: String)  extends EngineError
+  final case class ParsingError(description: String)   extends EngineError
+  final case class UnExpectedType(description: String) extends EngineError
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ParserError.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ParserError.scala
@@ -1,7 +1,0 @@
-package com.gsk.kg.sparqlparser
-
-sealed trait ParserError extends RuntimeException
-
-object ParserError {
-  final case class UnExpectedType(description: String) extends ParserError
-}

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/QueryConstruct.scala
@@ -1,78 +1,74 @@
 package com.gsk.kg.sparqlparser
 
+import cats.syntax.either._
+
 import org.apache.jena.query.QueryFactory
 import org.apache.jena.sparql.algebra.Algebra
 import org.apache.jena.sparql.core.{Quad => JenaQuad}
 
 import com.gsk.kg.Graphs
 import com.gsk.kg.config.Config
+import com.gsk.kg.sparqlparser.EngineError.ParsingError
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.Query._
 import com.gsk.kg.sparqlparser.StringVal._
 
 import scala.collection.JavaConverters._
 
-import fastparse.Parsed.Failure
-import fastparse.Parsed.Success
-
 object QueryConstruct {
-
-  final case class SparqlParsingError(s: String) extends Exception(s)
 
   def parse(
       sparql: String,
       config: Config
-  ): (Query, Graphs) = {
-    val query    = QueryFactory.create(sparql)
-    val compiled = Algebra.compile(query)
-    val parsed = fastparse.parse(
-      compiled.toString,
-      ExprParser.parser(_),
-      verboseFailures = true
-    )
-    val algebra = parsed match {
-      case Success(value, index) => value
-      case Failure(str, i, extra) =>
-        throw SparqlParsingError(s"$str at position $i, ${extra.input}")
-      case _ => //Failure()
-        throw SparqlParsingError(s"$sparql parsing failure.")
-    }
-
-    val defaultGraphs = if (config.isDefaultGraphExclusive) {
-      query.getGraphURIs.asScala.toList.map(URIVAL) :+ URIVAL("")
-    } else {
-      Nil
-    }
-    val namedGraphs =
-      query.getNamedGraphURIs.asScala.toList.map(URIVAL)
-    val graphs = Graphs(defaultGraphs, namedGraphs)
-
-    if (query.isConstructType) {
-      val template = query.getConstructTemplate
-      val vars     = getVars(query)
-      val bgp      = toBGP(template.getQuads.asScala)
-      (Construct(vars, bgp, algebra), graphs)
-    } else if (query.isSelectType) {
-      val vars = getVars(query)
-      (Select(vars, algebra), graphs)
-    } else if (query.isDescribeType) {
-      (Describe(getVars(query), algebra), graphs)
-    } else if (query.isAskType) {
-      (Ask(algebra), graphs)
-    } else {
-      throw SparqlParsingError(
-        s"The query type: ${query.queryType()} is not supported yet"
+  ): Result[(Query, Graphs)] = for {
+    query <- Either
+      .catchNonFatal(QueryFactory.create(sparql))
+      .leftMap[EngineError](t => ParsingError(t.getMessage))
+    compiled <- Either
+      .catchNonFatal(Algebra.compile(query))
+      .leftMap[EngineError](t => ParsingError(t.getMessage))
+    algebra <- fastparse
+      .parse(
+        compiled.toString,
+        ExprParser.parser(_),
+        verboseFailures = true
       )
+      .toParserResult
+    defaultGraphs =
+      if (config.isDefaultGraphExclusive) {
+        query.getGraphURIs.asScala.toList.map(URIVAL) :+ URIVAL("")
+      } else {
+        Nil
+      }
+    namedGraphs = query.getNamedGraphURIs.asScala.toList.map(URIVAL)
+    graphs      = Graphs(defaultGraphs, namedGraphs)
+    result <- query match {
+      case q if q.isConstructType =>
+        val template = query.getConstructTemplate
+        val vars     = getVars(query)
+        val bgp      = toBGP(template.getQuads.asScala)
+        (Construct(vars, bgp, algebra), graphs).asRight
+      case q if q.isSelectType =>
+        val vars = getVars(query)
+        (Select(vars, algebra), graphs).asRight
+      case q if q.isDescribeType =>
+        (Describe(getVars(query), algebra), graphs).asRight
+      case q if q.isAskType =>
+        (Ask(algebra), graphs).asRight
+      case _ =>
+        ParsingError(
+          s"The query type: ${query.queryType()} is not supported yet"
+        ).asLeft
     }
-  }
+  } yield result
 
   private def getVars(query: org.apache.jena.query.Query): Seq[VARIABLE] =
     query.getProjectVars.asScala.map(v =>
       VARIABLE(v.toString().replace(".", ""))
     )
 
-  def parseADT(sparql: String, config: Config): Expr =
-    parse(sparql, config)._1.r
+  def parseADT(sparql: String, config: Config): Result[Expr] =
+    parse(sparql, config).map(_._1.r)
 
   def getAllVariableNames(bgp: BGP): Set[String] = {
     bgp.quads.foldLeft(Set.empty[String]) { (acc, q) =>
@@ -84,5 +80,5 @@ object QueryConstruct {
   }
 
   def toBGP(quads: Iterable[JenaQuad]): BGP =
-    BGP(quads.flatMap(Quad.toIter(_)).toSeq)
+    BGP(quads.flatMap(Quad.toIter).toSeq)
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/package.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/package.scala
@@ -1,0 +1,25 @@
+package com.gsk.kg
+
+import cats.syntax.either._
+
+import com.gsk.kg.sparqlparser.EngineError.ParsingError
+
+import fastparse.Parsed
+import fastparse.Parsed.Failure
+import fastparse.Parsed.Success
+
+package object sparqlparser {
+
+  /** the type for operations that may fail
+    */
+  type Result[A] = Either[EngineError, A]
+  val Result = Either
+
+  implicit class RichParsed[T](parsed: Parsed[T]) {
+    def toParserResult: Result[T] = parsed match {
+      case Success(value, _) => value.asRight
+      case Failure(label, index, extra) =>
+        ParsingError(s"$label at position $index, ${extra.input}").asLeft
+    }
+  }
+}

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QueryConstructSpec.scala
@@ -1,5 +1,7 @@
 package com.gsk.kg.sparqlparser
 
+import cats.syntax.either._
+
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.Query._
 import com.gsk.kg.sparqlparser.StringVal._
@@ -11,72 +13,84 @@ import org.scalatest.flatspec.AnyFlatSpec
 class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
 
   "Simple Query" should "parse Construct statement with correct number of Triples" in {
-    query("/queries/q0-simple-basic-graph-pattern.sparql", config) match {
-      case Construct(vars, bgp, expr) =>
-        assert(vars.size == 2 && bgp.quads.size == 2)
-      case _ => fail
-    }
+    query("/queries/q0-simple-basic-graph-pattern.sparql", config)
+      .map {
+        case Construct(vars, bgp, expr) =>
+          assert(vars.size == 2 && bgp.quads.size == 2)
+        case _ => fail
+      }
+      .getOrElse(fail)
   }
 
   "Construct" should "result in proper variables, a basic graph pattern, and algebra expression" in {
-    query("/queries/q3-union.sparql", config) match {
-      case Construct(
-            vars,
-            bgp,
-            Union(BGP(quadsL: Seq[Quad]), BGP(quadsR: Seq[Quad]))
-          ) =>
-        val temp = QueryConstruct.getAllVariableNames(bgp)
-        val all  = vars.map(_.s).toSet
-        assert((all -- temp) == Set("?lnk"))
-      case _ => fail
-    }
+    query("/queries/q3-union.sparql", config)
+      .map {
+        case Construct(
+              vars,
+              bgp,
+              Union(BGP(quadsL: Seq[Quad]), BGP(quadsR: Seq[Quad]))
+            ) =>
+          val temp = QueryConstruct.getAllVariableNames(bgp)
+          val all  = vars.map(_.s).toSet
+          assert((all -- temp) == Set("?lnk"))
+        case _ => fail
+      }
+      .getOrElse(fail)
   }
 
   "Construct with Bind" should "contains bind variable" in {
-    query("/queries/q4-simple-bind.sparql", config) match {
-      case Construct(
-            vars,
-            bgp,
-            Extend(l: StringVal, r: StringVal, BGP(quads: Seq[Quad]))
-          ) =>
-        vars.exists(_.s == "?dbind")
-      case _ => fail
-    }
+    query("/queries/q4-simple-bind.sparql", config)
+      .map {
+        case Construct(
+              vars,
+              bgp,
+              Extend(l: StringVal, r: StringVal, BGP(quads: Seq[Quad]))
+            ) =>
+          vars.exists(_.s == "?dbind")
+        case _ => fail
+      }
+      .getOrElse(fail)
   }
 
   "Complex named graph query" should "be captured properly in Construct" in {
-    query("/queries/q13-complex-named-graph.sparql", config) match {
-      case Construct(vars, bgp, expr) =>
-        assert(vars.size == 13)
-        assert(vars.exists(va => va.s == "?ogihw"))
-      case _ => fail
-    }
+    query("/queries/q13-complex-named-graph.sparql", config)
+      .map {
+        case Construct(vars, bgp, expr) =>
+          assert(vars.size == 13)
+          assert(vars.exists(va => va.s == "?ogihw"))
+        case _ => fail
+      }
+      .getOrElse(fail)
   }
 
   "Complex lit-search query" should "return proper Construct type" in {
     val a = 1
-    query("/queries/lit-search-3.sparql", config) match {
-      case Construct(vars, bgp, expr) =>
-        assert(bgp.quads.size == 11)
-        assert(
-          bgp.quads.head.o
-            .asInstanceOf[BLANK]
-            .s == bgp.quads(1).s.asInstanceOf[BLANK].s
-        )
-        assert(vars.exists(v => v.s == "?secid"))
-      case _ => fail
-    }
+    query("/queries/lit-search-3.sparql", config)
+      .map {
+        case Construct(vars, bgp, expr) =>
+          assert(bgp.quads.size == 11)
+          assert(
+            bgp.quads.head.o
+              .asInstanceOf[BLANK]
+              .s == bgp.quads(1).s.asInstanceOf[BLANK].s
+          )
+          assert(vars.exists(v => v.s == "?secid"))
+        case _ => fail
+      }
+      .getOrElse(fail)
   }
 
   "Extra large query" should "return proper Construct type" in {
-    query("/queries/lit-search-xlarge.sparql", config) match {
-      case Construct(vars, bgp, expr) =>
-        assert(bgp.quads.size == 67)
-        assert(bgp.quads.head.s.asInstanceOf[VARIABLE].s == "?Year")
-        assert(bgp.quads.last.s.asInstanceOf[VARIABLE].s == "?Predication")
-        assert(vars.exists(v => v.s == "?de"))
-      case _ => fail
-    }
+    query("/queries/lit-search-xlarge.sparql", config)
+      .map {
+        case Construct(vars, bgp, expr) =>
+          assert(bgp.quads.size == 67)
+          assert(bgp.quads.head.s.asInstanceOf[VARIABLE].s == "?Year")
+          assert(bgp.quads.last.s.asInstanceOf[VARIABLE].s == "?Predication")
+          assert(vars.exists(v => v.s == "?de"))
+        case _ => fail
+      }
+      .getOrElse(fail)
   }
 
   "Select query" should "be supported even it is nested" in {
@@ -96,21 +110,23 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
         }
       """
 
-    parse(query, config) match {
-      case (
-            Construct(
-              vars,
-              bgp,
-              Project(
-                Seq(VARIABLE("?name"), VARIABLE("?person")),
-                Filter(funcs, expr)
-              )
-            ),
-            _
-          ) =>
-        succeed
-      case _ => fail
-    }
+    parse(query, config)
+      .map {
+        case (
+              Construct(
+                vars,
+                bgp,
+                Project(
+                  Seq(VARIABLE("?name"), VARIABLE("?person")),
+                  Filter(funcs, expr)
+                )
+              ),
+              _
+            ) =>
+          succeed
+        case _ => fail
+      }
+      .getOrElse(fail)
   }
 
   "Query with blank nodes" should "be supported in the QueryConstruct" in {
@@ -128,7 +144,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
 
     val x = parse(query, config)
 
-    x match {
+    x.map {
       case (
             Select(
               mutable.ArrayBuffer(VARIABLE("?de"), VARIABLE("?et")),
@@ -162,7 +178,7 @@ class QueryConstructSpec extends AnyFlatSpec with TestUtils with TestConfig {
           ) =>
         succeed
       case _ => fail
-    }
+    }.getOrElse(fail)
 
   }
 }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/QuerySamplesTestSpec.scala
@@ -1,4 +1,7 @@
 package com.gsk.kg.sparqlparser
+
+import cats.syntax.either._
+
 import org.apache.jena.query.QueryFactory
 import org.apache.jena.sparql.algebra.Algebra
 import org.apache.jena.sparql.algebra.Op
@@ -28,176 +31,202 @@ class QuerySamplesTestSpec
   "Get a small sample" should "parse" in {
     val query = QuerySamples.q1
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case OffsetLimit(None, Some(20), _) => succeed
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case OffsetLimit(None, Some(20), _) => succeed
+        case _                              => fail
+      }
+      .getOrElse(fail)
   }
 
   "Find label" should "parse" in {
     val query = QuerySamples.q2
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, BGP(_)) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, BGP(_)) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Find distinct label" should "parse" in {
     val query = QuerySamples.q3
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Distinct(Project(vs, BGP(_))) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Distinct(Project(vs, BGP(_))) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get all relations" should "parse" in {
     val query = QuerySamples.q4
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, BGP(_)) =>
-        assert(vs.nonEmpty && vs.size == 2)
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, BGP(_)) =>
+          assert(vs.nonEmpty && vs.size == 2)
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get parent class" should "parse" in {
     val query = QuerySamples.q5
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, BGP(_)) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, BGP(_)) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get parent class with filter" should "parse" in {
     val query = QuerySamples.q6
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, Filter(funcs, r)) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, Filter(funcs, r)) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test multiple hops" should "parse" in {
     val query = QuerySamples.q7
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, BGP(triples)) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?species"))
-        assert(triples.size == 7)
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, BGP(triples)) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?species"))
+          assert(triples.size == 7)
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test multiple hops and prefixes" should "parse" in {
     val query = QuerySamples.q8
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, BGP(triples)) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?species"))
-        assert(triples.size == 7)
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, BGP(triples)) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?species"))
+          assert(triples.size == 7)
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test find label" should "parse" in {
     val query = QuerySamples.q9
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, BGP(triples)) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, BGP(triples)) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test find parent class" should "parse" in {
     val query = QuerySamples.q10
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, BGP(triples)) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
-        assert(triples.size == 1)
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, BGP(triples)) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?parent"))
+          assert(triples.size == 1)
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Tests hops and distinct" should "parse" in {
     val query = QuerySamples.q11
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Distinct(Project(vs, BGP(triples))) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?parent_name"))
-        assert(triples.size == 2)
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Distinct(Project(vs, BGP(triples))) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?parent_name"))
+          assert(triples.size == 2)
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Tests filter and bind" should "parse" in {
     val query = QuerySamples.q12
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, Filter(funcs, Extend(to, from, BGP(_)))) =>
-        assert(vs.nonEmpty && vs.size == 3)
-        assert(funcs.size == 1)
-        assert(to == VARIABLE("?o"))
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, Filter(funcs, Extend(to, from, BGP(_)))) =>
+          assert(vs.nonEmpty && vs.size == 3)
+          assert(funcs.size == 1)
+          assert(to == VARIABLE("?o"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   // ignore for now since for diff position, Jena generates different representations
   "Test BIND in another position in the query" should "parse to same as q12" in {
     val query = QuerySamples.q13
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(
-            vs,
-            Filter(funcs, Join(Extend(to, from, TabUnit()), BGP(_)))
-          ) =>
-        assert(vs.nonEmpty && vs.size == 3)
-        assert(funcs.size == 1)
-        assert(to == VARIABLE("?o"))
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(
+              vs,
+              Filter(funcs, Join(Extend(to, from, TabUnit()), BGP(_)))
+            ) =>
+          assert(vs.nonEmpty && vs.size == 3)
+          assert(funcs.size == 1)
+          assert(to == VARIABLE("?o"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test union" should "parse" in {
     val query = QuerySamples.q14
     val expr  = QueryConstruct.parseADT(query, config)
-    expr match {
-      case Project(vs, Union(l, r)) =>
-        assert(vs.nonEmpty && vs.size == 3)
-        r match {
-          case Filter(funcs, e) => succeed
-          case _                => fail
-        }
-      case _ =>
-        fail
-    }
+    expr
+      .map {
+        case Project(vs, Union(l, r)) =>
+          assert(vs.nonEmpty && vs.size == 3)
+          r match {
+            case Filter(funcs, e) => succeed
+            case _                => fail
+          }
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test simple describe query" should "parse" in {
     val query = QuerySamples.q15
-    val q     = parse(query, config)
-    q match {
+    parse(query, config).map {
       case (Describe(_, OpNil()), _) =>
         succeed
       case _ =>
@@ -207,293 +236,315 @@ class QuerySamplesTestSpec
 
   "Test describe query" should "parse" in {
     val query = QuerySamples.q16
-    val q     = parse(query, config)
-    q match {
-      case (Describe(vars, Project(vs, Filter(_, _))), _) =>
-        assert(vars == vs)
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Describe(vars, Project(vs, Filter(_, _))), _) =>
+          assert(vars == vs)
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Tests str conversion and logical operators" should "parse" in {
     val query = QuerySamples.q17
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(vs, Filter(_, _))), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(vs, Filter(_, _))), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Tests FILTER positioning with graph sub-patterns" should "parse" in {
     val query = QuerySamples.q18
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(vs, Filter(_, _))), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(vs, Filter(_, _))), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test for FILTER in different positions" should "parse" in {
     val query = QuerySamples.q19
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Distinct(Project(vs, Filter(_, _)))), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Distinct(Project(vs, Filter(_, _)))), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test CONSTRUCT and string replacement" should "parse" in {
     val query = QuerySamples.q20
-    val q     = parse(query, config)
-    q match {
-      case (
-            Construct(
-              vars,
-              _,
-              Extend(to, REPLACE(_, _, _), r)
-            ),
-            _
-          ) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (
+              Construct(
+                vars,
+                _,
+                Extend(to, REPLACE(_, _, _), r)
+              ),
+              _
+            ) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Test document query" should "parse" in {
     val query = QuerySamples.q21
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(vs, BGP(ts))), _) =>
-        assert(ts.size == 21)
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(vs, BGP(ts))), _) =>
+          assert(ts.size == 21)
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   //Comprehensive queries
 
   "Get a sample of triples joining non-blank nodes" should "parse" in {
     val query = QuerySamples.q22
-    val q     = parse(query, config)
-    q match {
-      case (
-            Select(
-              vars,
-              OffsetLimit(None, Some(10), Project(_, Filter(_, _)))
-            ),
-            _
-          ) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (
+              Select(
+                vars,
+                OffsetLimit(None, Some(10), Project(_, Filter(_, _)))
+              ),
+              _
+            ) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Check DISTINCT works" should "parse" in {
     val query = QuerySamples.q23
-    val q     = parse(query, config)
-    q match {
-      case (
-            Select(
-              vars,
-              OffsetLimit(None, Some(10), Distinct(Project(vs, _)))
-            ),
-            _
-          ) =>
-        assert(vs.size == 3)
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (
+              Select(
+                vars,
+                OffsetLimit(None, Some(10), Distinct(Project(vs, _)))
+              ),
+              _
+            ) =>
+          assert(vs.size == 3)
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get class parent-child relations" should "parse" in {
     val query = QuerySamples.q24
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(_, Filter(_, _))), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(_, Filter(_, _))), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get class parent-child relations with optional labels" should "parse" in {
     val query = QuerySamples.q25
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(_, Filter(_, _))), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(_, Filter(_, _))), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get all labels in file" should "parse" in {
     val query = QuerySamples.q26
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Distinct(Project(_, _))), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Distinct(Project(_, _))), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get label of owl:Thing" should "parse" in {
     val query = QuerySamples.q27
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(vs, _)), _) =>
-        assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(vs, _)), _) =>
+          assert(vs.nonEmpty && vs.head == VARIABLE("?label"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get label of owl:Thing with prefix" should "parse" in {
     val query = QuerySamples.q28
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(_, _)), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(_, _)), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get label of owl:Thing with explanatory comment" should "parse" in {
     val query = QuerySamples.q29
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(_, _)), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(_, _)), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Get label of owl:Thing with regex to remove poor label if present" should "parse" in {
     val query = QuerySamples.q30
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(_, Filter(_, _))), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(_, Filter(_, _))), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Construct a graph where everything which is a Thing is asserted to exist" should "parse" in {
     val query = QuerySamples.q31
-    val q     = parse(query, config)
-    q match {
-      case (Construct(vars, bgp, BGP(_)), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Construct(vars, bgp, BGP(_)), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Construct a graph where all the terms derived from a species have a new relation" should "parse" in {
     val query = QuerySamples.q32
-    val q     = parse(query, config)
-    q match {
-      case (Construct(vars, bgp, BGP(_)), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Construct(vars, bgp, BGP(_)), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Detect punned relations in an ontology" should "parse" in {
     val query = QuerySamples.q33
-    val q     = parse(query, config)
-    q match {
-      case (Select(vars, Project(_, _)), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Select(vars, Project(_, _)), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Construct a triple where the predicate is derived" should "parse" in {
     val query = QuerySamples.q34
-    val q     = parse(query, config)
-    q match {
-      case (Construct(vars, bgp, Union(BGP(_), BGP(_))), _) =>
-        succeed
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Construct(vars, bgp, Union(BGP(_), BGP(_))), _) =>
+          succeed
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Query to convert schema of predications" should "parse" in {
     val query = QuerySamples.q35
-    val q     = parse(query, config)
-    q match {
-      case (Construct(vars, bgp, Extend(to, from, e)), _) =>
-        assert(to == VARIABLE("?pred"))
-      case _ =>
-        fail
-    }
+    parse(query, config)
+      .map {
+        case (Construct(vars, bgp, Extend(to, from, e)), _) =>
+          assert(to == VARIABLE("?pred"))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Query with default and named graphs to match on specific graph" should "parse" in {
     val query = QuerySamples.q36
-    val q     = parse(query, config.copy(isDefaultGraphExclusive = true))
-    q match {
-      case (
-            Select(
-              _,
-              Project(_, Graph(specifiedGraph, _))
-            ),
-            graphs
-          ) =>
-        graphs.default should (have size 2 and contain theSameElementsAs Seq(
-          URIVAL("http://example.org/dft.ttl"),
-          URIVAL("")
-        ))
-        graphs.named should (have size 2 and contain theSameElementsAs Seq(
-          URIVAL("http://example.org/alice"),
-          URIVAL("http://example.org/bob")
-        ))
-      case _ =>
-        fail
-    }
+    parse(query, config.copy(isDefaultGraphExclusive = true))
+      .map {
+        case (
+              Select(
+                _,
+                Project(_, Graph(specifiedGraph, _))
+              ),
+              graphs
+            ) =>
+          graphs.default should (have size 2 and contain theSameElementsAs Seq(
+            URIVAL("http://example.org/dft.ttl"),
+            URIVAL("")
+          ))
+          graphs.named should (have size 2 and contain theSameElementsAs Seq(
+            URIVAL("http://example.org/alice"),
+            URIVAL("http://example.org/bob")
+          ))
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
   "Query with default and named graphs to match on multiple graphs" should "parse" in {
     val query = QuerySamples.q37
-    val q     = parse(query, config.copy(isDefaultGraphExclusive = true))
-    q match {
-      case (
-            Select(
-              vars,
-              Project(_, Join(_, Graph(graphVariable, _)))
-            ),
-            graphs
-          ) =>
-        graphs.default should (have size 2 and contain theSameElementsAs Seq(
-          URIVAL("http://example.org/dft.ttl"),
-          URIVAL("")
-        ))
-        graphs.named should (have size 2 and contain theSameElementsAs Seq(
-          URIVAL("http://example.org/alice"),
-          URIVAL("http://example.org/bob")
-        ))
-        graphVariable shouldEqual vars(1)
-      case _ =>
-        fail
-    }
+    parse(query, config.copy(isDefaultGraphExclusive = true))
+      .map {
+        case (
+              Select(
+                vars,
+                Project(_, Join(_, Graph(graphVariable, _)))
+              ),
+              graphs
+            ) =>
+          graphs.default should (have size 2 and contain theSameElementsAs Seq(
+            URIVAL("http://example.org/dft.ttl"),
+            URIVAL("")
+          ))
+          graphs.named should (have size 2 and contain theSameElementsAs Seq(
+            URIVAL("http://example.org/alice"),
+            URIVAL("http://example.org/bob")
+          ))
+          graphVariable shouldEqual vars(1)
+        case _ =>
+          fail
+      }
+      .getOrElse(fail)
   }
 
 }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestUtils.scala
@@ -1,5 +1,7 @@
 package com.gsk.kg.sparqlparser
 
+import cats.syntax.either._
+
 import org.apache.jena.query.QueryFactory
 import org.apache.jena.sparql.algebra.Algebra
 
@@ -22,14 +24,14 @@ trait TestUtils {
     result
   }
 
-  def queryAlgebra(fileLoc: String, config: Config): Expr = {
+  def queryAlgebra(fileLoc: String, config: Config): Result[Expr] = {
     val q = readOutputFile(fileLoc)
     QueryConstruct.parseADT(q, config)
   }
 
-  def query(fileLoc: String, config: Config): Query = {
+  def query(fileLoc: String, config: Config): Result[Query] = {
     val q = readOutputFile(fileLoc)
-    parse(q, config)._1
+    parse(q, config).map(_._1)
   }
 
   def readOutputFile(fileLoc: String): String = {
@@ -45,7 +47,7 @@ trait TestUtils {
   def parse(
       query: String,
       config: Config
-  ): (Query, Graphs) =
+  ): Result[(Query, Graphs)] =
     QueryConstruct.parse(query, config)
 
 }

--- a/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
+++ b/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
@@ -1,15 +1,18 @@
 package com.gsk.kg.site.contrib.reftree
 
-import higherkindness.droste._
-import cats.implicits._
 import cats.Traverse
 import cats.data.State
-import reftree.core._
+import cats.implicits._
+
+import higherkindness.droste._
 import higherkindness.droste.data.Fix
-import com.gsk.kg.sparqlparser.Expr
-import com.gsk.kg.engine.data.ChunkedList
-import reftree.contrib.SimplifiedInstances._
+
 import com.gsk.kg.engine.DAG
+import com.gsk.kg.engine.data.ChunkedList
+import com.gsk.kg.sparqlparser.Expr
+
+import reftree.contrib.SimplifiedInstances._
+import reftree.core._
 
 object prelude {
 


### PR DESCRIPTION
This PR wraps the engine method `QueryConstruct.parse` into a `Result` monad so it can be managed as the rest of the phases of the Engine. 

Now, Jena exceptions are captured into the left projection of `Result` so errors can be handled in an homogeneous way through all the engine.

Closes #231 