### PR TITLE
make FindUnboundVariables find unbound vars in nested queries

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -130,6 +130,8 @@ object FindVariablesOnExpression {
         case MAX(e)                          => e
         case AVG(e)                          => e
         case SAMPLE(e)                       => e
+        case LCASE(e)                        => e
+        case UCASE(e)                        => e
         case GROUP_CONCAT(e, separator)      => e
         case STRING(s)                       => Set.empty[VARIABLE]
         case DT_STRING(s, tag)               => Set.empty[VARIABLE]


### PR DESCRIPTION
In this PR I needed to change the implementation of FindUnboundVariables.  the reason for that is that previously we were using a State monad for containing the declared vars, but that's not correct.  It's not correct because a piece of a query `a` may declare a variable and put it in the state, and a piece `b` may find it there, even if `b` shouldn't find that var in their lexical scope.

The approach we're following now is to have a simple cata that carries two values in a tuple, the declared variables, and the unbound variables.

closes #234