### PR TITLE
remove duplicates from Construct

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -360,6 +360,7 @@ object Engine {
           Row.fromSeq(fields)
         }
       }
+      .distinct()
 
     Multiset(
       Set.empty,


### PR DESCRIPTION
This PR eliminates duplicate BGPs from CONSTRUCT queries.

This is congruent with Apache Jena that they also remove duplicates.

Closes #321 