### PR TITLE
Support for order by

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/DAG.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/DAG.scala
@@ -3,18 +3,16 @@ package com.gsk.kg.engine
 import cats._
 import cats.data.NonEmptyList
 import cats.implicits._
-
 import higherkindness.droste._
 import higherkindness.droste.syntax.all._
 import higherkindness.droste.util.DefaultTraverse
-
 import com.gsk.kg.engine.data.ChunkedList
+import com.gsk.kg.sparqlparser.ConditionOrder
 import com.gsk.kg.sparqlparser.Expr
-import com.gsk.kg.sparqlparser.Expr.fixedpoint._
 import com.gsk.kg.sparqlparser.Expression
 import com.gsk.kg.sparqlparser.Query
+import com.gsk.kg.sparqlparser.Expr.fixedpoint._
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
-
 import monocle._
 import monocle.macros.Lenses
 
@@ -60,7 +58,7 @@ object DAG {
       func: Option[(VARIABLE, Expression)],
       r: A
   ) extends DAG[A]
-  @Lenses final case class Order[A](conds: NonEmptyList[Expression], r: A)
+  @Lenses final case class Order[A](conds: NonEmptyList[ConditionOrder], r: A)
       extends DAG[A]
   @Lenses final case class Distinct[A](r: A)      extends DAG[A]
   @Lenses final case class Noop[A](trace: String) extends DAG[A]
@@ -123,7 +121,7 @@ object DAG {
       r: A
   ): DAG[A] =
     Group[A](vars, func, r)
-  def order[A](conds: NonEmptyList[Expression], r: A): DAG[A] =
+  def order[A](conds: NonEmptyList[ConditionOrder], r: A): DAG[A] =
     Order[A](conds, r)
   def noop[A](trace: String): DAG[A] = Noop[A](trace)
 
@@ -168,7 +166,7 @@ object DAG {
       r: T
   ): T = group[T](vars, func, r).embed
   def orderR[T: Embed[DAG, *]](
-      conds: NonEmptyList[Expression],
+      conds: NonEmptyList[ConditionOrder],
       r: T
   ): T                                          = order[T](conds, r).embed
   def noopR[T: Embed[DAG, *]](trace: String): T = noop[T](trace).embed

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/DAG.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/DAG.scala
@@ -3,16 +3,19 @@ package com.gsk.kg.engine
 import cats._
 import cats.data.NonEmptyList
 import cats.implicits._
+
 import higherkindness.droste._
 import higherkindness.droste.syntax.all._
 import higherkindness.droste.util.DefaultTraverse
+
 import com.gsk.kg.engine.data.ChunkedList
 import com.gsk.kg.sparqlparser.ConditionOrder
 import com.gsk.kg.sparqlparser.Expr
+import com.gsk.kg.sparqlparser.Expr.fixedpoint._
 import com.gsk.kg.sparqlparser.Expression
 import com.gsk.kg.sparqlparser.Query
-import com.gsk.kg.sparqlparser.Expr.fixedpoint._
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+
 import monocle._
 import monocle.macros.Lenses
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -1,13 +1,14 @@
 package com.gsk.kg.engine
 
-import cats.Applicative
 import cats.Foldable
 import cats.data.NonEmptyList
 import cats.implicits.toTraverseOps
 import cats.instances.all._
 import cats.syntax.applicative._
 import cats.syntax.either._
+
 import higherkindness.droste._
+
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Encoder
@@ -17,6 +18,7 @@ import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
+
 import com.gsk.kg.config.Config
 import com.gsk.kg.engine.data.ChunkedList
 import com.gsk.kg.engine.data.ChunkedList.Chunk
@@ -248,14 +250,14 @@ object Engine {
       conds
         .map {
           case ASC(VARIABLE(v)) =>
-            col(v).asc.asRight: Result[Column]
+            col(v).asc.asRight
           case ASC(e) =>
             ExpressionF
               .compile[Expression](e, config)
               .apply(r.dataframe)
               .map(_.asc)
           case DESC(VARIABLE(v)) =>
-            col(v).desc.asRight: Result[Column]
+            col(v).desc.asRight
           case DESC(e) =>
             ExpressionF
               .compile[Expression](e, config)
@@ -263,7 +265,7 @@ object Engine {
               .map(_.desc)
         }
         .toList
-        .traverse[Either[EngineError, *], Column](identity)
+        .sequence[Either[EngineError, *], Column]
         .map(columns => r.copy(dataframe = r.dataframe.orderBy(columns: _*)))
     }
   }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -50,6 +50,7 @@ object Engine {
       case DAG.Limit(limit, r)         => evaluateLimit(limit, r)
       case DAG.Distinct(r)             => evaluateDistinct(r)
       case DAG.Group(vars, func, r)    => evaluateGroup(vars, func, r)
+      case DAG.Order(variable, r)      => evaluateOrder(variable, r)
       case DAG.Noop(str)               => notImplemented("Noop")
     }
 
