### PR TITLE
Implement hashing functions

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -63,6 +63,11 @@ object ExpressionF {
   final case class GROUP_CONCAT[A](e: A, separator: String)
       extends ExpressionF[A]
   final case class ENCODE_FOR_URI[A](s: A)                extends ExpressionF[A]
+  final case class MD5[A](s: A)                           extends ExpressionF[A]
+  final case class SHA1[A](s: A)                          extends ExpressionF[A]
+  final case class SHA256[A](s: A)                        extends ExpressionF[A]
+  final case class SHA384[A](s: A)                        extends ExpressionF[A]
+  final case class SHA512[A](s: A)                        extends ExpressionF[A]
   final case class STRING[A](s: String)                   extends ExpressionF[A]
   final case class DT_STRING[A](s: String, tag: String)   extends ExpressionF[A]
   final case class LANG_STRING[A](s: String, tag: String) extends ExpressionF[A]
@@ -140,6 +145,11 @@ object ExpressionF {
       case BuiltInFunc.ISBLANK(s)                      => ISBLANK(s)
       case BuiltInFunc.ISNUMERIC(s)                    => ISNUMERIC(s)
       case BuiltInFunc.ENCODE_FOR_URI(s)               => ENCODE_FOR_URI(s)
+      case BuiltInFunc.MD5(s)                          => MD5(s)
+      case BuiltInFunc.SHA1(s)                         => SHA1(s)
+      case BuiltInFunc.SHA256(s)                       => SHA256(s)
+      case BuiltInFunc.SHA384(s)                       => SHA384(s)
+      case BuiltInFunc.SHA512(s)                       => SHA512(s)
       case Aggregate.COUNT(e)                          => COUNT(e)
       case Aggregate.SUM(e)                            => SUM(e)
       case Aggregate.MIN(e)                            => MIN(e)
@@ -238,6 +248,16 @@ object ExpressionF {
       case ISNUMERIC(s) => BuiltInFunc.ISNUMERIC(s.asInstanceOf[StringLike])
       case ENCODE_FOR_URI(s) =>
         BuiltInFunc.ENCODE_FOR_URI(s.asInstanceOf[StringLike])
+      case MD5(s) =>
+        BuiltInFunc.MD5(s.asInstanceOf[StringLike])
+      case SHA1(s) =>
+        BuiltInFunc.SHA1(s.asInstanceOf[StringLike])
+      case SHA256(s) =>
+        BuiltInFunc.SHA256(s.asInstanceOf[StringLike])
+      case SHA384(s) =>
+        BuiltInFunc.SHA384(s.asInstanceOf[StringLike])
+      case SHA512(s) =>
+        BuiltInFunc.SHA512(s.asInstanceOf[StringLike])
       case COUNT(e)                   => Aggregate.COUNT(e)
       case SUM(e)                     => Aggregate.SUM(e)
       case MIN(e)                     => Aggregate.MIN(e)
@@ -298,6 +318,11 @@ object ExpressionF {
         case ISBLANK(s)                 => Func.isBlank(s).pure[M]
         case ISNUMERIC(s)               => Func.isNumeric(s).pure[M]
         case ENCODE_FOR_URI(s)          => Func.encodeForURI(s).pure[M]
+        case MD5(s)                     => Func.md5(s).pure[M]
+        case SHA1(s)                    => Func.sha1(s).pure[M]
+        case SHA256(s)                  => Func.sha256(s).pure[M]
+        case SHA384(s)                  => Func.sha384(s).pure[M]
+        case SHA512(s)                  => Func.sha512(s).pure[M]
         case COUNT(e)                   => unknownFunction("COUNT")
         case SUM(e)                     => unknownFunction("SUM")
         case MIN(e)                     => unknownFunction("MIN")

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -3,9 +3,9 @@ package com.gsk.kg.engine
 import cats.data.NonEmptyList
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.{functions => sparkFunctions}
 import org.apache.spark.sql.functions.{concat => cc, _}
 import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.{functions => sparkFunctions}
 
 import com.gsk.kg.engine.Func.StringFunctionUtils._
 import com.gsk.kg.engine.functions.Literals._

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -3,7 +3,7 @@ package com.gsk.kg.engine
 import cats.data.NonEmptyList
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{concat => cc, md5 => sparkMd5, sha1 => sparkSha1, _}
+import org.apache.spark.sql.functions.{concat => cc, md5 => sparkMd5, sha1 => sparkSha1, _} // scalastyle:ignore
 import org.apache.spark.sql.types.StringType
 
 import com.gsk.kg.engine.Func.StringFunctionUtils._

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -3,6 +3,7 @@ package com.gsk.kg.engine
 import cats.data.NonEmptyList
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.{functions => sparkFunctions}
 import org.apache.spark.sql.functions.{concat => cc, _}
 import org.apache.spark.sql.types.StringType
 
@@ -360,7 +361,7 @@ object Func {
     * @return
     */
   def md5(col: Column): Column =
-    functions.md5(extractStringLiteral(col))
+    sparkFunctions.md5(extractStringLiteral(col))
 
   /** Implementation of SparQL MD5 on Spark dataframes.
     *
@@ -369,7 +370,7 @@ object Func {
     * @return
     */
   def md5(str: String): Column =
-    functions.md5(lit(extractStringLiteral(str)))
+    sparkFunctions.md5(lit(extractStringLiteral(str)))
 
   /** Implementation of SparQL SHA1 on Spark dataframes.
     *
@@ -378,7 +379,7 @@ object Func {
     * @return
     */
   def sha1(col: Column): Column =
-    functions.sha1(extractStringLiteral(col))
+    sparkFunctions.sha1(extractStringLiteral(col))
 
   /** Implementation of SparQL SHA1 on Spark dataframes.
     *
@@ -387,7 +388,7 @@ object Func {
     * @return
     */
   def sha1(str: String): Column =
-    functions.sha1(lit(extractStringLiteral(str)))
+    sparkFunctions.sha1(lit(extractStringLiteral(str)))
 
   /** Implementation of SparQL SHA256 on Spark dataframes.
     *

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -3,12 +3,7 @@ package com.gsk.kg.engine
 import cats.data.NonEmptyList
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{
-  concat => cc,
-  md5 => smd5,
-  sha1 => ssha1,
-  _
-}
+import org.apache.spark.sql.functions.{concat => cc, md5 => sparkMd5, sha1 => sparkSha1, _}
 import org.apache.spark.sql.types.StringType
 
 import com.gsk.kg.engine.Func.StringFunctionUtils._
@@ -365,7 +360,7 @@ object Func {
     * @return
     */
   def md5(col: Column): Column =
-    smd5(extractStringLiteral(col))
+    sparkMd5(extractStringLiteral(col))
 
   /** Implementation of SparQL MD5 on Spark dataframes.
     *
@@ -374,7 +369,7 @@ object Func {
     * @return
     */
   def md5(str: String): Column =
-    smd5(lit(extractStringLiteral(str)))
+    sparkMd5(lit(extractStringLiteral(str)))
 
   /** Implementation of SparQL SHA1 on Spark dataframes.
     *
@@ -383,7 +378,7 @@ object Func {
     * @return
     */
   def sha1(col: Column): Column =
-    ssha1(extractStringLiteral(col))
+    sparkSha1(extractStringLiteral(col))
 
   /** Implementation of SparQL SHA1 on Spark dataframes.
     *
@@ -392,7 +387,7 @@ object Func {
     * @return
     */
   def sha1(str: String): Column =
-    ssha1(lit(extractStringLiteral(str)))
+    sparkSha1(lit(extractStringLiteral(str)))
 
   /** Implementation of SparQL SHA256 on Spark dataframes.
     *

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -3,7 +3,7 @@ package com.gsk.kg.engine
 import cats.data.NonEmptyList
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{concat => cc, md5 => sparkMd5, sha1 => sparkSha1, _} // scalastyle:ignore
+import org.apache.spark.sql.functions.{concat => cc, _}
 import org.apache.spark.sql.types.StringType
 
 import com.gsk.kg.engine.Func.StringFunctionUtils._
@@ -360,7 +360,7 @@ object Func {
     * @return
     */
   def md5(col: Column): Column =
-    sparkMd5(extractStringLiteral(col))
+    functions.md5(extractStringLiteral(col))
 
   /** Implementation of SparQL MD5 on Spark dataframes.
     *
@@ -369,7 +369,7 @@ object Func {
     * @return
     */
   def md5(str: String): Column =
-    sparkMd5(lit(extractStringLiteral(str)))
+    functions.md5(lit(extractStringLiteral(str)))
 
   /** Implementation of SparQL SHA1 on Spark dataframes.
     *
@@ -378,7 +378,7 @@ object Func {
     * @return
     */
   def sha1(col: Column): Column =
-    sparkSha1(extractStringLiteral(col))
+    functions.sha1(extractStringLiteral(col))
 
   /** Implementation of SparQL SHA1 on Spark dataframes.
     *
@@ -387,7 +387,7 @@ object Func {
     * @return
     */
   def sha1(str: String): Column =
-    sparkSha1(lit(extractStringLiteral(str)))
+    functions.sha1(lit(extractStringLiteral(str)))
 
   /** Implementation of SparQL SHA256 on Spark dataframes.
     *

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Func.scala
@@ -3,7 +3,12 @@ package com.gsk.kg.engine
 import cats.data.NonEmptyList
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{concat => cc, _}
+import org.apache.spark.sql.functions.{
+  concat => cc,
+  md5 => smd5,
+  sha1 => ssha1,
+  _
+}
 import org.apache.spark.sql.types.StringType
 
 import com.gsk.kg.engine.Func.StringFunctionUtils._
@@ -352,6 +357,108 @@ object Func {
     */
   def strstarts(col: Column, str: String): Column =
     extractStringLiteral(col).startsWith(extractStringLiteral(str))
+
+  /** Implementation of SparQL MD5 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-md5]]
+    * @param col
+    * @return
+    */
+  def md5(col: Column): Column =
+    smd5(extractStringLiteral(col))
+
+  /** Implementation of SparQL MD5 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-md5]]
+    * @param str
+    * @return
+    */
+  def md5(str: String): Column =
+    smd5(lit(extractStringLiteral(str)))
+
+  /** Implementation of SparQL SHA1 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-sha1]]
+    * @param col
+    * @return
+    */
+  def sha1(col: Column): Column =
+    ssha1(extractStringLiteral(col))
+
+  /** Implementation of SparQL SHA1 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-sha1]]
+    * @param str
+    * @return
+    */
+  def sha1(str: String): Column =
+    ssha1(lit(extractStringLiteral(str)))
+
+  /** Implementation of SparQL SHA256 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-sha256]]
+    * @param col
+    * @return
+    */
+  def sha256(col: Column): Column = {
+    val numBits = 256
+    sha2(extractStringLiteral(col), numBits)
+  }
+
+  /** Implementation of SparQL SHA256 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-sha256]]
+    * @param str
+    * @return
+    */
+  def sha256(str: String): Column = {
+    val numBits = 256
+    sha2(lit(extractStringLiteral(str)), numBits)
+  }
+
+  /** Implementation of SparQL SHA384 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-sha384]]
+    * @param col
+    * @return
+    */
+  def sha384(col: Column): Column = {
+    val numBits = 384
+    sha2(extractStringLiteral(col), numBits)
+  }
+
+  /** Implementation of SparQL SHA384 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-sha384]]
+    * @param str
+    * @return
+    */
+  def sha384(str: String): Column = {
+    val numBits = 384
+    sha2(lit(extractStringLiteral(str)), numBits)
+  }
+
+  /** Implementation of SparQL SHA512 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-sha512]]
+    * @param col
+    * @return
+    */
+  def sha512(col: Column): Column = {
+    val numBits = 512
+    sha2(extractStringLiteral(col), numBits)
+  }
+
+  /** Implementation of SparQL SHA512 on Spark dataframes.
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-sha512]]
+    * @param str
+    * @return
+    */
+  def sha512(str: String): Column = {
+    val numBits = 512
+    sha2(lit(extractStringLiteral(str)), numBits)
+  }
 
   private def extractStringLiteral(col: Column): Column =
     when(

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -145,6 +145,11 @@ object FindVariablesOnExpression {
         case ISLITERAL(e)                    => e
         case GROUP_CONCAT(e, separator)      => e
         case ENCODE_FOR_URI(s)               => s
+        case MD5(s)                          => s
+        case SHA1(s)                         => s
+        case SHA256(s)                       => s
+        case SHA384(s)                       => s
+        case SHA512(s)                       => s
         case STRING(s)                       => Set.empty[VARIABLE]
         case DT_STRING(s, tag)               => Set.empty[VARIABLE]
         case LANG_STRING(s, tag)             => Set.empty[VARIABLE]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -179,6 +179,11 @@ object ToTree extends LowPriorityToTreeInstances0 {
             Node("GROUP_CONCAT", Stream(e, separator.toTree))
           case ExpressionF.ENCODE_FOR_URI(s) =>
             Node("ENCODE_FOR_URI", Stream(s))
+          case ExpressionF.MD5(s)    => Node("MD5", Stream(s))
+          case ExpressionF.SHA1(s)   => Node("SHA1", Stream(s))
+          case ExpressionF.SHA256(s) => Node("SHA256", Stream(s))
+          case ExpressionF.SHA384(s) => Node("SHA384", Stream(s))
+          case ExpressionF.SHA512(s) => Node("SHA512", Stream(s))
           case ExpressionF.STRING(s) =>
             Leaf(s"STRING($s)")
           case ExpressionF.DT_STRING(s, tag) =>

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/FuncSpec.scala
@@ -2462,6 +2462,104 @@ class FuncSpec
         expected shouldEqual result
       }
     }
+
+    "Func.md5" should {
+
+      "correctly return hash" in {
+        val initial = List(
+          ("abc", "900150983cd24fb0d6963f7d28e17f72"),
+          ("\"abc\"^^xsd:string", "900150983cd24fb0d6963f7d28e17f72")
+        ).toDF("input", "expected")
+
+        val df = initial.withColumn("result", Func.md5(initial("input")))
+
+        df.collect.foreach { case Row(_, expected, result) =>
+          expected shouldEqual result
+        }
+      }
+    }
+
+    "Func.sha1" should {
+
+      "correctly return hash" in {
+        val initial = List(
+          ("abc", "a9993e364706816aba3e25717850c26c9cd0d89d"),
+          ("\"abc\"^^xsd:string", "a9993e364706816aba3e25717850c26c9cd0d89d")
+        ).toDF("input", "expected")
+
+        val df = initial.withColumn("result", Func.sha1(initial("input")))
+
+        df.collect.foreach { case Row(_, expected, result) =>
+          expected shouldEqual result
+        }
+      }
+    }
+
+    "Func.sha256" should {
+
+      "correctly return hash" in {
+        val initial = List(
+          (
+            "abc",
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+          ),
+          (
+            "\"abc\"^^xsd:string",
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+          )
+        ).toDF("input", "expected")
+
+        val df = initial.withColumn("result", Func.sha256(initial("input")))
+
+        df.collect.foreach { case Row(_, expected, result) =>
+          expected shouldEqual result
+        }
+      }
+    }
+
+    "Func.sha384" should {
+
+      "correctly return hash" in {
+        val initial = List(
+          (
+            "abc",
+            "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
+          ),
+          (
+            "\"abc\"^^xsd:string",
+            "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
+          )
+        ).toDF("input", "expected")
+
+        val df = initial.withColumn("result", Func.sha384(initial("input")))
+
+        df.collect.foreach { case Row(_, expected, result) =>
+          expected shouldEqual result
+        }
+      }
+    }
+
+    "Func.sha512" should {
+
+      "correctly return hash" in {
+        val initial = List(
+          (
+            "abc",
+            "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+          ),
+          (
+            "\"abc\"^^xsd:string",
+            "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+          )
+        ).toDF("input", "expected")
+
+        val df = initial.withColumn("result", Func.sha512(initial("input")))
+
+        df.collect.foreach { case Row(_, expected, result) =>
+          expected shouldEqual result
+        }
+      }
+    }
   }
 
   def toRDFDateTime(datetime: TemporalAccessor): String =

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Md5Spec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Md5Spec.scala
@@ -1,0 +1,72 @@
+package com.gsk.kg.engine.compiler
+
+import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class Md5Spec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  /*
+   https://www.w3.org/TR/sparql11-query/#func-md5
+   MD5("abc") -> "900150983cd24fb0d6963f7d28e17f72"
+   MD5("abc"^^xsd:string) -> "900150983cd24fb0d6963f7d28e17f72"
+   */
+
+  "perform MD5 function correctly" when {
+
+    "str is simple literal" in {
+      val str      = "abc"
+      val expected = Row("\"900150983cd24fb0d6963f7d28e17f72\"")
+      val actual   = act(str)
+      actual shouldEqual expected
+    }
+
+    "str is xsd:string" in {
+      val str      = "\"abc\"^^xsd:string"
+      val expected = Row("\"900150983cd24fb0d6963f7d28e17f72\"")
+      val actual   = act(str)
+      actual shouldEqual expected
+    }
+  }
+
+  private def act(str: String): Row = {
+    val df = List(
+      (
+        "<http://uri.com/subject/#a1>",
+        "<http://xmlns.com/foaf/0.1/title>",
+        str
+      )
+    ).toDF("s", "p", "o")
+
+    val query =
+      s"""
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          CONSTRUCT {
+            ?x foaf:titleHashed ?titleHashed .
+          }
+          WHERE{
+            ?x foaf:title ?title .
+            BIND(md5(?title) as ?titleHashed) .
+          }
+          """
+
+    Compiler
+      .compile(df, query, config)
+      .right
+      .get
+      .drop("s", "p")
+      .head()
+  }
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Sha1Spec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Sha1Spec.scala
@@ -1,0 +1,72 @@
+package com.gsk.kg.engine.compiler
+
+import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class Sha1Spec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  /*
+   https://www.w3.org/TR/sparql11-query/#func-sha1
+   SHA1("abc") -> "a9993e364706816aba3e25717850c26c9cd0d89d"
+   SHA1("abc"^^xsd:string) -> "a9993e364706816aba3e25717850c26c9cd0d89d"
+   */
+
+  "perform SHA1 function correctly" when {
+
+    "str is simple literal" in {
+      val str      = "abc"
+      val expected = Row("\"a9993e364706816aba3e25717850c26c9cd0d89d\"")
+      val actual   = act(str)
+      actual shouldEqual expected
+    }
+
+    "str is xsd:string" in {
+      val str      = "\"abc\"^^xsd:string"
+      val expected = Row("\"a9993e364706816aba3e25717850c26c9cd0d89d\"")
+      val actual   = act(str)
+      actual shouldEqual expected
+    }
+  }
+
+  private def act(str: String): Row = {
+    val df = List(
+      (
+        "<http://uri.com/subject/#a1>",
+        "<http://xmlns.com/foaf/0.1/title>",
+        str
+      )
+    ).toDF("s", "p", "o")
+
+    val query =
+      s"""
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          CONSTRUCT {
+            ?x foaf:titleHashed ?titleHashed .
+          }
+          WHERE{
+            ?x foaf:title ?title .
+            BIND(sha1(?title) as ?titleHashed) .
+          }
+          """
+
+    Compiler
+      .compile(df, query, config)
+      .right
+      .get
+      .drop("s", "p")
+      .head()
+  }
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Sha256Spec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Sha256Spec.scala
@@ -1,0 +1,76 @@
+package com.gsk.kg.engine.compiler
+
+import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class Sha256Spec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  /*
+   https://www.w3.org/TR/sparql11-query/#func-sha256
+   SHA256("abc") -> "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+   SHA256("abc"^^xsd:string) -> "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+   */
+
+  "perform SHA256 function correctly" when {
+
+    "str is simple literal" in {
+      val str = "abc"
+      val expected = Row(
+        "\"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\""
+      )
+      val actual = act(str)
+      actual shouldEqual expected
+    }
+
+    "str is xsd:string" in {
+      val str = "\"abc\"^^xsd:string"
+      val expected = Row(
+        "\"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad\""
+      )
+      val actual = act(str)
+      actual shouldEqual expected
+    }
+  }
+
+  private def act(str: String): Row = {
+    val df = List(
+      (
+        "<http://uri.com/subject/#a1>",
+        "<http://xmlns.com/foaf/0.1/title>",
+        str
+      )
+    ).toDF("s", "p", "o")
+
+    val query =
+      s"""
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          CONSTRUCT {
+            ?x foaf:titleHashed ?titleHashed .
+          }
+          WHERE{
+            ?x foaf:title ?title .
+            BIND(sha256(?title) as ?titleHashed) .
+          }
+          """
+
+    Compiler
+      .compile(df, query, config)
+      .right
+      .get
+      .drop("s", "p")
+      .head()
+  }
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Sha384Spec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Sha384Spec.scala
@@ -1,0 +1,76 @@
+package com.gsk.kg.engine.compiler
+
+import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class Sha384Spec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  /*
+   https://www.w3.org/TR/sparql11-query/#func-sha384
+   SHA384("abc") -> "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
+   SHA384("abc"^^xsd:string) -> "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
+   */
+
+  "perform SHA384 function correctly" when {
+
+    "str is simple literal" in {
+      val str = "abc"
+      val expected = Row(
+        "\"cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7\""
+      )
+      val actual = act(str)
+      actual shouldEqual expected
+    }
+
+    "str is xsd:string" in {
+      val str = "\"abc\"^^xsd:string"
+      val expected = Row(
+        "\"cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7\""
+      )
+      val actual = act(str)
+      actual shouldEqual expected
+    }
+  }
+
+  private def act(str: String): Row = {
+    val df = List(
+      (
+        "<http://uri.com/subject/#a1>",
+        "<http://xmlns.com/foaf/0.1/title>",
+        str
+      )
+    ).toDF("s", "p", "o")
+
+    val query =
+      s"""
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          CONSTRUCT {
+            ?x foaf:titleHashed ?titleHashed .
+          }
+          WHERE{
+            ?x foaf:title ?title .
+            BIND(sha384(?title) as ?titleHashed) .
+          }
+          """
+
+    Compiler
+      .compile(df, query, config)
+      .right
+      .get
+      .drop("s", "p")
+      .head()
+  }
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Sha512Spec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Sha512Spec.scala
@@ -1,0 +1,76 @@
+package com.gsk.kg.engine.compiler
+
+import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class Sha512Spec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  /*
+   https://www.w3.org/TR/sparql11-query/#func-sha512
+   SHA512("abc") -> "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+   SHA512("abc"^^xsd:string) -> "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+   */
+
+  "perform SHA512 function correctly" when {
+
+    "str is simple literal" in {
+      val str = "abc"
+      val expected = Row(
+        "\"ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f\""
+      )
+      val actual = act(str)
+      actual shouldEqual expected
+    }
+
+    "str is xsd:string" in {
+      val str = "\"abc\"^^xsd:string"
+      val expected = Row(
+        "\"ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f\""
+      )
+      val actual = act(str)
+      actual shouldEqual expected
+    }
+  }
+
+  private def act(str: String): Row = {
+    val df = List(
+      (
+        "<http://uri.com/subject/#a1>",
+        "<http://xmlns.com/foaf/0.1/title>",
+        str
+      )
+    ).toDF("s", "p", "o")
+
+    val query =
+      s"""
+          PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          CONSTRUCT {
+            ?x foaf:titleHashed ?titleHashed .
+          }
+          WHERE{
+            ?x foaf:title ?title .
+            BIND(sha512(?title) as ?titleHashed) .
+          }
+          """
+
+    Compiler
+      .compile(df, query, config)
+      .right
+      .get
+      .drop("s", "p")
+      .head()
+  }
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/scalacheck/ExpressionArbitraries.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/scalacheck/ExpressionArbitraries.scala
@@ -73,7 +73,22 @@ trait ExpressionArbitraries extends CommonGenerators {
       Gen.lzy(expressionGenerator)
     ).mapN(BuiltInFunc.REPLACE(_, _, _)),
     (Gen.lzy(expressionGenerator), Gen.lzy(expressionGenerator))
-      .mapN(BuiltInFunc.REGEX(_, _))
+      .mapN(BuiltInFunc.REGEX(_, _)),
+    (Gen
+      .lzy(expressionGenerator))
+      .map(BuiltInFunc.MD5(_)),
+    (Gen
+      .lzy(expressionGenerator))
+      .map(BuiltInFunc.SHA1(_)),
+    (Gen
+      .lzy(expressionGenerator))
+      .map(BuiltInFunc.SHA256(_)),
+    (Gen
+      .lzy(expressionGenerator))
+      .map(BuiltInFunc.SHA384(_)),
+    (Gen
+      .lzy(expressionGenerator))
+      .map(BuiltInFunc.SHA512(_))
   )
 
   val conditionalGenerator: Gen[Expression] = Gen.oneOf(

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/BuiltInFuncParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/BuiltInFuncParser.scala
@@ -29,6 +29,11 @@ object BuiltInFuncParser {
   def encodeForURI[_: P]: P[Unit] = P("encode_for_uri")
   def lang[_: P]: P[Unit]         = P("lang")
   def langMatches[_: P]: P[Unit]  = P("langMatches")
+  def md5[_: P]: P[Unit]          = P("md5")
+  def sha1[_: P]: P[Unit]         = P("sha1")
+  def sha256[_: P]: P[Unit]       = P("sha256")
+  def sha384[_: P]: P[Unit]       = P("sha384")
+  def sha512[_: P]: P[Unit]       = P("sha512")
 
   def uriParen[_: P]: P[URI] =
     P("(" ~ uri ~ ExpressionParser.parser ~ ")").map(s => URI(s))
@@ -134,6 +139,26 @@ object BuiltInFuncParser {
     )
       .map(f => LANGMATCHES(f._1, f._2))
 
+  def md5Paren[_: P]: P[MD5] =
+    P("(" ~ md5 ~ ExpressionParser.parser ~ ")")
+      .map(f => MD5(f))
+
+  def sha1Paren[_: P]: P[SHA1] =
+    P("(" ~ sha1 ~ ExpressionParser.parser ~ ")")
+      .map(f => SHA1(f))
+
+  def sha256Paren[_: P]: P[SHA256] =
+    P("(" ~ sha256 ~ ExpressionParser.parser ~ ")")
+      .map(f => SHA256(f))
+
+  def sha384Paren[_: P]: P[SHA384] =
+    P("(" ~ sha384 ~ ExpressionParser.parser ~ ")")
+      .map(f => SHA384(f))
+
+  def sha512Paren[_: P]: P[SHA512] =
+    P("(" ~ sha512 ~ ExpressionParser.parser ~ ")")
+      .map(f => SHA512(f))
+
   def funcPatterns[_: P]: P[StringLike] =
     P(
       uriParen
@@ -159,6 +184,11 @@ object BuiltInFuncParser {
         | encodeForURIParen
         | langParen
         | langMatchesParen
+        | md5Paren
+        | sha1Paren
+        | sha256Paren
+        | sha384Paren
+        | sha512Paren
     )
 //      | StringValParser.string
 //      | StringValParser.variable)

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/BuiltInFuncParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/BuiltInFuncParser.scala
@@ -29,11 +29,11 @@ object BuiltInFuncParser {
   def encodeForURI[_: P]: P[Unit] = P("encode_for_uri")
   def lang[_: P]: P[Unit]         = P("lang")
   def langMatches[_: P]: P[Unit]  = P("langMatches")
-  def md5[_: P]: P[Unit]          = P("md5")
-  def sha1[_: P]: P[Unit]         = P("sha1")
-  def sha256[_: P]: P[Unit]       = P("sha256")
-  def sha384[_: P]: P[Unit]       = P("sha384")
-  def sha512[_: P]: P[Unit]       = P("sha512")
+  def md5[_: P]: P[Unit]          = P("md5" | "MD5")
+  def sha1[_: P]: P[Unit]         = P("sha1" | "SHA1")
+  def sha256[_: P]: P[Unit]       = P("sha256" | "SHA256")
+  def sha384[_: P]: P[Unit]       = P("sha384" | "SHA384")
+  def sha512[_: P]: P[Unit]       = P("sha512" | "SHA512")
 
   def uriParen[_: P]: P[URI] =
     P("(" ~ uri ~ ExpressionParser.parser ~ ")").map(s => URI(s))

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -50,6 +50,11 @@ object BuiltInFunc {
   final case class ISBLANK(s: Expression)        extends BuiltInFunc
   final case class ISNUMERIC(s: Expression)      extends BuiltInFunc
   final case class ENCODE_FOR_URI(s: Expression) extends BuiltInFunc
+  final case class MD5(s: Expression)            extends BuiltInFunc
+  final case class SHA1(s: Expression)           extends BuiltInFunc
+  final case class SHA256(s: Expression)         extends BuiltInFunc
+  final case class SHA384(s: Expression)         extends BuiltInFunc
+  final case class SHA512(s: Expression)         extends BuiltInFunc
   final case class REPLACE(
       st: Expression,
       pattern: Expression,

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/BuiltInFuncParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/BuiltInFuncParserSpec.scala
@@ -325,4 +325,134 @@ class BuiltInFuncParserSpec extends AnyFlatSpec {
       case _ => fail
     }
   }
+
+  "MD5 parser with variable" should "return MD5 type" in {
+    val p =
+      fastparse.parse(
+        """(md5 ?d)""",
+        BuiltInFuncParser.md5Paren(_)
+      )
+    p.get.value match {
+      case MD5(VARIABLE("?d")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "MD5 parser with string" should "return MD5 type" in {
+    val p =
+      fastparse.parse(
+        """(md5 "x")""",
+        BuiltInFuncParser.md5Paren(_)
+      )
+    p.get.value match {
+      case MD5(STRING("x")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "SHA1 parser with variable" should "return SHA1 type" in {
+    val p =
+      fastparse.parse(
+        """(sha1 ?d)""",
+        BuiltInFuncParser.sha1Paren(_)
+      )
+    p.get.value match {
+      case SHA1(VARIABLE("?d")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "SHA1 parser with string" should "return SHA1 type" in {
+    val p =
+      fastparse.parse(
+        """(sha1 "x")""",
+        BuiltInFuncParser.sha1Paren(_)
+      )
+    p.get.value match {
+      case SHA1(STRING("x")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "SHA256 parser with variable" should "return SHA256 type" in {
+    val p =
+      fastparse.parse(
+        """(sha256 ?d)""",
+        BuiltInFuncParser.sha256Paren(_)
+      )
+    p.get.value match {
+      case SHA256(VARIABLE("?d")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "SHA256 parser with string" should "return SHA256 type" in {
+    val p =
+      fastparse.parse(
+        """(sha256 "x")""",
+        BuiltInFuncParser.sha256Paren(_)
+      )
+    p.get.value match {
+      case SHA256(STRING("x")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "SHA384 parser with variable" should "return SHA384 type" in {
+    val p =
+      fastparse.parse(
+        """(sha384 ?d)""",
+        BuiltInFuncParser.sha384Paren(_)
+      )
+    p.get.value match {
+      case SHA384(VARIABLE("?d")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "SHA384 parser with string" should "return SHA384 type" in {
+    val p =
+      fastparse.parse(
+        """(sha384 "x")""",
+        BuiltInFuncParser.sha384Paren(_)
+      )
+    p.get.value match {
+      case SHA384(STRING("x")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "SHA512 parser with variable" should "return SHA512 type" in {
+    val p =
+      fastparse.parse(
+        """(sha512 ?d)""",
+        BuiltInFuncParser.sha512Paren(_)
+      )
+    p.get.value match {
+      case SHA512(VARIABLE("?d")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "SHA512 parser with string" should "return SHA512 type" in {
+    val p =
+      fastparse.parse(
+        """(sha512 "x")""",
+        BuiltInFuncParser.sha512Paren(_)
+      )
+    p.get.value match {
+      case SHA512(STRING("x")) =>
+        succeed
+      case _ => fail
+    }
+  }
 }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -80,7 +80,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
   <parameters>
-   <parameter name="maximum"><![CDATA[50]]></parameter>
+   <parameter name="maximum"><![CDATA[60]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
@@ -93,7 +93,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxLength"><![CDATA[60]]></parameter>
+   <parameter name="maxLength"><![CDATA[80]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
@@ -103,7 +103,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
   <parameters>
-   <parameter name="maxMethods"><![CDATA[50]]></parameter>
+   <parameter name="maxMethods"><![CDATA[60]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>


### PR DESCRIPTION
This PR implements the SparQL hashing functions MD5, SHA1, SHA256, SHA384, and SHA512.

Closes #290
Closes #291 
Closes #292 
Closes #293 
Closes #294