### PR TITLE
Add support values with no undef on table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,5 +203,8 @@ $RECYCLE.BIN/
 #vim
 *.swp
 
+#metals
+.metals
+
 sonatype.sbt
 .vscode

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -13,11 +13,11 @@ import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.RelationalGroupedDataset
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Row => SparkRow}
 
 import com.gsk.kg.config.Config
 import com.gsk.kg.engine.data.ChunkedList
@@ -26,6 +26,7 @@ import com.gsk.kg.engine.functions.FuncAgg
 import com.gsk.kg.sparqlparser.ConditionOrder.ASC
 import com.gsk.kg.sparqlparser.ConditionOrder.DESC
 import com.gsk.kg.sparqlparser.Expr.Quad
+import com.gsk.kg.sparqlparser.Expr.Row
 import com.gsk.kg.sparqlparser.Expression
 import com.gsk.kg.sparqlparser.StringVal
 import com.gsk.kg.sparqlparser.StringVal._
@@ -55,6 +56,7 @@ object Engine {
       case DAG.Distinct(r)             => evaluateDistinct(r)
       case DAG.Group(vars, func, r)    => evaluateGroup(vars, func, r)
       case DAG.Order(conds, r)         => evaluateOrder(conds, r)
+      case DAG.Table(vars, rows)       => evaluateTable(vars, rows)
       case DAG.Noop(str)               => notImplemented("Noop")
     }
 
@@ -93,7 +95,7 @@ object Engine {
     } yield dataFrame
   }
 