@@ -237,6 +238,10 @@ object Engine {
           .asLeft[DataFrame]
       )
   }
+
+  private def evaluateOrder(variable: VARIABLE, r: Multiset): M[Multiset] =
+    r.copy(dataframe = r.dataframe.orderBy(col(variable.s).asc)).pure[M]
+//    r.copy(dataframe = r.dataframe.sort(col(variable.s).asc)).pure[M]
 
   private def evaluateLeftJoin(
       l: Multiset,

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -50,7 +50,7 @@ object Engine {
       case DAG.Limit(limit, r)         => evaluateLimit(limit, r)
       case DAG.Distinct(r)             => evaluateDistinct(r)
       case DAG.Group(vars, func, r)    => evaluateGroup(vars, func, r)
-      case DAG.Order(variable, r)      => evaluateOrder(variable, r)
+      case DAG.Order(conds, r)         => evaluateOrder(conds, r)
       case DAG.Noop(str)               => notImplemented("Noop")
     }
 
@@ -239,8 +239,11 @@ object Engine {
       )
   }
 
-  private def evaluateOrder(variable: VARIABLE, r: Multiset): M[Multiset] =
-    r.copy(dataframe = r.dataframe.orderBy(col(variable.s).asc)).pure[M]
+  private def evaluateOrder(
+      conds: NonEmptyList[Expression],
+      r: Multiset
+  ): M[Multiset] = ???
+//    r.copy(dataframe = r.dataframe.orderBy(col(variable.s).asc)).pure[M]
 //    r.copy(dataframe = r.dataframe.sort(col(variable.s).asc)).pure[M]
 
   private def evaluateLeftJoin(

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -7,7 +7,7 @@ import cats.{Group => _, _}
 
 import higherkindness.droste.{Project => _, _}
 
-import com.gsk.kg.engine.DAG._
+import com.gsk.kg.engine.DAG.{Order => DAGOrder, _}
 import com.gsk.kg.engine.data.ChunkedList
 import com.gsk.kg.sparqlparser.StringVal.GRAPH_VARIABLE
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
@@ -85,6 +85,7 @@ object FindUnboundVariables {
       case Limit(limit, r)         => r.pure[ST]
       case Distinct(r)             => r.pure[ST]
       case Group(vars, func, r)    => r.pure[ST]
+      case DAGOrder(variable, r)   => r.pure[ST]
       case Noop(trace)             => Set.empty.pure[ST]
     }
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -85,7 +85,7 @@ object FindUnboundVariables {
       case Limit(limit, r)         => r.pure[ST]
       case Distinct(r)             => r.pure[ST]
       case Group(vars, func, r)    => r.pure[ST]
-      case DAGOrder(variable, r)   => r.pure[ST]
+      case DAGOrder(conds, r)      => r.pure[ST]
       case Noop(trace)             => Set.empty.pure[ST]
     }
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -10,6 +10,9 @@ import higherkindness.droste.Algebra
 import higherkindness.droste.Basis
 import higherkindness.droste.scheme
 
+import com.gsk.kg.sparqlparser.ConditionOrder
+import com.gsk.kg.sparqlparser.ConditionOrder.ASC
+import com.gsk.kg.sparqlparser.ConditionOrder.DESC
 import com.gsk.kg.sparqlparser.Expr
 import com.gsk.kg.sparqlparser.Expression
 
@@ -43,6 +46,14 @@ object ToTree extends LowPriorityToTreeInstances0 {
         )
       )
   }
+
+  implicit val conditionOrderToTree: ToTree[ConditionOrder] =
+    new ToTree[ConditionOrder] {
+      override def toTree(t: ConditionOrder): TreeRep[String] = t match {
+        case ASC(e)  => TreeRep.Node("Asc", Stream(e.toTree))
+        case DESC(e) => TreeRep.Node("Desc", Stream(e.toTree))
+      }
+    }
 
   // scalastyle:off
   implicit def dagToTree[T: Basis[DAG, *]]: ToTree[T] =
