### PR TITLE
fix uri function

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -245,14 +245,14 @@ object Func {
     * | IRI("http://example/") | <http://example/> |
     * | IRI(<http://example/>) | <http://example/> |
     *
-    * TODO(pepegar): We need to check if it's feasible to validate
-    * that values in the columns are URI formatted.
-    *
     * @param col
     * @return
     */
   def iri(col: Column): Column =
-    col
+    when(
+      col.startsWith("<") && col.endsWith(">"),
+      col
+    ).otherwise(format_string("<%s>", col))
 
   /** synonym for [[Func.iri]]
     *

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
@@ -325,8 +325,8 @@ class FuncSpec
       ).toDF("text")
 
       df.select(Func.iri(df("text")).as("result")).collect shouldEqual Array(
-        Row("http://google.com"),
-        Row("http://other.com")
+        Row("<http://google.com>"),
+        Row("<http://other.com>")
       )
     }
   }


### PR DESCRIPTION
Since uris didn't need to contain angle brackets before, this function
was just a simple identity.  Now we're actually checking if the
received value is a angle bracket wrapped uri, or if it's a string
that needs to be wrapped.

Closes #337