-  implicit val spoEncoder: Encoder[Row] = RowEncoder(
+  implicit val spoEncoder: Encoder[SparkRow] = RowEncoder(
     StructType(
       List(
         StructField("s", StringType),
@@ -365,7 +367,7 @@ object Engine {
             .sortBy(_._2)
             .map(_._1)
 
-          Row.fromSeq(fields)
+          SparkRow.fromSeq(fields)
         }
       }
       .distinct()
@@ -388,6 +390,37 @@ object Engine {
       }
     }
   }
+
+  private def evaluateTable(
+      vars: List[VARIABLE],
+      rows: List[Row]
+  )(implicit sc: SQLContext): M[Multiset] = {
+    import scala.collection.JavaConverters._
+
+    def parseRow(totalVars: Seq[VARIABLE], row: Row): SparkRow = {
+      SparkRow.fromSeq(totalVars.foldLeft(Seq.empty[String]) { case (acc, v) =>
+        val parsed = row.tuples
+          .groupBy(_._1.s)
+          .mapValues(_.map(_._2.s))
+          .getOrElse(v.s, Seq(null)) // scalastyle:ignore
+        acc ++ parsed
+      } :+ "")
+    }
+
+    val sparkRows = rows.map(r => parseRow(vars, r))
+    val schema = StructType(
+      vars
+        .map(name => StructField(name.s, StringType, true)) :+
+        StructField(GRAPH_VARIABLE.s, StringType, false)
+    )
+
+    val df = sc.sparkSession.createDataFrame(sparkRows.asJava, schema)
+
+    Multiset(
+      bindings = (vars :+ VARIABLE(GRAPH_VARIABLE.s)).toSet,
+      dataframe = df
+    )
+  }.pure[M]
 
   private def notImplemented(constructor: String): M[Multiset] =
     M.liftF[Result, Config, Log, DataFrame, Multiset](

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -395,7 +395,6 @@ object Engine {
       vars: List[VARIABLE],
       rows: List[Row]
   )(implicit sc: SQLContext): M[Multiset] = {
-    import scala.collection.JavaConverters._
 
     def parseRow(totalVars: Seq[VARIABLE], row: Row): SparkRow = {
       SparkRow.fromSeq(totalVars.foldLeft(Seq.empty[String]) { case (acc, v) =>
@@ -414,7 +413,10 @@ object Engine {
         StructField(GRAPH_VARIABLE.s, StringType, false)
     )
 
-    val df = sc.sparkSession.createDataFrame(sparkRows.asJava, schema)
+    val df = sc.sparkSession.createDataFrame(
+      sc.sparkContext.parallelize(sparkRows),
+      schema
+    )
 
     Multiset(
       bindings = (vars :+ VARIABLE(GRAPH_VARIABLE.s)).toSet,

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -98,6 +98,8 @@ object FindUnboundVariables {
           }
 
         (declared, (condVars diff declared) ++ unbound)
+      case Table(vars, rows) =>
+        (vars.toSet, Set.empty)
       case Noop(trace) =>
         (Set.empty, Set.empty)
     }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -105,7 +105,12 @@ object ToTree extends LowPriorityToTreeInstances0 {
           case DAG.Order(conds, r) =>
             Node("Order", conds.map(_.toTree).toList.toStream #::: Stream(r))
           case DAG.Distinct(r) => Node("Distinct", Stream(r))
-          case DAG.Noop(str)   => Leaf(s"Noop($str)")
+          case DAG.Table(vars, rows) =>
+            val v: List[Expression] = vars
+            val rs: List[List[(Expression, Expression)]] =
+              rows.map(_.tuples.toList)
+            Node("Table", Stream(v.toTree, rs.toTree))
+          case DAG.Noop(str) => Leaf(s"Noop($str)")
         }
 
         val t = scheme.cata(alg)

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
@@ -166,6 +166,7 @@ object GraphsPushdown {
             graphsOrList => DAG.groupR(vars, func, r(graphsOrList))
           case DAG.Order(variable, r) =>
             graphsOrList => DAG.orderR(variable, r(graphsOrList))
+          case DAG.Table(vars, rows)  => _ => DAG.tableR(vars, rows)
           case DAG.Noop(graphsOrList) => _ => DAG.noopR(graphsOrList)
         }
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/SubqueryPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/SubqueryPushdown.scala
@@ -203,7 +203,8 @@ object SubqueryPushdown {
           isFromSubquery => DAG.groupR(vars, func, r(isFromSubquery))
         case DAG.Order(variable, r) =>
           isFromSubquery => DAG.orderR(variable, r(isFromSubquery))
-        case DAG.Noop(s) => _ => DAG.noopR(s)
+        case DAG.Table(vars, rows) => _ => DAG.tableR(vars, rows)
+        case DAG.Noop(s)           => _ => DAG.noopR(s)
       }
 
     val eval = scheme.cata(alg)

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ValuesSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ValuesSpec.scala
@@ -1,10 +1,12 @@
 package com.gsk.kg.engine.compiler
 
-import com.gsk.kg.engine.Compiler
-import com.gsk.kg.sparqlparser.TestConfig
-import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -19,6 +21,56 @@ class ValuesSpec
   "perform VALUES queries" should {
 
     "execute and obtain expected results" when {
+
+      "only values with no other clauses" in {
+
+        val df: DataFrame = List(
+          (
+            "<http://example.org/book/book1>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "SPARQL Tutorial"
+          ),
+          (
+            "<http://example.org/book/book1>",
+            "<http://example.org/ns#price>",
+            "42"
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "The Semantic Web"
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://example.org/ns#price>",
+            "23"
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX dc:   <http://purl.org/dc/elements/1.1/> 
+            |PREFIX :     <http://example.org/book/> 
+            |PREFIX ns:   <http://example.org/ns#>
+            |
+            |SELECT ?book ?title
+            |{
+            |   VALUES (?book ?title)
+            |   { (UNDEF "SPARQL Tutorial")
+            |     (:book2 UNDEF)
+            |   }
+            |}
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 2
+        result.right.get.collect.toSet shouldEqual Set(
+          Row(null, "\"SPARQL Tutorial\""),
+          Row("<http://example.org/book/book2>", null)
+        )
+      }
 
       "single variable on clause" in {
 
@@ -64,11 +116,65 @@ class ValuesSpec
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 1
         result.right.get.collect.toSet shouldEqual Set(
-          Row("<http://example.org/book/book1>", "SPARQL Tutorial", "42")
+          Row("<http://example.org/book/book1>", "\"SPARQL Tutorial\"", "42")
         )
       }
 
       "multiple variables on clause" in {
+
+        val df: DataFrame = List(
+          (
+            "<http://example.org/book/book1>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "SPARQL Tutorial"
+          ),
+          (
+            "<http://example.org/book/book1>",
+            "<http://example.org/ns#price>",
+            "42"
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "The Semantic Web"
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://example.org/ns#price>",
+            "23"
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX dc:   <http://purl.org/dc/elements/1.1/> 
+            |PREFIX :     <http://example.org/book/> 
+            |PREFIX ns:   <http://example.org/ns#> 
+            |
+            |SELECT ?book ?title ?price
+            |{
+            |   ?book dc:title ?title ;
+            |         ns:price ?price .
+            |   VALUES (?book ?title)
+            |   { (:book1 "SPARQL Tutorial")
+            |     (:book2 "The Semantic Web")
+            |   }
+            |}
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 2
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("<http://example.org/book/book1>", "\"SPARQL Tutorial\"", "42"),
+          Row("<http://example.org/book/book2>", "\"The Semantic Web\"", "23")
+        )
+      }
+
+      // TODO: Un-ignore when UNDEF supported
+      // See: https://github.com/gsk-aiops/bellman/issues/390
+      "multiple variables on clause and UNDEF values" ignore {
 
         val df: DataFrame = List(
           (
@@ -115,8 +221,8 @@ class ValuesSpec
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
         result.right.get.collect.toSet shouldEqual Set(
-          Row("<http://example.org/book/book1>", "SPARQL Tutorial", "42"),
-          Row("<http://example.org/book/book2>", "The Semantic Web", "23")
+          Row("<http://example.org/book/book1>", "\"SPARQL Tutorial\"", "42"),
+          Row("<http://example.org/book/book2>", "\"The Semantic Web\"", "23")
         )
       }
 
@@ -157,8 +263,8 @@ class ValuesSpec
             |         ns:price ?price .
             |}
             |VALUES (?book ?title)
-            |{ (UNDEF "SPARQL Tutorial")
-            |  (:book2 UNDEF)
+            |{ (:book1 "SPARQL Tutorial")
+            |  (:book2 "The Semantic Web")
             |}
             |""".stripMargin
 
@@ -167,8 +273,8 @@ class ValuesSpec
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
         result.right.get.collect.toSet shouldEqual Set(
-          Row("<http://example.org/book/book1>", "SPARQL Tutorial", "42"),
-          Row("<http://example.org/book/book2>", "The Semantic Web", "23")
+          Row("<http://example.org/book/book1>", "\"SPARQL Tutorial\"", "42"),
+          Row("<http://example.org/book/book2>", "\"The Semantic Web\"", "23")
         )
       }
     }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ValuesSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ValuesSpec.scala
@@ -31,7 +31,7 @@ class ValuesSpec
           (
             "<http://example.org/book/book1>",
             "<http://example.org/ns#price>",
-            42
+            "42"
           ),
           (
             "<http://example.org/book/book2>",
@@ -41,7 +41,7 @@ class ValuesSpec
           (
             "<http://example.org/book/book2>",
             "<http://example.org/ns#price>",
-            23
+            "23"
           )
         ).toDF("s", "p", "o")
 
@@ -79,7 +79,7 @@ class ValuesSpec
           (
             "<http://example.org/book/book1>",
             "<http://example.org/ns#price>",
-            42
+            "42"
           ),
           (
             "<http://example.org/book/book2>",
@@ -89,7 +89,7 @@ class ValuesSpec
           (
             "<http://example.org/book/book2>",
             "<http://example.org/ns#price>",
-            23
+            "23"
           )
         ).toDF("s", "p", "o")
 
@@ -131,7 +131,7 @@ class ValuesSpec
           (
             "<http://example.org/book/book1>",
             "<http://example.org/ns#price>",
-            42
+            "42"
           ),
           (
             "<http://example.org/book/book2>",
@@ -141,7 +141,7 @@ class ValuesSpec
           (
             "<http://example.org/book/book2>",
             "<http://example.org/ns#price>",
-            23
+            "23"
           )
         ).toDF("s", "p", "o")
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ValuesSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ValuesSpec.scala
@@ -1,0 +1,176 @@
+package com.gsk.kg.engine.compiler
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ValuesSpec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  "perform VALUES queries" should {
+
+    "execute and obtain expected results" when {
+
+      "single variable on clause" in {
+
+        val df: DataFrame = List(
+          (
+            "<http://example.org/book/book1>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "SPARQL Tutorial"
+          ),
+          (
+            "<http://example.org/book/book1>",
+            "<http://example.org/ns#price>",
+            42
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "The Semantic Web"
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://example.org/ns#price>",
+            23
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX dc:   <http://purl.org/dc/elements/1.1/> 
+            |PREFIX :     <http://example.org/book/> 
+            |PREFIX ns:   <http://example.org/ns#> 
+            |
+            |SELECT ?book ?title ?price
+            |{
+            |   VALUES ?book { :book1 :book3 }
+            |   ?book dc:title ?title ;
+            |         ns:price ?price .
+            |}
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 1
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("<http://example.org/book/book1>", "SPARQL Tutorial", "42")
+        )
+      }
+
+      "multiple variables on clause" in {
+
+        val df: DataFrame = List(
+          (
+            "<http://example.org/book/book1>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "SPARQL Tutorial"
+          ),
+          (
+            "<http://example.org/book/book1>",
+            "<http://example.org/ns#price>",
+            42
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "The Semantic Web"
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://example.org/ns#price>",
+            23
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX dc:   <http://purl.org/dc/elements/1.1/> 
+            |PREFIX :     <http://example.org/book/> 
+            |PREFIX ns:   <http://example.org/ns#> 
+            |
+            |SELECT ?book ?title ?price
+            |{
+            |   ?book dc:title ?title ;
+            |         ns:price ?price .
+            |   VALUES (?book ?title)
+            |   { (UNDEF "SPARQL Tutorial")
+            |     (:book2 UNDEF)
+            |   }
+            |}
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 2
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("<http://example.org/book/book1>", "SPARQL Tutorial", "42"),
+          Row("<http://example.org/book/book2>", "The Semantic Web", "23")
+        )
+      }
+
+      "performed over SELECT statement results" in {
+
+        val df: DataFrame = List(
+          (
+            "<http://example.org/book/book1>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "SPARQL Tutorial"
+          ),
+          (
+            "<http://example.org/book/book1>",
+            "<http://example.org/ns#price>",
+            42
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "The Semantic Web"
+          ),
+          (
+            "<http://example.org/book/book2>",
+            "<http://example.org/ns#price>",
+            23
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX dc:   <http://purl.org/dc/elements/1.1/> 
+            |PREFIX :     <http://example.org/book/> 
+            |PREFIX ns:   <http://example.org/ns#> 
+            |
+            |SELECT ?book ?title ?price
+            |{
+            |   ?book dc:title ?title ;
+            |         ns:price ?price .
+            |}
+            |VALUES (?book ?title)
+            |{ (UNDEF "SPARQL Tutorial")
+            |  (:book2 UNDEF)
+            |}
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 2
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("<http://example.org/book/book1>", "SPARQL Tutorial", "42"),
+          Row("<http://example.org/book/book2>", "The Semantic Web", "23")
+        )
+      }
+    }
+  }
+}

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -109,7 +109,7 @@ object Expr {
   final case class Order(conds: Seq[ConditionOrder], r: Expr) extends Expr
   final case class Distinct(r: Expr)                          extends Expr
   final case class Table(vars: Seq[VARIABLE], rows: Seq[Row]) extends Expr
-  final case class Row(tuples: Seq[(VARIABLE, Expression)])   extends Expr
+  final case class Row(tuples: Seq[(VARIABLE, StringVal)])    extends Expr
   final case class OpNil()                                    extends Expr
   final case class TabUnit()                                  extends Expr
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -108,6 +108,8 @@ object Expr {
   )                                                           extends Expr
   final case class Order(conds: Seq[ConditionOrder], r: Expr) extends Expr
   final case class Distinct(r: Expr)                          extends Expr
+  final case class Table(vars: Seq[VARIABLE], rows: Seq[Row]) extends Expr
+  final case class Row(tuples: Seq[(VARIABLE, Expression)])   extends Expr
   final case class OpNil()                                    extends Expr
   final case class TabUnit()                                  extends Expr
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -3,6 +3,7 @@ package com.gsk.kg.sparqlparser
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.StringVal.GRAPH_VARIABLE
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+
 import fastparse.MultiLineWhitespace._
 import fastparse._
 
@@ -144,13 +145,13 @@ object ExprParser {
     Order(p._1, p._2)
   }
 
-  def tupleParen[_: P]: P[(VARIABLE, Expression)] = P(
-    "[" ~ StringValParser.variable ~ ExpressionParser.parser ~ "]"
+  def tupleParen[_: P]: P[(VARIABLE, StringVal)] = P(
+    "[" ~ StringValParser.variable ~ StringValParser.tripleValParser ~ "]"
   )
 
   def rowParen[_: P]: P[Row] = P(
     "(" ~ row ~ tupleParen.rep(0) ~ ")"
-  ).map(r => Row(r))
+  ).map(Row)
 
   def tableParen[_: P]: P[Table] = P(
     "(" ~ table ~ "(" ~ vars ~ StringValParser.variable.rep(0) ~ ")" ~ rowParen

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringValParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringValParser.scala
@@ -46,7 +46,7 @@ object StringValParser {
       VARIABLE(str.replace(".", ""))
     )
   def urival[_: P]: P[URIVAL] =
-    iri.map(URIVAL)
+    iri.map(x => URIVAL(x))
   def num[_: P]: P[NUM] =
     P("-".? ~ CharsWhileIn("0-9") ~ ("." ~ CharsWhileIn("0-9")).?).!.map {
       NUM

--- a/modules/parser/src/test/resources/queries/q44-values-simple-variable.sparql
+++ b/modules/parser/src/test/resources/queries/q44-values-simple-variable.sparql
@@ -1,0 +1,10 @@
+PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+PREFIX :     <http://example.org/book/>
+PREFIX ns:   <http://example.org/ns#>
+
+SELECT ?book ?title ?price
+{
+   VALUES ?book { :book1 :book3 }
+   ?book dc:title ?title ;
+         ns:price ?price .
+}

--- a/modules/parser/src/test/resources/queries/q45-values-multiple-variables.sparql
+++ b/modules/parser/src/test/resources/queries/q45-values-multiple-variables.sparql
@@ -1,0 +1,13 @@
+PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+PREFIX :     <http://example.org/book/>
+PREFIX ns:   <http://example.org/ns#>
+
+SELECT ?book ?title ?price
+{
+   ?book dc:title ?title ;
+         ns:price ?price .
+   VALUES (?book ?title)
+   { (UNDEF "SPARQL Tutorial")
+     (:book2 UNDEF)
+   }
+}

--- a/modules/parser/src/test/resources/queries/q46-values-multiple-values-rows.sparql
+++ b/modules/parser/src/test/resources/queries/q46-values-multiple-values-rows.sparql
@@ -1,0 +1,13 @@
+PREFIX dc:   <http://purl.org/dc/elements/1.1/>
+PREFIX :     <http://example.org/book/>
+PREFIX ns:   <http://example.org/ns#>
+
+SELECT ?book ?title ?price
+{
+   ?book dc:title ?title ;
+         ns:price ?price .
+   VALUES (?book ?title)
+   { (:book1 "SPARQL Tutorial")
+     (:book2 "The Semantic Web")
+   }
+}

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
@@ -612,6 +612,172 @@ class ExprParserSpec extends AnyFlatSpec with TestUtils {
     }
   }
 
+  "Values" should "return proper type when simple variable" in {
+
+    val p = fastparse.parse(
+      sparql2Algebra(
+        "/queries/q44-values-simple-variable.sparql"
+      ),
+      ExprParser.parser(_)
+    )
+
+    p.get.value match {
+      case Project(
+            Seq(VARIABLE("?book"), VARIABLE("?title"), VARIABLE("?price")),
+            Join(
+              Table(
+                Seq(VARIABLE("?book")),
+                Seq(
+                  Row(
+                    Seq(
+                      (
+                        VARIABLE("?book"),
+                        URIVAL("<http://example.org/book/book1>")
+                      )
+                    )
+                  ),
+                  Row(
+                    Seq(
+                      (
+                        VARIABLE("?book"),
+                        URIVAL("<http://example.org/book/book3>")
+                      )
+                    )
+                  )
+                )
+              ),
+              BGP(
+                Seq(
+                  Quad(
+                    VARIABLE("?book"),
+                    URIVAL("<http://purl.org/dc/elements/1.1/title>"),
+                    VARIABLE("?title"),
+                    List(GRAPH_VARIABLE)
+                  ),
+                  Quad(
+                    VARIABLE("?book"),
+                    URIVAL("<http://example.org/ns#price>"),
+                    VARIABLE("?price"),
+                    List(GRAPH_VARIABLE)
+                  )
+                )
+              )
+            )
+          ) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  it should "return proper type when multiple variables" in {
+
+    val p = fastparse.parse(
+      sparql2Algebra(
+        "/queries/q45-values-multiple-variables.sparql"
+      ),
+      ExprParser.parser(_)
+    )
+
+    p.get.value match {
+      case Project(
+            Seq(VARIABLE("?book"), VARIABLE("?title"), VARIABLE("?price")),
+            Join(
+              BGP(
+                Seq(
+                  Quad(
+                    VARIABLE("?book"),
+                    URIVAL("<http://purl.org/dc/elements/1.1/title>"),
+                    VARIABLE("?title"),
+                    List(GRAPH_VARIABLE)
+                  ),
+                  Quad(
+                    VARIABLE("?book"),
+                    URIVAL("<http://example.org/ns#price>"),
+                    VARIABLE("?price"),
+                    List(GRAPH_VARIABLE)
+                  )
+                )
+              ),
+              Table(
+                Seq(VARIABLE("?book"), VARIABLE("?title")),
+                Seq(
+                  Row(Seq((VARIABLE("?title"), STRING("SPARQL Tutorial")))),
+                  Row(
+                    Seq(
+                      (
+                        VARIABLE("?book"),
+                        URIVAL("<http://example.org/book/book2>")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          ) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  it should "return proper type when multiple values on rows" in {
+
+    val p = fastparse.parse(
+      sparql2Algebra(
+        "/queries/q46-values-multiple-values-rows.sparql"
+      ),
+      ExprParser.parser(_)
+    )
+
+    p.get.value match {
+      case Project(
+            Seq(VARIABLE("?book"), VARIABLE("?title"), VARIABLE("?price")),
+            Join(
+              BGP(
+                Seq(
+                  Quad(
+                    VARIABLE("?book"),
+                    URIVAL("<http://purl.org/dc/elements/1.1/title>"),
+                    VARIABLE("?title"),
+                    List(GRAPH_VARIABLE)
+                  ),
+                  Quad(
+                    VARIABLE("?book"),
+                    URIVAL("<http://example.org/ns#price>"),
+                    VARIABLE("?price"),
+                    List(GRAPH_VARIABLE)
+                  )
+                )
+              ),
+              Table(
+                Seq(VARIABLE("?book"), VARIABLE("?title")),
+                Seq(
+                  Row(
+                    Seq(
+                      (VARIABLE("?title"), STRING("SPARQL Tutorial")),
+                      (
+                        VARIABLE("?book"),
+                        URIVAL("<http://example.org/book/book1>")
+                      )
+                    )
+                  ),
+                  Row(
+                    Seq(
+                      (VARIABLE("?title"), STRING("The Semantic Web")),
+                      (
+                        VARIABLE("?book"),
+                        URIVAL("<http://example.org/book/book2>")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          ) =>
+        succeed
+      case _ => fail
+    }
+  }
+
   /*Below are where assertions are beginning to get complex. The assumption is that previous tests appropriately exercise the parser
   combinator functions. Reading expected results from file instead of explicitly defining inline.
    */


### PR DESCRIPTION
This PR adds support for VALUES statement on queries that allows to set inline data.

I does not support UNDEF on VALUES table. See https://github.com/gsk-aiops/bellman/issues/390

Closes #227 