@@ -91,6 +102,8 @@ object ToTree extends LowPriorityToTreeInstances0 {
             val v: List[Expression]                 = vars
             val f: Option[(Expression, Expression)] = func
             Node("Group", Stream(v.toTree, f.toTree, r))
+          case DAG.Order(conds, r) =>
+            Node("Order", conds.map(_.toTree).toList.toStream #::: Stream(r))
           case DAG.Distinct(r) => Node("Distinct", Stream(r))
           case DAG.Noop(str)   => Leaf(s"Noop($str)")
         }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
@@ -162,6 +162,8 @@ object GraphsPushdown {
           case DAG.Distinct(r) => graphsOrList => DAG.distinctR(r(graphsOrList))
           case DAG.Group(vars, func, r) =>
             graphsOrList => DAG.groupR(vars, func, r(graphsOrList))
+          case DAG.Order(variable, r) =>
+            graphsOrList => DAG.orderR(variable, r(graphsOrList))
           case DAG.Noop(graphsOrList) => _ => DAG.noopR(graphsOrList)
         }
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/SubqueryPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/SubqueryPushdown.scala
@@ -197,6 +197,8 @@ object SubqueryPushdown {
           isFromSubquery => DAG.distinctR(r(isFromSubquery))
         case DAG.Group(vars, func, r) =>
           isFromSubquery => DAG.groupR(vars, func, r(isFromSubquery))
+        case DAG.Order(variable, r) =>
+          isFromSubquery => DAG.orderR(variable, r(isFromSubquery))
         case DAG.Noop(s) => _ => DAG.noopR(s)
       }
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -5181,17 +5181,17 @@ class CompilerSpec
             |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
             |
             |SELECT ?name
-            |WHERE { ?x foaf:name ?name ; foaf:empId ?emp }
-            |ORDER BY ?name DESC(?emp)
+            |WHERE { ?x foaf:name ?name ; foaf:age ?age }
+            |ORDER BY ?name DESC(?age)
             |""".stripMargin
 
         val result = Compiler.compile(df, query, config)
 
         result.right.get.collect().length shouldEqual 3
         result.right.get.collect.toList shouldEqual List(
-          Row("\"Charlie\""),
-          Row("\"Bob\""),
-          Row("\"Alice\"")
+          Row("\"A. Alice\""),
+          Row("\"A. Bob\""),
+          Row("\"A. Charlie\"")
         )
       }
 
@@ -5241,19 +5241,17 @@ class CompilerSpec
             |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
             |
             |SELECT ?name
-            |WHERE { ?x foaf:name ?name ; foaf:empId ?emp }
-            |ORDER BY ?name ?emp DESC(?emp) ASC(?name) DESC((isBlank(?x) || isBlank(?emp)))
+            |WHERE { ?x foaf:name ?name ; foaf:age ?age }
+            |ORDER BY DESC(?name) ?age DESC(?age) ASC(?name) DESC((isBlank(?x) || isBlank(?age)))
             |""".stripMargin
 
         val result = Compiler.compile(df, query, config)
 
-        println(result)
-
         result.right.get.collect().length shouldEqual 3
         result.right.get.collect.toList shouldEqual List(
-          Row("\"Charlie\""),
-          Row("\"Bob\""),
-          Row("\"Alice\"")
+          Row("\"A. Charlie\""),
+          Row("\"A. Bob\""),
+          Row("\"A. Alice\"")
         )
       }
     }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -5045,9 +5045,9 @@ class CompilerSpec
 
         result.right.get.collect().length shouldEqual 3
         result.right.get.collect.toList shouldEqual List(
-          Row("\"Charlie\""),
+          Row("\"Alice\""),
           Row("\"Bob\""),
-          Row("\"Alice\"")
+          Row("\"Charlie\"")
         )
       }
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -5007,6 +5007,55 @@ class CompilerSpec
       }
     }
 
