### PR TITLE
Support for langmatches

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -34,20 +34,21 @@ object ExpressionF {
   final case class STRBEFORE[A](s: A, f: String) extends ExpressionF[A]
   final case class SUBSTR[A](s: A, pos: Int, len: Option[Int])
       extends ExpressionF[A]
-  final case class STRLEN[A](s: A)       extends ExpressionF[A]
-  final case class EQUALS[A](l: A, r: A) extends ExpressionF[A]
-  final case class GT[A](l: A, r: A)     extends ExpressionF[A]
-  final case class LT[A](l: A, r: A)     extends ExpressionF[A]
-  final case class GTE[A](l: A, r: A)    extends ExpressionF[A]
-  final case class LTE[A](l: A, r: A)    extends ExpressionF[A]
-  final case class OR[A](l: A, r: A)     extends ExpressionF[A]
-  final case class AND[A](l: A, r: A)    extends ExpressionF[A]
-  final case class NEGATE[A](s: A)       extends ExpressionF[A]
-  final case class URI[A](s: A)          extends ExpressionF[A]
-  final case class LANG[A](s: A)         extends ExpressionF[A]
-  final case class LCASE[A](s: A)        extends ExpressionF[A]
-  final case class UCASE[A](s: A)        extends ExpressionF[A]
-  final case class ISLITERAL[A](s: A)    extends ExpressionF[A]
+  final case class STRLEN[A](s: A)                     extends ExpressionF[A]
+  final case class EQUALS[A](l: A, r: A)               extends ExpressionF[A]
+  final case class GT[A](l: A, r: A)                   extends ExpressionF[A]
+  final case class LT[A](l: A, r: A)                   extends ExpressionF[A]
+  final case class GTE[A](l: A, r: A)                  extends ExpressionF[A]
+  final case class LTE[A](l: A, r: A)                  extends ExpressionF[A]
+  final case class OR[A](l: A, r: A)                   extends ExpressionF[A]
+  final case class AND[A](l: A, r: A)                  extends ExpressionF[A]
+  final case class NEGATE[A](s: A)                     extends ExpressionF[A]
+  final case class URI[A](s: A)                        extends ExpressionF[A]
+  final case class LANG[A](s: A)                       extends ExpressionF[A]
+  final case class LANGMATCHES[A](s: A, range: String) extends ExpressionF[A]
+  final case class LCASE[A](s: A)                      extends ExpressionF[A]
+  final case class UCASE[A](s: A)                      extends ExpressionF[A]
+  final case class ISLITERAL[A](s: A)                  extends ExpressionF[A]
   final case class CONCAT[A](appendTo: A, append: NonEmptyList[A])
       extends ExpressionF[A]
   final case class STR[A](s: A)       extends ExpressionF[A]
@@ -85,6 +86,8 @@ object ExpressionF {
       case Conditional.NEGATE(s)    => NEGATE(s)
       case BuiltInFunc.URI(s)       => URI(s)
       case BuiltInFunc.LANG(s)      => LANG(s)
+      case BuiltInFunc.LANGMATCHES(s, StringVal.STRING(range)) =>
+        LANGMATCHES(s, range)
       case BuiltInFunc.LCASE(s)     => LCASE(s)
       case BuiltInFunc.UCASE(s)     => UCASE(s)
       case BuiltInFunc.ISLITERAL(s) => ISLITERAL(s)
@@ -170,6 +173,11 @@ object ExpressionF {
         BuiltInFunc.UCASE(s.asInstanceOf[StringLike])
       case LANG(s) =>
         BuiltInFunc.LANG(s.asInstanceOf[StringLike])
+      case LANGMATCHES(s, range) =>
+        BuiltInFunc.LANGMATCHES(
+          s.asInstanceOf[StringLike],
+          range.asInstanceOf[StringLike]
+        )
       case LCASE(s) =>
         BuiltInFunc.LCASE(s.asInstanceOf[StringLike])
       case ISLITERAL(s) =>
@@ -282,6 +290,7 @@ object ExpressionF {
         case NEGATE(s)                  => Func.negate(s).pure[M]
         case URI(s)                     => Func.iri(s).pure[M]
         case LANG(s)                    => Func.lang(s).pure[M]
+        case LANGMATCHES(s, range)      => Func.langMatches(s, range).pure[M]
         case LCASE(s)                   => Func.lcase(s).pure[M]
         case UCASE(s)                   => Func.ucase(s).pure[M]
         case ISLITERAL(s)               => Func.isLiteral(s).pure[M]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -10,9 +10,12 @@ import com.gsk.kg.engine.Func.StringFunctionUtils._
 import com.gsk.kg.engine.functions.Literals._
 
 import java.nio.charset.StandardCharsets
+import java.util.Locale
 import java.util.regex.Pattern
 
 import org.apache.commons.codec.binary.Hex
+
+import scala.collection.JavaConverters._
 
 object Func {
 
@@ -529,6 +532,27 @@ object Func {
       col.startsWith("\"") && col.contains("\"@"),
       trim(substring_index(col, "\"@", -1), "\"")
     ).otherwise(lit(""))
+
+  /** Implementation of SparQL LANGMATCHES on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-langMatches]]
+    * @param col
+    * @return
+    */
+  def langMatches(col: Column, range: String): Column = {
+    val langMatch =
+      udf((tag: String, range: String) => hasMatchingLangTag(tag, range))
+    when(col === lit("") && lit(range) === "*", lit(false))
+      .otherwise(langMatch(col, lit(range)))
+  }
+
+  private def hasMatchingLangTag(tag: String, range: String): Boolean =
+    !Locale
+      .filter(
+        Locale.LanguageRange.parse(range),
+        List(Locale.forLanguageTag(tag)).asJava
+      )
+      .isEmpty
 
   /** Implementation of SparQL LCASE on Spark dataframes.
     *

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -13,9 +13,9 @@ import java.nio.charset.StandardCharsets
 import java.util.Locale
 import java.util.regex.Pattern
 
-import org.apache.commons.codec.binary.Hex
-
 import scala.collection.JavaConverters._
+
+import org.apache.commons.codec.binary.Hex
 
 object Func {
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -542,7 +542,7 @@ object Func {
   def langMatches(col: Column, range: String): Column = {
     val langMatch =
       udf((tag: String, range: String) => hasMatchingLangTag(tag, range))
-    when(col === lit("") && lit(range) === "*", lit(false))
+    when(col === lit("") && range == "*", lit(false))
       .otherwise(langMatch(col, lit(range)))
   }
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -137,6 +137,7 @@ object FindVariablesOnExpression {
         case AVG(e)                          => e
         case SAMPLE(e)                       => e
         case LANG(e)                         => e
+        case LANGMATCHES(e, range)           => e
         case LCASE(e)                        => e
         case UCASE(e)                        => e
         case ISLITERAL(e)                    => e

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -140,7 +140,9 @@ object ToTree extends LowPriorityToTreeInstances0 {
             Node("STRENDS", Stream(s, Leaf(f.toString)))
           case ExpressionF.STRSTARTS(s, f) =>
             Node("STRSTARTS", Stream(s, Leaf(f.toString)))
-          case ExpressionF.URI(s)       => Node("URI", Stream(s))
+          case ExpressionF.URI(s) => Node("URI", Stream(s))
+          case ExpressionF.LANGMATCHES(s, range) =>
+            Node("LANGMATCHES", Stream(s, Leaf(range.toString)))
           case ExpressionF.LANG(s)      => Node("LANG", Stream(s))
           case ExpressionF.LCASE(s)     => Node("LCASE", Stream(s))
           case ExpressionF.UCASE(s)     => Node("UCASE", Stream(s))

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
@@ -2427,6 +2427,43 @@ class FuncSpec
     }
   }
 
+  "Func.langMatches" should {
+
+    "correctly apply function when used with range" in {
+      val initial = List(
+        ("fr", true),
+        ("fr-BE", true),
+        ("en", false),
+        ("", false)
+      ).toDF("tags", "expected")
+
+      val range = "FR"
+      val df =
+        initial.withColumn("result", Func.langMatches(initial("tags"), range))
+
+      df.collect.foreach { case Row(_, expected, result) =>
+        expected shouldEqual result
+      }
+    }
+
+    "correctly apply function when used with wildcard" in {
+      val initial = List(
+        ("fr", true),
+        ("fr-BE", true),
+        ("en", true),
+        ("", false)
+      ).toDF("tags", "expected")
+
+      val range = "*"
+      val df =
+        initial.withColumn("result", Func.langMatches(initial("tags"), range))
+
+      df.collect.foreach { case Row(_, expected, result) =>
+        expected shouldEqual result
+      }
+    }
+  }
+
   def toRDFDateTime(datetime: TemporalAccessor): String =
     "\"" + DateTimeFormatter
       .ofPattern("yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]")

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/LangMatchesSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/LangMatchesSpec.scala
@@ -1,0 +1,103 @@
+package com.gsk.kg.engine.compiler
+
+import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class LangMatchesSpec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  "perform langMatches function correctly" when {
+
+    "used with range" in {
+      val df = List(
+        (
+          "<http://uri.com/subject/a1>",
+          "<http://xmlns.com/foaf/0.1/title>",
+          "\"That Seventies Show\"@en"
+        ),
+        (
+          "<http://uri.com/subject/a1>",
+          "<http://xmlns.com/foaf/0.1/title>",
+          "\"Cette Série des Années Soixante-dix\"@fr"
+        ),
+        (
+          "<http://uri.com/subject/a1>",
+          "<http://xmlns.com/foaf/0.1/title>",
+          "\"Cette Série des Années Septante\"@fr-BE"
+        ),
+        (
+          "<http://uri.com/subject/a1>",
+          "<http://xmlns.com/foaf/0.1/title>",
+          "Il Buono, il Bruto, il Cattivo"
+        )
+      ).toDF("s", "p", "o")
+
+      val query =
+        """
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          SELECT ?title
+           WHERE { ?x foaf:title ?title
+                   FILTER langMatches(LANG(?title), "FR") }
+          """
+
+      val result = Compiler.compile(df, query, config)
+
+      result.right.get.collect.toSet shouldEqual Set(
+        Row("\"Cette Série des Années Soixante-dix\"@fr"),
+        Row("\"Cette Série des Années Septante\"@fr-BE")
+      )
+    }
+
+    "used with wildcard" in {
+      val df = List(
+        (
+          "<http://uri.com/subject/a1>",
+          "<http://xmlns.com/foaf/0.1/title>",
+          "\"That Seventies Show\"@en"
+        ),
+        (
+          "<http://uri.com/subject/a1>",
+          "<http://xmlns.com/foaf/0.1/title>",
+          "\"Cette Série des Années Soixante-dix\"@fr"
+        ),
+        (
+          "<http://uri.com/subject/a1>",
+          "<http://xmlns.com/foaf/0.1/title>",
+          "\"Cette Série des Années Septante\"@fr-BE"
+        ),
+        (
+          "<http://uri.com/subject/a1>",
+          "<http://xmlns.com/foaf/0.1/title>",
+          "Il Buono, il Bruto, il Cattivo"
+        )
+      ).toDF("s", "p", "o")
+
+      val query =
+        """
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          SELECT ?title
+           WHERE { ?x foaf:title ?title
+                   FILTER langMatches(LANG(?title), "*") }
+          """
+
+      val result = Compiler.compile(df, query, config)
+
+      result.right.get.collect.toSet shouldEqual Set(
+        Row("\"That Seventies Show\"@en"),
+        Row("\"Cette Série des Années Soixante-dix\"@fr"),
+        Row("\"Cette Série des Années Septante\"@fr-BE")
+      )
+    }
+  }
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/scalacheck/ExpressionArbitraries.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/scalacheck/ExpressionArbitraries.scala
@@ -54,6 +54,10 @@ trait ExpressionArbitraries extends CommonGenerators {
     (Gen
       .lzy(expressionGenerator))
       .map(BuiltInFunc.LANG(_)),
+    (
+      Gen.lzy(expressionGenerator),
+      Gen.lzy(expressionGenerator)
+    ).mapN(BuiltInFunc.LANGMATCHES(_, _)),
     (Gen
       .lzy(expressionGenerator))
       .map(BuiltInFunc.LCASE(_)),

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/BuiltInFuncParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/BuiltInFuncParser.scala
@@ -28,6 +28,7 @@ object BuiltInFuncParser {
   def isNumeric[_: P]: P[Unit]    = P("isNumeric")
   def encodeForURI[_: P]: P[Unit] = P("encode_for_uri")
   def lang[_: P]: P[Unit]         = P("lang")
+  def langMatches[_: P]: P[Unit]  = P("langMatches")
 
   def uriParen[_: P]: P[URI] =
     P("(" ~ uri ~ ExpressionParser.parser ~ ")").map(s => URI(s))
@@ -127,6 +128,12 @@ object BuiltInFuncParser {
     P("(" ~ lang ~ ExpressionParser.parser ~ ")")
       .map(f => LANG(f))
 
+  def langMatchesParen[_: P]: P[LANGMATCHES] =
+    P(
+      "(" ~ langMatches ~ ExpressionParser.parser ~ ExpressionParser.parser ~ ")"
+    )
+      .map(f => LANGMATCHES(f._1, f._2))
+
   def funcPatterns[_: P]: P[StringLike] =
     P(
       uriParen
@@ -151,6 +158,7 @@ object BuiltInFuncParser {
         | isNumericParen
         | encodeForURIParen
         | langParen
+        | langMatchesParen
     )
 //      | StringValParser.string
 //      | StringValParser.variable)

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -28,9 +28,11 @@ object BuiltInFunc {
   final case class CONCAT(
       appendTo: Expression,
       append: List[Expression]
-  )                                                        extends BuiltInFunc
-  final case class STR(s: Expression)                      extends BuiltInFunc
-  final case class LANG(s: Expression)                     extends BuiltInFunc
+  )                                    extends BuiltInFunc
+  final case class STR(s: Expression)  extends BuiltInFunc
+  final case class LANG(s: Expression) extends BuiltInFunc
+  final case class LANGMATCHES(s: Expression, range: Expression)
+      extends BuiltInFunc
   final case class LCASE(s: Expression)                    extends BuiltInFunc
   final case class UCASE(s: Expression)                    extends BuiltInFunc
   final case class ISLITERAL(s: Expression)                extends BuiltInFunc

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/BuiltInFuncParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/BuiltInFuncParserSpec.scala
@@ -312,4 +312,17 @@ class BuiltInFuncParserSpec extends AnyFlatSpec {
       case _ => fail
     }
   }
+
+  "LANGMATCHES parser" should "return LANGMATCHES type" in {
+    val p =
+      fastparse.parse(
+        """(langMatches ?d "FR")""",
+        BuiltInFuncParser.langMatchesParen(_)
+      )
+    p.get.value match {
+      case LANGMATCHES(VARIABLE("?d"), STRING("FR")) =>
+        succeed
+      case _ => fail
+    }
+  }
 }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -3,7 +3,7 @@
  <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+   <parameter name="maxFileLength"><![CDATA[1000]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">


### PR DESCRIPTION
This PR implements the SparQL function langMatches.  It uses the Java Locale package.

Closes #275 