### PR TITLE
Add support in/not in

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -47,6 +47,7 @@ object ExpressionF {
   final case class OR[A](l: A, r: A)                   extends ExpressionF[A]
   final case class AND[A](l: A, r: A)                  extends ExpressionF[A]
   final case class NEGATE[A](s: A)                     extends ExpressionF[A]
+  final case class IN[A](e: A, xs: List[A])            extends ExpressionF[A]
   final case class URI[A](s: A)                        extends ExpressionF[A]
   final case class LANG[A](s: A)                       extends ExpressionF[A]
   final case class LANGMATCHES[A](s: A, range: String) extends ExpressionF[A]
@@ -93,6 +94,7 @@ object ExpressionF {
       case Conditional.OR(l, r)     => OR(l, r)
       case Conditional.AND(l, r)    => AND(l, r)
       case Conditional.NEGATE(s)    => NEGATE(s)
+      case Conditional.IN(e, xs)    => IN(e, xs)
       case BuiltInFunc.URI(s)       => URI(s)
       case BuiltInFunc.LANG(s)      => LANG(s)
       case BuiltInFunc.LANGMATCHES(s, StringVal.STRING(range)) =>
@@ -183,6 +185,7 @@ object ExpressionF {
       case OR(l, r)     => Conditional.OR(l, r)
       case AND(l, r)    => Conditional.AND(l, r)
       case NEGATE(s)    => Conditional.NEGATE(s)
+      case IN(e, xs)    => Conditional.IN(e, xs)
       case UCASE(s) =>
         BuiltInFunc.UCASE(s.asInstanceOf[StringLike])
       case LANG(s) =>
@@ -317,6 +320,7 @@ object ExpressionF {
         case OR(l, r)                   => FuncForms.or(l, r).pure[M]
         case AND(l, r)                  => FuncForms.and(l, r).pure[M]
         case NEGATE(s)                  => FuncForms.negate(s).pure[M]
+        case IN(e, xs)                  => FuncForms.in(e, xs).pure[M]
         case STR(s)                     => FuncTerms.str(s).pure[M]
         case STRDT(e, uri)              => FuncTerms.strdt(e, uri).pure[M]
         case URI(s)                     => FuncTerms.iri(s).pure[M]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -121,6 +121,7 @@ object FindVariablesOnExpression {
         case OR(l, r)                        => l ++ r
         case AND(l, r)                       => l ++ r
         case NEGATE(s)                       => s
+        case IN(e, xs)                       => e ++ xs.flatten
         case URI(s)                          => s
         case REGEX(s, pattern, flags)        => s
         case REPLACE(st, pattern, by, flags) => st

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -136,6 +136,7 @@ object ToTree extends LowPriorityToTreeInstances0 {
           case ExpressionF.OR(l, r)     => Node("OR", Stream(l, r))
           case ExpressionF.AND(l, r)    => Node("AND", Stream(l, r))
           case ExpressionF.NEGATE(s)    => Node("NEGATE", Stream(s))
+          case ExpressionF.IN(e, xs)    => Node("IN", Stream(e) #::: xs.toStream)
           case ExpressionF.REGEX(s, pattern, flags) =>
             Node(
               "REGEX",

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
@@ -1,8 +1,8 @@
 package com.gsk.kg.engine.functions
 
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.functions.not
-
 import com.gsk.kg.engine.functions.Literals.DateLiteral
 import com.gsk.kg.engine.functions.Literals.promoteNumericBoolean
 
@@ -109,5 +109,6 @@ object FuncForms {
     * @param xs
     * @return
     */
-  def in(e: Column, xs: List[Column]): Column = ???
+  def in(e: Column, xs: List[Column]): Column =
+    xs.foldLeft(lit(false)) { case (acc, x) => acc || e.contains(x) }
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
@@ -96,4 +96,18 @@ object FuncForms {
     */
   def negate(s: Column): Column =
     not(s)
+
+  /** The IN operator tests whether the RDF term on the left-hand side is found in the values of list of expressions
+    * on the right-hand side. The test is done with "=" operator, which tests for the same value, as determined by
+    * the operator mapping.
+    *
+    * A list of zero terms on the right-hand side is legal.
+    *
+    * Errors in comparisons cause the IN expression to raise an error if the RDF term being tested is not found
+    * elsewhere in the list of terms.
+    * @param e
+    * @param xs
+    * @return
+    */
+  def in(e: Column, xs: List[Column]): Column = ???
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
@@ -1,9 +1,7 @@
 package com.gsk.kg.engine.functions
 
 import org.apache.spark.sql.Column
-import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.functions.not
-import org.apache.spark.sql.functions.when
+import org.apache.spark.sql.functions._
 
 import com.gsk.kg.engine.functions.Literals.DateLiteral
 import com.gsk.kg.engine.functions.Literals.promoteNumericBoolean
@@ -111,15 +109,24 @@ object FuncForms {
     * @param xs
     * @return
     */
-  def in(e: Column, xs: List[Column]): Column =
-    xs.foldLeft(lit(false)) { case (acc, x) =>
-      acc || {
-        val xType    = x.expr.dataType
-        val castExpr = e.cast(xType)
-        when(
-          castExpr.isNotNull,
-          castExpr.contains(x)
-        ).otherwise(false)
-      }
+  def in(e: Column, xs: List[Column]): Column = {
+
+    val anyEqualsExpr = xs.foldLeft(lit(false)) { case (acc, x) =>
+      acc || (e === x)
     }
+
+    val anyIsNull = xs.foldLeft(lit(false)) { case (acc, x) =>
+      acc || x.isNull
+    }
+
+    when(
+      anyEqualsExpr,
+      lit(true)
+    ).otherwise(
+      when(
+        anyIsNull,
+        Literals.nullLiteral
+      ).otherwise(lit(false))
+    )
+  }
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/InSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/InSpec.scala
@@ -1,10 +1,12 @@
 package com.gsk.kg.engine.compiler
 
-import com.gsk.kg.engine.Compiler
-import com.gsk.kg.sparqlparser.TestConfig
-import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/InSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/InSpec.scala
@@ -1,0 +1,112 @@
+package com.gsk.kg.engine.compiler
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class InSpec
+    extends AnyWordSpec
+    with Matchers
+    with DataFrameSuiteBase
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  "perform IN query" should {
+
+    "execute and obtain expected results" when {
+
+      "simple query with IN" in {
+
+        val df: DataFrame = List(
+          (
+            "<http://example.org/Star_wars>",
+            "<http://xmlns.com/foaf/0.1/title>",
+            "\"Star Wars\"@en"
+          ),
+          (
+            "<http://example.org/Star_wars>",
+            "<http://xmlns.com/foaf/0.1/title>",
+            "\"La guerra de las galaxias\"@es"
+          ),
+          (
+            "<http://example.org/Star_wars>",
+            "<http://xmlns.com/foaf/0.1/title>",
+            "\"sterrenoorlogen\"@de"
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?title
+            |WHERE {
+            | ?film foaf:title ?title .
+            | FILTER (lang(?title) IN ("en", "es"))
+            |}
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 2
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("\"Star wars\"@en"),
+          Row("\"La guerra de las galaxias\"@es")
+        )
+      }
+    }
+  }
+
+  "perform NOT IN query" should {
+
+    "execute and obtain expected results" when {
+
+      "simple query with NOT IN" in {
+
+        val df: DataFrame = List(
+          (
+            "<http://example.org/Star_wars>",
+            "<http://xmlns.com/foaf/0.1/title>",
+            "\"Star Wars\"@en"
+          ),
+          (
+            "<http://example.org/Star_wars>",
+            "<http://xmlns.com/foaf/0.1/title>",
+            "\"La guerra de las galaxias\"@es"
+          ),
+          (
+            "<http://example.org/Star_wars>",
+            "<http://xmlns.com/foaf/0.1/title>",
+            "\"sterrenoorlogen\"@de"
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?title
+            |WHERE {
+            | ?film foaf:title ?title .
+            | FILTER (lang(?title) NOT IN ("en", "es"))
+            |}
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 1
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("\"sterrenoorlogen\"@de")
+        )
+      }
+    }
+  }
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/InSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/InSpec.scala
@@ -56,7 +56,7 @@ class InSpec
         result shouldBe a[Right[_, _]]
         result.right.get.collect.length shouldEqual 2
         result.right.get.collect.toSet shouldEqual Set(
-          Row("\"Star wars\"@en"),
+          Row("\"Star Wars\"@en"),
           Row("\"La guerra de las galaxias\"@es")
         )
       }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
@@ -1,8 +1,9 @@
 package com.gsk.kg.engine.functions
 
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions._
 
 import com.gsk.kg.engine.compiler.SparkSpec
 import com.gsk.kg.engine.scalacheck.CommonGenerators
@@ -1555,6 +1556,53 @@ class FuncFormsSpec
 
         caught.getMessage should contain
         "cannot resolve '(NOT `boolean`)' due to data type mismatch"
+      }
+    }
+
+    "FuncForms.in" should {
+
+      "return true when exists" in {
+
+        val e = lit(2)
+        val df = List(
+          (1, 2, 3)
+        ).toDF("e1", "e2", "e3")
+
+        val result =
+          df.select(FuncForms.in(e, List(df("e1"), df("e2"), df("e3")))).collect
+
+        result shouldEqual Array(
+          Row(true)
+        )
+      }
+
+      "return false when empty" in {
+
+        val e = lit(2)
+        val df = List(
+          ""
+        ).toDF("e1")
+
+        val result = df.select(FuncForms.in(e, List.empty[Column])).collect
+
+        result shouldEqual Array(
+          Row(false)
+        )
+      }
+
+      "return true when exists with mixed types" in {
+
+        val e = lit(2)
+        val df = List(
+          ("<http://example/iri>", "str", 2.0)
+        ).toDF("e1", "e2", "e3")
+
+        val result =
+          df.select(FuncForms.in(e, List(df("e1"), df("e2"), df("e3")))).collect
+
+        result shouldEqual Array(
+          Row(true)
+        )
       }
     }
   }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
@@ -1604,6 +1604,51 @@ class FuncFormsSpec
           Row(true)
         )
       }
+
+      "return true when exists and there are null expressions" in {
+
+        val e = lit(2)
+        val df = List(
+          (null, 2)
+        ).toDF("e1", "e2")
+
+        val result =
+          df.select(FuncForms.in(e, List(df("e1"), df("e2")))).collect
+
+        result shouldEqual Array(
+          Row(true)
+        )
+      }
+
+      "return true when exists and there are null expressions 2" in {
+
+        val e = lit(2)
+        val df = List(
+          (2, null)
+        ).toDF("e1", "e2")
+
+        val result =
+          df.select(FuncForms.in(e, List(df("e1"), df("e2")))).collect
+
+        result shouldEqual Array(
+          Row(true)
+        )
+      }
+
+      "return false when not exists and there are null expressions" in {
+
+        val e = lit(2)
+        val df = List(
+          (3, null)
+        ).toDF("e1", "e2")
+
+        val result =
+          df.select(FuncForms.in(e, List(df("e1"), df("e2")))).collect
+
+        result shouldEqual Array(
+          Row(null)
+        )
+      }
     }
   }
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ConditionalParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ConditionalParser.scala
@@ -15,6 +15,8 @@ object ConditionalParser {
   def and[_: P]: P[Unit]       = P("&&")
   def or[_: P]: P[Unit]        = P("||")
   def negate[_: P]: P[Unit]    = P("!")
+  def in[_: P]: P[Unit]        = P("in")
+  def notIn[_: P]: P[Unit]     = P("notin")
 
   def equalsParen[_: P]: P[EQUALS] =
     P("(" ~ equals ~ ExpressionParser.parser ~ ExpressionParser.parser ~ ")")
@@ -54,7 +56,20 @@ object ConditionalParser {
     )
 
   def negateParen[_: P]: P[NEGATE] =
-    P("(" ~ negate ~ ExpressionParser.parser ~ ")").map(NEGATE(_))
+    P("(" ~ negate ~ ExpressionParser.parser ~ ")")
+      .map(NEGATE)
+
+  def inParen[_: P]: P[IN] =
+    P("(" ~ in ~ ExpressionParser.parser ~ ExpressionParser.parser.rep(0) ~ ")")
+      .map(f => IN(f._1, f._2.toList))
+
+  def notInParen[_: P]: P[Conditional] =
+    P(
+      "(" ~ notIn ~ ExpressionParser.parser ~ ExpressionParser.parser.rep(
+        0
+      ) ~ ")"
+    )
+      .map(f => NEGATE(IN(f._1, f._2.toList)))
 
   def parser[_: P]: P[Conditional] =
     P(
@@ -67,5 +82,7 @@ object ConditionalParser {
         | andParen
         | orParen
         | negateParen
+        | inParen
+        | notInParen
     )
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -9,15 +9,15 @@ sealed trait Expression
 sealed trait Conditional extends Expression
 
 object Conditional {
-  final case class EQUALS(l: Expression, r: Expression) extends Conditional
-  final case class GT(l: Expression, r: Expression)     extends Conditional
-  final case class GTE(l: Expression, r: Expression)    extends Conditional
-  final case class LT(l: Expression, r: Expression)     extends Conditional
-  final case class LTE(l: Expression, r: Expression)    extends Conditional
-  final case class OR(l: Expression, r: Expression)     extends Conditional
-  final case class AND(l: Expression, r: Expression)    extends Conditional
-  final case class NEGATE(s: Expression)                extends Conditional
-  final case class EXISTS(pattern: Expr)                extends Conditional
+  final case class EQUALS(l: Expression, r: Expression)    extends Conditional
+  final case class GT(l: Expression, r: Expression)        extends Conditional
+  final case class GTE(l: Expression, r: Expression)       extends Conditional
+  final case class LT(l: Expression, r: Expression)        extends Conditional
+  final case class LTE(l: Expression, r: Expression)       extends Conditional
+  final case class OR(l: Expression, r: Expression)        extends Conditional
+  final case class AND(l: Expression, r: Expression)       extends Conditional
+  final case class NEGATE(s: Expression)                   extends Conditional
+  final case class IN(e: Expression, xs: List[Expression]) extends Conditional
 }
 
 sealed trait StringLike extends Expression

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ConditionalParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ConditionalParserSpec.scala
@@ -3,6 +3,7 @@ package com.gsk.kg.sparqlparser
 import com.gsk.kg.sparqlparser.BuiltInFunc.LANG
 import com.gsk.kg.sparqlparser.Conditional._
 import com.gsk.kg.sparqlparser.StringVal._
+
 import org.scalatest.flatspec.AnyFlatSpec
 
 class ConditionalParserSpec extends AnyFlatSpec {

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ConditionalParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ConditionalParserSpec.scala
@@ -1,8 +1,8 @@
 package com.gsk.kg.sparqlparser
 
+import com.gsk.kg.sparqlparser.BuiltInFunc.LANG
 import com.gsk.kg.sparqlparser.Conditional._
 import com.gsk.kg.sparqlparser.StringVal._
-
 import org.scalatest.flatspec.AnyFlatSpec
 
 class ConditionalParserSpec extends AnyFlatSpec {
@@ -60,6 +60,34 @@ class ConditionalParserSpec extends AnyFlatSpec {
     p.get.value match {
       case LTE(VARIABLE("?year"), STRING("2015")) => succeed
       case _                                      => fail
+    }
+  }
+
+  "In parser" should "return IN type" in {
+    val p =
+      fastparse.parse(
+        """(in (lang ?title) "en" "es")""",
+        ConditionalParser.inParen(_)
+      )
+    p.get.value match {
+      case IN(LANG(VARIABLE("?title")), List(STRING("en"), STRING("es"))) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "NotIn parser" should "return NEGATE(IN) type" in {
+    val p =
+      fastparse.parse(
+        """(notin (lang ?title) "en" "es")""",
+        ConditionalParser.parser(_)
+      )
+    p.get.value match {
+      case NEGATE(
+            IN(LANG(VARIABLE("?title")), List(STRING("en"), STRING("es")))
+          ) =>
+        succeed
+      case _ => fail
     }
   }
 }


### PR DESCRIPTION
This PR adds support for IN/NOT IN function. E.g:

```
PREFIX foaf: <http://xmlns.com/foaf/0.1/>

SELECT ?title
WHERE {
 ?film foaf:title ?title .
 FILTER (lang(?title) NOT IN ("en", "es"))
}
```

Closes #261 