+    "perform query with ORDER BY" should {
+
+      "execute and obtain expected results when no order modifier" in {
+
+        val df: DataFrame = List(
+          (
+            "_:a",
+            "http://xmlns.com/foaf/0.1/name",
+            "Alice",
+            ""
+          ),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/name",
+            "Bob",
+            ""
+          ),
+          (
+            "_:c",
+            "http://xmlns.com/foaf/0.1/name",
+            "Charlie",
+            ""
+          )
+        ).toDF("s", "p", "o", "g")
+
+        val query =
+          """
+            |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?name
+            |WHERE { ?x foaf:name ?name }
+            |ORDER BY ?name
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result.right.get.collect().length shouldEqual 3
+        result.right.get.collect.toList shouldEqual List(
+          Row("\"Charlie\""),
+          Row("\"Bob\""),
+          Row("\"Alice\"")
+        )
+      }
+
+      "execute and obtain expected results when ASC modifier" in {}
+
+      "execute and obtain expected results when DESC modifier" in {}
+    }
+
     "inclusive/exclusive default graph" should {
 
       "exclude graphs when no explicit FROM" in {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -5019,15 +5019,15 @@ class CompilerSpec
             ""
           ),
           (
-            "_:b",
-            "http://xmlns.com/foaf/0.1/name",
-            "Bob",
-            ""
-          ),
-          (
             "_:c",
             "http://xmlns.com/foaf/0.1/name",
             "Charlie",
+            ""
+          ),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/name",
+            "Bob",
             ""
           )
         ).toDF("s", "p", "o", "g")
@@ -5051,9 +5051,211 @@ class CompilerSpec
         )
       }
 
-      "execute and obtain expected results when ASC modifier" in {}
+      "execute and obtain expected results when ASC modifier" in {
 
-      "execute and obtain expected results when DESC modifier" in {}
+        val df: DataFrame = List(
+          (
+            "_:a",
+            "http://xmlns.com/foaf/0.1/name",
+            "Alice",
+            ""
+          ),
+          (
+            "_:c",
+            "http://xmlns.com/foaf/0.1/name",
+            "Charlie",
+            ""
+          ),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/name",
+            "Bob",
+            ""
+          )
+        ).toDF("s", "p", "o", "g")
+
+        val query =
+          """
+            |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?name
+            |WHERE { ?x foaf:name ?name }
+            |ORDER BY ASC(?name)
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result.right.get.collect().length shouldEqual 3
+        result.right.get.collect.toList shouldEqual List(
+          Row("\"Alice\""),
+          Row("\"Bob\""),
+          Row("\"Charlie\"")
+        )
+      }
+
+      "execute and obtain expected results when DESC modifier" in {
+
+        val df: DataFrame = List(
+          (
+            "_:a",
+            "http://xmlns.com/foaf/0.1/name",
+            "Alice",
+            ""
+          ),
+          (
+            "_:c",
+            "http://xmlns.com/foaf/0.1/name",
+            "Charlie",
+            ""
+          ),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/name",
+            "Bob",
+            ""
+          )
+        ).toDF("s", "p", "o", "g")
+
+        val query =
+          """
+            |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?name
+            |WHERE { ?x foaf:name ?name }
+            |ORDER BY DESC(?name)
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result.right.get.collect().length shouldEqual 3
+        result.right.get.collect.toList shouldEqual List(
+          Row("\"Charlie\""),
+          Row("\"Bob\""),
+          Row("\"Alice\"")
+        )
+      }
+
+      "execute and obtain expected results whit multiple comparators" in {
+
+        val df: DataFrame = List(
+          (
+            "_:a",
+            "http://xmlns.com/foaf/0.1/name",
+            "A. Alice",
+            ""
+          ),
+          (
+            "_:a",
+            "http://xmlns.com/foaf/0.1/age",
+            "10",
+            ""
+          ),
+          (
+            "_:c",
+            "http://xmlns.com/foaf/0.1/name",
+            "A. Charlie",
+            ""
+          ),
+          (
+            "_:c",
+            "http://xmlns.com/foaf/0.1/age",
+            "30",
+            ""
+          ),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/name",
+            "A. Bob",
+            ""
+          ),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/age",
+            "20",
+            ""
+          )
+        ).toDF("s", "p", "o", "g")
+
+        val query =
+          """
+            |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?name
+            |WHERE { ?x foaf:name ?name ; foaf:empId ?emp }
+            |ORDER BY ?name DESC(?emp)
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result.right.get.collect().length shouldEqual 3
+        result.right.get.collect.toList shouldEqual List(
+          Row("\"Charlie\""),
+          Row("\"Bob\""),
+          Row("\"Alice\"")
+        )
+      }
+
+      "execute and obtain expected results whit multiple comparators 2" in {
+
+        val df: DataFrame = List(
+          (
+            "_:a",
+            "http://xmlns.com/foaf/0.1/name",
+            "A. Alice",
+            ""
+          ),
+          (
+            "_:a",
+            "http://xmlns.com/foaf/0.1/age",
+            "10",
+            ""
+          ),
+          (
+            "_:c",
+            "http://xmlns.com/foaf/0.1/name",
+            "A. Charlie",
+            ""
+          ),
+          (
+            "_:c",
+            "http://xmlns.com/foaf/0.1/age",
+            "30",
+            ""
+          ),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/name",
+            "A. Bob",
+            ""
+          ),
+          (
+            "_:b",
+            "http://xmlns.com/foaf/0.1/age",
+            "20",
+            ""
+          )
+        ).toDF("s", "p", "o", "g")
+
+        val query =
+          """
+            |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?name
+            |WHERE { ?x foaf:name ?name ; foaf:empId ?emp }
+            |ORDER BY ?name ?emp DESC(?emp) ASC(?name) DESC((isBlank(?x) || isBlank(?emp)))
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        println(result)
+
+        result.right.get.collect().length shouldEqual 3
+        result.right.get.collect.toList shouldEqual List(
+          Row("\"Charlie\""),
+          Row("\"Bob\""),
+          Row("\"Alice\"")
+        )
+      }
     }
 
     "inclusive/exclusive default graph" should {

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -105,9 +105,9 @@ object Expr {
       vars: Seq[VARIABLE],
       func: Option[(VARIABLE, Expression)],
       r: Expr
-  )                                                       extends Expr
-  final case class Order(conds: Seq[Expression], r: Expr) extends Expr
-  final case class Distinct(r: Expr)                      extends Expr
-  final case class OpNil()                                extends Expr
-  final case class TabUnit()                              extends Expr
+  )                                                           extends Expr
+  final case class Order(conds: Seq[ConditionOrder], r: Expr) extends Expr
+  final case class Distinct(r: Expr)                          extends Expr
+  final case class OpNil()                                    extends Expr
+  final case class TabUnit()                                  extends Expr
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -105,9 +105,9 @@ object Expr {
       vars: Seq[VARIABLE],
       func: Option[(VARIABLE, Expression)],
       r: Expr
-  )                                                   extends Expr
-  final case class Order(variable: VARIABLE, r: Expr) extends Expr
-  final case class Distinct(r: Expr)                  extends Expr
-  final case class OpNil()                            extends Expr
-  final case class TabUnit()                          extends Expr
+  )                                                       extends Expr
+  final case class Order(conds: Seq[Expression], r: Expr) extends Expr
+  final case class Distinct(r: Expr)                      extends Expr
+  final case class OpNil()                                extends Expr
+  final case class TabUnit()                              extends Expr
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -105,8 +105,9 @@ object Expr {
       vars: Seq[VARIABLE],
       func: Option[(VARIABLE, Expression)],
       r: Expr
-  )                                  extends Expr
-  final case class Distinct(r: Expr) extends Expr
-  final case class OpNil()           extends Expr
-  final case class TabUnit()         extends Expr
+  )                                                   extends Expr
+  final case class Order(variable: VARIABLE, r: Expr) extends Expr
+  final case class Distinct(r: Expr)                  extends Expr
+  final case class OpNil()                            extends Expr
+  final case class TabUnit()                          extends Expr
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -22,6 +22,7 @@ object ExprParser {
   def offsetLimit[_: P]: P[Unit] = P("slice")
   def distinct[_: P]: P[Unit]    = P("distinct")
   def group[_: P]: P[Unit]       = P("group")
+  def order[_: P]: P[Unit]       = P("order")
 
   def opNull[_: P]: P[OpNil]      = P("(null)").map(_ => OpNil())
   def tableUnit[_: P]: P[TabUnit] = P("(table unit)").map(_ => TabUnit())
@@ -126,6 +127,12 @@ object ExprParser {
     Graph(p._1, p._2)
   }
 
+  def orderParen[_: P]: P[Order] = P(
+    "(" ~ order ~ "(" ~ StringValParser.variable ~ ")" ~ graphPattern ~ ")"
+  ).map { p =>
+    Order(p._1, p._2)
+  }
+
   def graphPattern[_: P]: P[Expr] =
     P(
       selectParen
@@ -141,6 +148,7 @@ object ExprParser {
         | filterSingleParen
         | filterListParen
         | groupParen
+        | orderParen
         | opNull
         | tableUnit
     )

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -128,7 +128,9 @@ object ExprParser {
   }
 
   def orderParen[_: P]: P[Order] = P(
-    "(" ~ order ~ "(" ~ StringValParser.variable ~ ")" ~ graphPattern ~ ")"
+    "(" ~ order ~ "(" ~ OrderConditionParser.parser.rep(
+      1
+    ) ~ ")" ~ graphPattern ~ ")"
   ).map { p =>
     Order(p._1, p._2)
   }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -81,3 +81,9 @@ object Aggregate {
   final case class GROUP_CONCAT(e: Expression, separator: String)
       extends Aggregate
 }
+
+sealed trait ConditionOrder extends Expression
+object ConditionOrder {
+  final case class ASC(e: Expression)  extends ConditionOrder
+  final case class DESC(e: Expression) extends ConditionOrder
+}

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/OrderConditionParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/OrderConditionParser.scala
@@ -1,0 +1,31 @@
+package com.gsk.kg.sparqlparser
+
+import com.gsk.kg.sparqlparser.ConditionOrder.ASC
+import com.gsk.kg.sparqlparser.ConditionOrder.DESC
+import fastparse.MultiLineWhitespace._
+import fastparse._
+
+object OrderConditionParser {
+
+  def asc[_: P]: P[Unit]  = P("asc")
+  def desc[_: P]: P[Unit] = P("desc")
+
+  def conditionParen[_: P]: P[Expression] = P(
+    BuiltInFuncParser.parser | ConditionalParser.parser
+  )
+
+  def ascParen[_: P]: P[ASC] = P(
+    "(" ~ asc ~ (StringValParser.variable | conditionParen) ~ ")" |
+      StringValParser.variable |
+      conditionParen
+  ).map(p => ASC(p))
+
+  def descParen[_: P]: P[DESC] = P(
+    "(" ~ desc ~ (StringValParser.variable | conditionParen) ~ ")"
+  ).map(p => DESC(p))
+
+  def parser[_: P]: P[Expression] = P(
+    ascParen |
+      descParen
+  )
+}

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/OrderConditionParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/OrderConditionParser.scala
@@ -24,7 +24,7 @@ object OrderConditionParser {
     "(" ~ desc ~ (StringValParser.variable | conditionParen) ~ ")"
   ).map(p => DESC(p))
 
-  def parser[_: P]: P[Expression] = P(
+  def parser[_: P]: P[ConditionOrder] = P(
     ascParen |
       descParen
   )

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/OrderConditionParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/OrderConditionParser.scala
@@ -2,6 +2,7 @@ package com.gsk.kg.sparqlparser
 
 import com.gsk.kg.sparqlparser.ConditionOrder.ASC
 import com.gsk.kg.sparqlparser.ConditionOrder.DESC
+
 import fastparse.MultiLineWhitespace._
 import fastparse._
 

--- a/modules/parser/src/test/resources/queries/q41-orderby-simple-variable.sparql
+++ b/modules/parser/src/test/resources/queries/q41-orderby-simple-variable.sparql
@@ -1,0 +1,5 @@
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+
+SELECT ?name
+WHERE { ?x foaf:name ?name }
+ORDER BY ?name

--- a/modules/parser/src/test/resources/queries/q42-orderby-simple-condition.sparql
+++ b/modules/parser/src/test/resources/queries/q42-orderby-simple-condition.sparql
@@ -1,0 +1,5 @@
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+
+SELECT ?name
+WHERE { ?x foaf:name ?name ; foaf:age ?age }
+ORDER BY DESC(isBlank(?x))

--- a/modules/parser/src/test/resources/queries/q43-orderby-multi-mixing.sparql
+++ b/modules/parser/src/test/resources/queries/q43-orderby-multi-mixing.sparql
@@ -1,0 +1,5 @@
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+
+SELECT ?name
+WHERE { ?x foaf:name ?name ; foaf:age ?age }
+ORDER BY DESC(?name) ?age DESC(?age) ASC(?name) DESC((isBlank(?x) || isBlank(?age)))

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
@@ -1,6 +1,8 @@
 package com.gsk.kg.sparqlparser
 
 import com.gsk.kg.sparqlparser.BuiltInFunc._
+import com.gsk.kg.sparqlparser.ConditionOrder.ASC
+import com.gsk.kg.sparqlparser.ConditionOrder.DESC
 import com.gsk.kg.sparqlparser.Conditional._
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.StringVal._
@@ -408,6 +410,119 @@ class ExprParserSpec extends AnyFlatSpec with TestUtils {
                       VARIABLE("?ad"),
                       List(GRAPH_VARIABLE)
                     )
+                  )
+                )
+              )
+            )
+          ) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "Order By" should "return proper type when simple variable" in {
+    val p = fastparse.parse(
+      sparql2Algebra(
+        "/queries/q41-orderby-simple-variable.sparql"
+      ),
+      ExprParser.parser(_)
+    )
+
+    p.get.value match {
+      case Project(
+            Seq(VARIABLE("?name")),
+            Order(
+              Seq(ASC(VARIABLE("?name"))),
+              BGP(
+                Seq(
+                  Quad(
+                    VARIABLE("?x"),
+                    URIVAL("http://xmlns.com/foaf/0.1/name"),
+                    VARIABLE("?name"),
+                    List(GRAPH_VARIABLE)
+                  )
+                )
+              )
+            )
+          ) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  it should "return proper type when simple condition" in {
+    val p = fastparse.parse(
+      sparql2Algebra(
+        "/queries/q42-orderby-simple-condition.sparql"
+      ),
+      ExprParser.parser(_)
+    )
+
+    p.get.value match {
+      case Project(
+            Seq(VARIABLE("?name")),
+            Order(
+              Seq(DESC(ISBLANK(VARIABLE("?x")))),
+              BGP(
+                Seq(
+                  Quad(
+                    VARIABLE("?x"),
+                    URIVAL("http://xmlns.com/foaf/0.1/name"),
+                    VARIABLE("?name"),
+                    List(GRAPH_VARIABLE)
+                  ),
+                  Quad(
+                    VARIABLE("?x"),
+                    URIVAL("http://xmlns.com/foaf/0.1/age"),
+                    VARIABLE("?age"),
+                    List(GRAPH_VARIABLE)
+                  )
+                )
+              )
+            )
+          ) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  it should "return proper type when mixing multiple variables and multiple conditions" in {
+    val p = fastparse.parse(
+      sparql2Algebra(
+        "/queries/q43-orderby-multi-mixing.sparql"
+      ),
+      ExprParser.parser(_)
+    )
+
+    p.get.value match {
+      case Project(
+            Seq(VARIABLE("?name")),
+            Order(
+              Seq(
+                DESC(VARIABLE("?name")),
+                ASC(VARIABLE("?age")),
+                DESC(VARIABLE("?age")),
+                ASC(VARIABLE("?name")),
+                DESC(
+                  OR(
+                    ISBLANK(VARIABLE("?x")),
+                    ISBLANK(VARIABLE("?age"))
+                  )
+                )
+              ),
+              BGP(
+                Seq(
+                  Quad(
+                    VARIABLE("?x"),
+                    URIVAL("http://xmlns.com/foaf/0.1/name"),
+                    VARIABLE("?name"),
+                    List(GRAPH_VARIABLE)
+                  ),
+                  Quad(
+                    VARIABLE("?x"),
+                    URIVAL("http://xmlns.com/foaf/0.1/age"),
+                    VARIABLE("?age"),
+                    List(GRAPH_VARIABLE)
                   )
                 )
               )

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/OrderConditionParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/OrderConditionParserSpec.scala
@@ -85,31 +85,3 @@ class OrderConditionParserSpec extends AnyWordSpec {
     }
   }
 }
-
-//(project (?name)
-//(order (?name (desc ?emp))
-//(bgp
-//(triple ?x <http://xmlns.com/foaf/0.1/name> ?name)
-//(triple ?x <http://xmlns.com/foaf/0.1/empId> ?emp)
-//)))
-//
-//(project (?name)
-//(order (?name (desc ?emp) (|| (isBlank ?x) (isBlank ?emp)))
-//(bgp
-//(triple ?x <http://xmlns.com/foaf/0.1/name> ?name)
-//(triple ?x <http://xmlns.com/foaf/0.1/empId> ?emp)
-//)))
-//
-//(project (?name)
-//(order (?name ?emp (desc ?emp) (asc ?name) (|| (isBlank ?x) (isBlank ?emp)))
-//(bgp
-//(triple ?x <http://xmlns.com/foaf/0.1/name> ?name)
-//(triple ?x <http://xmlns.com/foaf/0.1/empId> ?emp)
-//)))
-//
-//(project (?name)
-//(order (?name ?emp (desc ?emp) (asc ?name) (desc (|| (isBlank ?x) (isBlank ?emp))))
-//(bgp
-//(triple ?x <http://xmlns.com/foaf/0.1/name> ?name)
-//(triple ?x <http://xmlns.com/foaf/0.1/empId> ?emp)
-//)))

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/OrderConditionParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/OrderConditionParserSpec.scala
@@ -1,0 +1,115 @@
+package com.gsk.kg.sparqlparser
+
+import com.gsk.kg.sparqlparser.BuiltInFunc.ISBLANK
+import com.gsk.kg.sparqlparser.ConditionOrder.ASC
+import com.gsk.kg.sparqlparser.ConditionOrder.DESC
+import com.gsk.kg.sparqlparser.Conditional.OR
+import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class OrderConditionParserSpec extends AnyWordSpec {
+
+  "Asc parser" should {
+
+    "return ASC type" when {
+
+      "no explicit order defined with variable" in {
+        val p =
+          fastparse.parse("""?name""", OrderConditionParser.ascParen(_))
+        p.get.value match {
+          case ASC(VARIABLE(v)) => succeed
+          case _                => fail
+        }
+      }
+
+      "no explicit order defined with condition" in {
+        val p =
+          fastparse.parse(
+            """(|| (isBlank ?x) (isBlank ?emp))""",
+            OrderConditionParser.ascParen(_)
+          )
+        p.get.value match {
+          case ASC(OR(ISBLANK(a), ISBLANK(b))) => succeed
+          case _                               => fail
+        }
+      }
+
+      "explicit ASC order defined with variable" in {
+        val p =
+          fastparse.parse("""(asc ?name)""", OrderConditionParser.ascParen(_))
+        p.get.value match {
+          case ASC(VARIABLE(v)) => succeed
+          case _                => fail
+        }
+      }
+
+      "explicit ASC order defined with condition" in {
+        val p =
+          fastparse.parse(
+            """(asc (|| (isBlank ?x) (isBlank ?emp)))""",
+            OrderConditionParser.ascParen(_)
+          )
+        p.get.value match {
+          case ASC(OR(ISBLANK(a), ISBLANK(b))) => succeed
+          case _                               => fail
+        }
+      }
+    }
+  }
+
+  "Desc parser" should {
+
+    "return DESC type" when {
+
+      "explicit DESC order defined with variable" in {
+        val p =
+          fastparse.parse("""(desc ?name)""", OrderConditionParser.descParen(_))
+        p.get.value match {
+          case DESC(VARIABLE(v)) => succeed
+          case _                 => fail
+        }
+      }
+
+      "explicit DESC order defined with condition" in {
+        val p =
+          fastparse.parse(
+            """(desc (|| (isBlank ?x) (isBlank ?emp)))""",
+            OrderConditionParser.descParen(_)
+          )
+        p.get.value match {
+          case DESC(OR(ISBLANK(a), ISBLANK(b))) => succeed
+          case _                                => fail
+        }
+      }
+    }
+  }
+}
+
+//(project (?name)
+//(order (?name (desc ?emp))
+//(bgp
+//(triple ?x <http://xmlns.com/foaf/0.1/name> ?name)
+//(triple ?x <http://xmlns.com/foaf/0.1/empId> ?emp)
+//)))
+//
+//(project (?name)
+//(order (?name (desc ?emp) (|| (isBlank ?x) (isBlank ?emp)))
+//(bgp
+//(triple ?x <http://xmlns.com/foaf/0.1/name> ?name)
+//(triple ?x <http://xmlns.com/foaf/0.1/empId> ?emp)
+//)))
+//
+//(project (?name)
+//(order (?name ?emp (desc ?emp) (asc ?name) (|| (isBlank ?x) (isBlank ?emp)))
+//(bgp
+//(triple ?x <http://xmlns.com/foaf/0.1/name> ?name)
+//(triple ?x <http://xmlns.com/foaf/0.1/empId> ?emp)
+//)))
+//
+//(project (?name)
+//(order (?name ?emp (desc ?emp) (asc ?name) (desc (|| (isBlank ?x) (isBlank ?emp))))
+//(bgp
+//(triple ?x <http://xmlns.com/foaf/0.1/name> ?name)
+//(triple ?x <http://xmlns.com/foaf/0.1/empId> ?emp)
+//)))

--- a/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
+++ b/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
@@ -9,6 +9,9 @@ import higherkindness.droste.data.Fix
 
 import com.gsk.kg.engine.DAG
 import com.gsk.kg.engine.data.ChunkedList
+import com.gsk.kg.sparqlparser.ConditionOrder
+import com.gsk.kg.sparqlparser.ConditionOrder.ASC
+import com.gsk.kg.sparqlparser.ConditionOrder.DESC
 import com.gsk.kg.sparqlparser.Expr
 
 import reftree.contrib.SimplifiedInstances._
@@ -84,6 +87,13 @@ object prelude {
     )
   )
 
+  implicit val conditionOrderRefTree: ToRefTree[ConditionOrder] = ToRefTree {
+    case tree @ ASC(e) =>
+      RefTree.Ref(tree, Seq(e.refTree.toField.withName("Asc")))
+    case tree @ DESC(e) =>
+      RefTree.Ref(tree, Seq(e.refTree.toField.withName("Desc")))
+  }
+
   implicit def chunkToRefTree[A: ToRefTree]: ToRefTree[ChunkedList.Chunk[A]] =
     ToRefTree(chunk =>
       RefTree.Ref(
@@ -143,6 +153,8 @@ object prelude {
     case dag @ DAG.Distinct(r) => RefTree.Ref(dag, Seq(r.toField))
     case dag @ DAG.Group(vars, func, r) =>
       RefTree.Ref(dag, Seq(vars.refTree.toField, r.toField))
+    case dag @ DAG.Order(conds, r) =>
+      RefTree.Ref(dag, Seq(conds.refTree.toField, r.toField))
     case dag @ DAG.Noop(str) => RefTree.Ref(dag, Seq())
   }
 }


### PR DESCRIPTION
This PR add support for queries with order by like this one:

```
PREFIX foaf:    <http://xmlns.com/foaf/0.1/>

SELECT ?name
WHERE { ?x foaf:name ?name ; foaf:age ?age }
ORDER BY DESC(?name) ?age DESC(?age) ASC(?name) DESC((isBlank(?x) || isBlank(?age)))
```

Where variables, functions and binary operations can be defined as conditions.

Closes #89 