### PR TITLE
Add expression variables to find unbounded

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -57,6 +57,8 @@ object ExpressionF {
   final case class URIVAL[A](s: String)   extends ExpressionF[A]
   final case class BLANK[A](s: String)    extends ExpressionF[A]
   final case class BOOL[A](s: String)     extends ExpressionF[A]
+  final case class ASC[A](e: A)           extends ExpressionF[A]
+  final case class DESC[A](e: A)          extends ExpressionF[A]
 
   val fromExpressionCoalg: Coalgebra[ExpressionF, Expression] =
     Coalgebra {
@@ -102,6 +104,8 @@ object ExpressionF {
       case StringVal.URIVAL(s)                              => URIVAL(s)
       case StringVal.BLANK(s)                               => BLANK(s)
       case StringVal.BOOL(s)                                => BOOL(s)
+      case ConditionOrder.ASC(e)                            => ASC(e)
+      case ConditionOrder.DESC(e)                           => DESC(e)
     }
 
   val toExpressionAlgebra: Algebra[ExpressionF, Expression] =
@@ -168,6 +172,8 @@ object ExpressionF {
       case URIVAL(s)                  => StringVal.URIVAL(s)
       case BLANK(s)                   => StringVal.BLANK(s)
       case BOOL(s)                    => StringVal.BOOL(s)
+      case ASC(e)                     => ConditionOrder.ASC(e)
+      case DESC(e)                    => ConditionOrder.DESC(e)
     }
 
   implicit val basis: Basis[ExpressionF, Expression] =
@@ -216,6 +222,8 @@ object ExpressionF {
         case URIVAL(s) => lit(s).pure[M]
         case BLANK(s)  => lit(s).pure[M]
         case BOOL(s)   => lit(s).pure[M]
+        case ASC(e)    => unknownFunction("ASC")
+        case DESC(e)   => unknownFunction("DESC")
       }
 
     val eval = scheme.cataM[M, ExpressionF, T, Column](algebraM)

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -7,8 +7,10 @@ import cats.{Group => _, _}
 
 import higherkindness.droste.{Project => _, _}
 
-import com.gsk.kg.engine.DAG.{Order => DAGOrder, _}
+import com.gsk.kg.engine.DAG._
+import com.gsk.kg.engine.ExpressionF._
 import com.gsk.kg.engine.data.ChunkedList
+import com.gsk.kg.sparqlparser.Expression
 import com.gsk.kg.sparqlparser.StringVal.GRAPH_VARIABLE
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
 
@@ -46,7 +48,7 @@ object FindUnboundVariables {
   val findUnboundVariables: AlgebraM[ST, DAG, Set[VARIABLE]] =
     AlgebraM[ST, DAG, Set[VARIABLE]] {
       case Describe(vars, r) => (vars.toSet diff r).pure[ST]
-      case Ask(r)            => Set.empty.pure[ST]
+      case Ask(r)            => Set.empty[VARIABLE].pure[ST]
       case Construct(bgp, r) =>
         val used = bgp.quads
           .flatMap(_.getVariables)
@@ -76,7 +78,7 @@ object FindUnboundVariables {
 
         State
           .modify[Set[VARIABLE]](x => x union vars)
-          .flatMap(_ => Set.empty.pure[ST])
+          .flatMap(_ => Set.empty[VARIABLE].pure[ST])
       case LeftJoin(l, r, filters) => (l union r).pure[ST]
       case Union(l, r)             => (l union r).pure[ST]
       case Filter(funcs, expr)     => expr.pure[ST]
@@ -84,8 +86,64 @@ object FindUnboundVariables {
       case Offset(offset, r)       => r.pure[ST]
       case Limit(limit, r)         => r.pure[ST]
       case Distinct(r)             => r.pure[ST]
-      case Group(vars, func, r)    => r.pure[ST]
-      case DAGOrder(conds, r)      => r.pure[ST]
-      case Noop(trace)             => Set.empty.pure[ST]
+      case Group(vars, func, r) =>
+        for {
+          declared <- State.get
+        } yield (vars.toSet diff declared) ++ r
+      case DAG.Order(conds, r) =>
+        val condVars = conds.toNes.toSortedSet
+          .foldLeft(Set.empty[VARIABLE]) { case (acc, cond) =>
+            acc ++ FindVariablesOnExpression.apply[Expression](cond)
+          }
+        for {
+          declared <- State.get
+        } yield (condVars diff declared) ++ r
+      case Noop(trace) => Set.empty[VARIABLE].pure[ST]
     }
+}
+
+object FindVariablesOnExpression {
+
+  def apply[T](t: T)(implicit T: Basis[ExpressionF, T]): Set[VARIABLE] = {
+    val algebra: Algebra[ExpressionF, Set[VARIABLE]] =
+      Algebra[ExpressionF, Set[VARIABLE]] {
+        case EQUALS(l, r)                    => l ++ r
+        case REGEX(s, pattern, flags)        => s
+        case STRENDS(s, f)                   => s
+        case STRSTARTS(s, f)                 => s
+        case GT(l, r)                        => l ++ r
+        case LT(l, r)                        => l ++ r
+        case GTE(l, r)                       => l ++ r
+        case LTE(l, r)                       => l ++ r
+        case OR(l, r)                        => l ++ r
+        case AND(l, r)                       => l ++ r
+        case NEGATE(s)                       => s
+        case URI(s)                          => s
+        case CONCAT(appendTo, append)        => appendTo ++ append
+        case STR(s)                          => s
+        case STRAFTER(s, f)                  => s
+        case ISBLANK(s)                      => s
+        case REPLACE(st, pattern, by, flags) => st
+        case COUNT(e)                        => e
+        case SUM(e)                          => e
+        case MIN(e)                          => e
+        case MAX(e)                          => e
+        case AVG(e)                          => e
+        case SAMPLE(e)                       => e
+        case GROUP_CONCAT(e, separator)      => e
+        case STRING(s, _)                    => Set.empty[VARIABLE]
+        case NUM(s)                          => Set.empty[VARIABLE]
+        case ExpressionF.VARIABLE(s)         => Set(VARIABLE(s))
+        case URIVAL(s)                       => Set.empty[VARIABLE]
+        case BLANK(s)                        => Set.empty[VARIABLE]
+        case BOOL(s)                         => Set.empty[VARIABLE]
+        case ASC(e)                          => e
+        case DESC(e)                         => e
+      }
+
+    val eval =
+      scheme.cata[ExpressionF, T, Set[VARIABLE]](algebra)
+
+    eval(t)
+  }
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -163,7 +163,8 @@ object ToTree extends LowPriorityToTreeInstances0 {
           case ExpressionF.URIVAL(s)   => Leaf(s"URIVAL($s)")
           case ExpressionF.BLANK(s)    => Leaf(s"BLANK($s)")
           case ExpressionF.BOOL(s)     => Leaf(s"BOOL($s)")
-
+          case ExpressionF.ASC(e)      => Node(s"ASC", Stream(e))
+          case ExpressionF.DESC(e)     => Node(s"DESC", Stream(e))
         }
 
         val t = scheme.cata(alg)

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/CompilerSpec.scala
@@ -1075,9 +1075,8 @@ class CompilerSpec
               |SELECT  ?name
               |WHERE   {
               |   ?x foaf:name ?name .
-              |   FILTER (isBlank(?x) && isURI(?x))
+              |   FILTER(isBlank(?x) && isURI(?x))
               |}
-              |
               |""".stripMargin
 
           val result = Compiler.compile(df, query, config)

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/analyzer/AnalyzerSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/analyzer/AnalyzerSpec.scala
@@ -74,6 +74,61 @@ class AnalyzerSpec
       )
   }
 
+  it should "find unbound variables when variable in ORDER BY not declared in WHERE clause" in {
+    val q =
+      """
+        |PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+        |
+        |SELECT ?name
+        |WHERE { ?x foaf:name ?name ; foaf:age ?age }
+        |ORDER BY DESC(?name) ?age DESC(?age) ASC(?names) DESC((isBlank(?x) || isBlank(?age)))
+        |""".stripMargin
+
+    val parsed: Either[EngineError, (Query, Graphs)] = parse(q, config)
+    parsed
+      .flatMap { case (query, _) =>
+        val dag = DAG.fromQuery.apply(query)
+        Analyzer.analyze.apply(dag).runA(config, null)
+      }
+      .fold(
+        { error =>
+          error shouldEqual EngineError.AnalyzerError(
+            NonEmptyChain(
+              "found free variables VARIABLE(?names)"
+            )
+          )
+        },
+        _ => fail
+      )
+  }
+
+  it should "find unbound variables when variable in GROUP BY not declared in WHERE clause" in {
+    val q =
+      """
+        |SELECT ?c SUM(?b)
+        |WHERE {
+        | ?a ?b <http://uri.com/object>
+        |} GROUP BY ?c
+        |""".stripMargin
+
+    val parsed: Either[EngineError, (Query, Graphs)] = parse(q, config)
+    parsed
+      .flatMap { case (query, _) =>
+        val dag = DAG.fromQuery.apply(query)
+        Analyzer.analyze.apply(dag).runA(config, null)
+      }
+      .fold(
+        { error =>
+          error shouldEqual EngineError.AnalyzerError(
+            NonEmptyChain(
+              "found free variables VARIABLE(?c)"
+            )
+          )
+        },
+        _ => fail
+      )
+  }
+
   it should "find bound variables even when they're bound as part of expressions" in {
     val q =
       """

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -6,6 +6,12 @@ import cats.kernel.Order
   */
 sealed trait Expression
 
+object Expression {
+  implicit def order[T <: Expression]: Order[T] = new cats.Order[T] {
+    override def compare(x: T, y: T): Int = -1
+  }
+}
+
 sealed trait Conditional extends Expression
 
 object Conditional {
@@ -94,8 +100,4 @@ sealed trait ConditionOrder extends Expression
 object ConditionOrder {
   final case class ASC(e: Expression)  extends ConditionOrder
   final case class DESC(e: Expression) extends ConditionOrder
-
-  implicit val order: Order[ConditionOrder] = new cats.Order[ConditionOrder] {
-    override def compare(x: ConditionOrder, y: ConditionOrder): Int = -1
-  }
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -1,5 +1,7 @@
 package com.gsk.kg.sparqlparser
 
+import cats.kernel.Order
+
 /** @see Model after [[https://www.w3.org/TR/sparql11-query/#rExpression]]
   */
 sealed trait Expression
@@ -92,4 +94,8 @@ sealed trait ConditionOrder extends Expression
 object ConditionOrder {
   final case class ASC(e: Expression)  extends ConditionOrder
   final case class DESC(e: Expression) extends ConditionOrder
+
+  implicit val order: Order[ConditionOrder] = new cats.Order[ConditionOrder] {
+    override def compare(x: ConditionOrder, y: ConditionOrder): Int = -1
+  }
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -1,16 +1,8 @@
 package com.gsk.kg.sparqlparser
 
-import cats.kernel.Order
-
 /** @see Model after [[https://www.w3.org/TR/sparql11-query/#rExpression]]
   */
 sealed trait Expression
-
-object Expression {
-  implicit def order[T <: Expression]: Order[T] = new cats.Order[T] {
-    override def compare(x: T, y: T): Int = -1
-  }
-}
 
 sealed trait Conditional extends Expression
 


### PR DESCRIPTION
This PR adds static analysis support for unbounded variables on GROUP BY, ORDER BY and FILTER. 
When some variables on statement conditions are not defined in the WHERE or BGPs clauses, then it fails with an error.

Closes #313 