### PR TITLE
Add support sameterm

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -48,6 +48,7 @@ object ExpressionF {
   final case class AND[A](l: A, r: A)                  extends ExpressionF[A]
   final case class NEGATE[A](s: A)                     extends ExpressionF[A]
   final case class IN[A](e: A, xs: List[A])            extends ExpressionF[A]
+  final case class SAMETERM[A](l: A, r: A)             extends ExpressionF[A]
   final case class URI[A](s: A)                        extends ExpressionF[A]
   final case class LANG[A](s: A)                       extends ExpressionF[A]
   final case class LANGMATCHES[A](s: A, range: String) extends ExpressionF[A]
@@ -86,17 +87,18 @@ object ExpressionF {
 
   val fromExpressionCoalg: Coalgebra[ExpressionF, Expression] =
     Coalgebra {
-      case Conditional.EQUALS(l, r) => EQUALS(l, r)
-      case Conditional.GT(l, r)     => GT(l, r)
-      case Conditional.LT(l, r)     => LT(l, r)
-      case Conditional.GTE(l, r)    => GTE(l, r)
-      case Conditional.LTE(l, r)    => LTE(l, r)
-      case Conditional.OR(l, r)     => OR(l, r)
-      case Conditional.AND(l, r)    => AND(l, r)
-      case Conditional.NEGATE(s)    => NEGATE(s)
-      case Conditional.IN(e, xs)    => IN(e, xs)
-      case BuiltInFunc.URI(s)       => URI(s)
-      case BuiltInFunc.LANG(s)      => LANG(s)
+      case Conditional.EQUALS(l, r)   => EQUALS(l, r)
+      case Conditional.GT(l, r)       => GT(l, r)
+      case Conditional.LT(l, r)       => LT(l, r)
+      case Conditional.GTE(l, r)      => GTE(l, r)
+      case Conditional.LTE(l, r)      => LTE(l, r)
+      case Conditional.OR(l, r)       => OR(l, r)
+      case Conditional.AND(l, r)      => AND(l, r)
+      case Conditional.NEGATE(s)      => NEGATE(s)
+      case Conditional.IN(e, xs)      => IN(e, xs)
+      case Conditional.SAMETERM(l, r) => SAMETERM(l, r)
+      case BuiltInFunc.URI(s)         => URI(s)
+      case BuiltInFunc.LANG(s)        => LANG(s)
       case BuiltInFunc.LANGMATCHES(s, StringVal.STRING(range)) =>
         LANGMATCHES(s, range)
       case BuiltInFunc.LCASE(s)     => LCASE(s)
@@ -177,15 +179,16 @@ object ExpressionF {
 
   val toExpressionAlgebra: Algebra[ExpressionF, Expression] =
     Algebra {
-      case EQUALS(l, r) => Conditional.EQUALS(l, r)
-      case GT(l, r)     => Conditional.GT(l, r)
-      case LT(l, r)     => Conditional.LT(l, r)
-      case GTE(l, r)    => Conditional.GTE(l, r)
-      case LTE(l, r)    => Conditional.LTE(l, r)
-      case OR(l, r)     => Conditional.OR(l, r)
-      case AND(l, r)    => Conditional.AND(l, r)
-      case NEGATE(s)    => Conditional.NEGATE(s)
-      case IN(e, xs)    => Conditional.IN(e, xs)
+      case EQUALS(l, r)   => Conditional.EQUALS(l, r)
+      case GT(l, r)       => Conditional.GT(l, r)
+      case LT(l, r)       => Conditional.LT(l, r)
+      case GTE(l, r)      => Conditional.GTE(l, r)
+      case LTE(l, r)      => Conditional.LTE(l, r)
+      case OR(l, r)       => Conditional.OR(l, r)
+      case AND(l, r)      => Conditional.AND(l, r)
+      case NEGATE(s)      => Conditional.NEGATE(s)
+      case IN(e, xs)      => Conditional.IN(e, xs)
+      case SAMETERM(l, r) => Conditional.SAMETERM(l, r)
       case UCASE(s) =>
         BuiltInFunc.UCASE(s.asInstanceOf[StringLike])
       case LANG(s) =>
@@ -321,6 +324,7 @@ object ExpressionF {
         case AND(l, r)                  => FuncForms.and(l, r).pure[M]
         case NEGATE(s)                  => FuncForms.negate(s).pure[M]
         case IN(e, xs)                  => FuncForms.in(e, xs).pure[M]
+        case SAMETERM(l, r)             => FuncForms.sameTerm(l, r).pure[M]
         case STR(s)                     => FuncTerms.str(s).pure[M]
         case STRDT(e, uri)              => FuncTerms.strdt(e, uri).pure[M]
         case URI(s)                     => FuncTerms.iri(s).pure[M]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Multiset.scala
@@ -44,14 +44,14 @@ final case class Multiset(
     * @param other
     * @return the join result of both multisets
     */
-  def join(other: Multiset)(implicit sc: SQLContext): Multiset =
+  def join(other: Multiset)(implicit sc: SQLContext): Multiset = {
     (this, other) match {
       case (l, r) if l.isEmpty => r
       case (l, r) if r.isEmpty => l
       case (l, r) if noCommonBindings(l, r) =>
         Multiset(
           l.bindings union r.bindings,
-          l.dataframe.crossJoin(r.dataframe)
+          l.dataframe.crossJoin(r.dataframe.drop(GRAPH_VARIABLE.s))
         )
       case (l, r) =>
         Multiset(
@@ -59,6 +59,7 @@ final case class Multiset(
           innerJoinWithGraphsColumn(l.dataframe, r.dataframe)
         )
     }
+  }
 
   /** A left join returns all values from the left relation and the matched values from the right relation,
     * or appends NULL if there is no match. It is also referred to as a left outer join.

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -122,6 +122,7 @@ object FindVariablesOnExpression {
         case AND(l, r)                       => l ++ r
         case NEGATE(s)                       => s
         case IN(e, xs)                       => e ++ xs.flatten
+        case SAMETERM(l, r)                  => l ++ r
         case URI(s)                          => s
         case REGEX(s, pattern, flags)        => s
         case REPLACE(st, pattern, by, flags) => st

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -128,15 +128,16 @@ object ToTree extends LowPriorityToTreeInstances0 {
       def toTree(tree: T): TreeRep[String] = {
         import TreeRep._
         val alg = Algebra[ExpressionF, TreeRep[String]] {
-          case ExpressionF.EQUALS(l, r) => Node("EQUALS", Stream(l, r))
-          case ExpressionF.GT(l, r)     => Node("GT", Stream(l, r))
-          case ExpressionF.LT(l, r)     => Node("LT", Stream(l, r))
-          case ExpressionF.GTE(l, r)    => Node("GTE", Stream(l, r))
-          case ExpressionF.LTE(l, r)    => Node("LTE", Stream(l, r))
-          case ExpressionF.OR(l, r)     => Node("OR", Stream(l, r))
-          case ExpressionF.AND(l, r)    => Node("AND", Stream(l, r))
-          case ExpressionF.NEGATE(s)    => Node("NEGATE", Stream(s))
-          case ExpressionF.IN(e, xs)    => Node("IN", Stream(e) #::: xs.toStream)
+          case ExpressionF.EQUALS(l, r)   => Node("EQUALS", Stream(l, r))
+          case ExpressionF.GT(l, r)       => Node("GT", Stream(l, r))
+          case ExpressionF.LT(l, r)       => Node("LT", Stream(l, r))
+          case ExpressionF.GTE(l, r)      => Node("GTE", Stream(l, r))
+          case ExpressionF.LTE(l, r)      => Node("LTE", Stream(l, r))
+          case ExpressionF.OR(l, r)       => Node("OR", Stream(l, r))
+          case ExpressionF.AND(l, r)      => Node("AND", Stream(l, r))
+          case ExpressionF.NEGATE(s)      => Node("NEGATE", Stream(s))
+          case ExpressionF.IN(e, xs)      => Node("IN", Stream(e) #::: xs.toStream)
+          case ExpressionF.SAMETERM(l, r) => Node("SAMETERM", Stream(l, r))
           case ExpressionF.REGEX(s, pattern, flags) =>
             Node(
               "REGEX",

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
@@ -127,4 +127,6 @@ object FuncForms {
       ).otherwise(lit(false))
     )
   }
+
+  def sameTerm(l: Column, r: Column): Column = ???
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
@@ -2,9 +2,7 @@ package com.gsk.kg.engine.functions
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
-
-import com.gsk.kg.engine.functions.Literals.DateLiteral
-import com.gsk.kg.engine.functions.Literals.promoteNumericBoolean
+import com.gsk.kg.engine.functions.Literals._
 
 object FuncForms {
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncForms.scala
@@ -1,8 +1,9 @@
 package com.gsk.kg.engine.functions
 
-import com.gsk.kg.engine.RdfFormatter
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
+
+import com.gsk.kg.engine.RdfFormatter
 import com.gsk.kg.engine.functions.Literals._
 
 object FuncForms {

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncStrings.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncStrings.scala
@@ -153,16 +153,16 @@ object FuncStrings {
     } else {
       when(
         isLocalizedLocalizedArgs(col, str),
-        strFuncArgsLocalizedLocalized(col, str, "%s\"@")(getLeftOrEmpty)
+        strFuncArgsLocalizedLocalized(col, str, "\"%s\"@")(getLeftOrEmpty)
       ).when(
         isLocalizedPlainArgs(col),
-        strFuncArgsLocalizedPlain(col, str, "%s\"@")(getLeftOrEmpty)
+        strFuncArgsLocalizedPlain(col, str, "\"%s\"@")(getLeftOrEmpty)
       ).when(
         isTypedTypedArgs(col, str),
-        strFuncArgsTypedTyped(col, str, "%s\"^^")(getLeftOrEmpty)
+        strFuncArgsTypedTyped(col, str, "\"%s\"^^")(getLeftOrEmpty)
       ).when(
         isTypedPlainArgs(col),
-        strFuncArgsTypedPlain(col, str, "%s\"^^")(getLeftOrEmpty)
+        strFuncArgsTypedPlain(col, str, "\"%s\"^^")(getLeftOrEmpty)
       ).otherwise(getLeftOrEmpty(col, str))
     }
   }
@@ -201,16 +201,16 @@ object FuncStrings {
     } else {
       when(
         isLocalizedLocalizedArgs(col, str),
-        strFuncArgsLocalizedLocalized(col, str, "\"%s@")(getLeftOrEmpty)
+        strFuncArgsLocalizedLocalized(col, str, "\"%s\"@")(getLeftOrEmpty)
       ).when(
         isLocalizedPlainArgs(col),
-        strFuncArgsLocalizedPlain(col, str, "\"%s@")(getLeftOrEmpty)
+        strFuncArgsLocalizedPlain(col, str, "\"%s\"@")(getLeftOrEmpty)
       ).when(
         isTypedTypedArgs(col, str),
-        strFuncArgsTypedTyped(col, str, "\"%s^^")(getLeftOrEmpty)
+        strFuncArgsTypedTyped(col, str, "\"%s\"^^")(getLeftOrEmpty)
       ).when(
         isTypedPlainArgs(col),
-        strFuncArgsTypedPlain(col, str, "\"%s^^")(getLeftOrEmpty)
+        strFuncArgsTypedPlain(col, str, "\"%s\"^^")(getLeftOrEmpty)
       ).otherwise(getLeftOrEmpty(col, str))
     }
   }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/Literals.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/Literals.scala
@@ -197,7 +197,7 @@ object Literals {
 
     def apply(c: Column): LocalizedLiteral = {
       new LocalizedLiteral(
-        substring_index(c, "@", 1),
+        trim(substring_index(c, "@", 1), "\""),
         substring_index(c, "@", -1)
       )
     }
@@ -232,7 +232,7 @@ object Literals {
 
     def apply(c: Column): TypedLiteral = {
       new TypedLiteral(
-        substring_index(c, "^^", 1),
+        trim(substring_index(c, "^^", 1), "\""),
         substring_index(c, "^^", -1)
       )
     }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/MultisetSpec.scala
@@ -147,7 +147,9 @@ class MultisetSpec extends AnyWordSpec with SparkSpec with MultisetMatchers {
       result should equalsMultiset(expectedResult)
     }
 
-    "perform a cartesian product when there's no shared bindings between multisets" in {
+    // TODO: This test if being ignore due to fix for: https://github.com/gsk-aiops/bellman/issues/357
+    // It should be un-ignore when we address this ticket: https://github.com/gsk-aiops/bellman/issues/409
+    "perform a cartesian product when there's no shared bindings between multisets" ignore {
       import sqlContext.implicits._
       val d = VARIABLE("d")
       val e = VARIABLE("e")

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/SameTermSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/SameTermSpec.scala
@@ -1,0 +1,64 @@
+package com.gsk.kg.engine.compiler
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SameTermSpec
+    extends AnyWordSpec
+    with Matchers
+    with SparkSpec
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  "perform SAMETERM query" should {
+
+    "execute and obtain expected results" when {
+
+      "simple query" in {
+
+        val df: DataFrame = List(
+          ("_:a", "<http://xmlns.com/foaf/0.1/name>", "Alice"),
+          (
+            "_:a",
+            "<http://xmlns.com/foaf/0.1/mbox>",
+            "<mailto:alice@work.example>"
+          ),
+          ("_:b", "<http://xmlns.com/foaf/0.1/name>", "Ms A."),
+          (
+            "_:b",
+            "<http://xmlns.com/foaf/0.1/mbox>",
+            "<mailto:alice@work.example>"
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+            |
+            |SELECT ?name1 ?name2
+            |WHERE { 
+            | ?x foaf:name  ?name1 ;
+            | foaf:mbox  ?mbox1 .
+            | ?y foaf:name  ?name2 ;
+            | foaf:mbox  ?mbox2 .
+            | FILTER (sameTerm(?mbox1, ?mbox2) && !sameTerm(?name1, ?name2))
+            |} 
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 2
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("\"Alice\"", "\"Ms A.\""),
+          Row("\"Ms A.\"", "\"Alice\"")
+        )
+      }
+    }
+  }
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/SameTermSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/SameTermSpec.scala
@@ -1,9 +1,11 @@
 package com.gsk.kg.engine.compiler
 
-import com.gsk.kg.engine.Compiler
-import com.gsk.kg.sparqlparser.TestConfig
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/SameTermSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/SameTermSpec.scala
@@ -61,6 +61,82 @@ class SameTermSpec
           Row("\"Ms A.\"", "\"Alice\"")
         )
       }
+
+      "simple query with non-equivalent typed literals" in {
+
+        val df: DataFrame = List(
+          (
+            "_:c1",
+            "<http://example.org/WMterms#label>",
+            "Container 1"
+          ),
+          (
+            "_:c1",
+            "<http://example.org/WMterms#weight>",
+            "\"100\"^^<http://example.org/types#kilos>"
+          ),
+          (
+            "_:c1",
+            "<http://example.org/WMterms#displacement>",
+            "\"100\"^^<http://example.org/types#liters>"
+          ),
+          (
+            "_:c2",
+            "<http://example.org/WMterms#label>",
+            "Container 2"
+          ),
+          (
+            "_:c2",
+            "<http://example.org/WMterms#weight>",
+            "\"100\"^^<http://example.org/types#kilos>"
+          ),
+          (
+            "_:c2",
+            "<http://example.org/WMterms#displacement>",
+            "\"85\"^^<http://example.org/types#liters>"
+          ),
+          (
+            "_:c3",
+            "<http://example.org/WMterms#label>",
+            "Container 3"
+          ),
+          (
+            "_:c3",
+            "<http://example.org/WMterms#weight>",
+            "\"85\"^^<http://example.org/types#kilos>"
+          ),
+          (
+            "_:c3",
+            "<http://example.org/WMterms#displacement>",
+            "\"85\"^^<http://example.org/types#liters>"
+          )
+        ).toDF("s", "p", "o")
+
+        val query =
+          """
+            |PREFIX  :      <http://example.org/WMterms#>
+            |PREFIX  t:     <http://example.org/types#>
+            |
+            |SELECT ?aLabel ?bLabel
+            |WHERE { ?a  :label        ?aLabel .
+            |        ?a  :weight       ?aWeight .
+            |        ?a  :displacement ?aDisp .
+            |
+            |        ?b  :label        ?bLabel .
+            |        ?b  :weight       ?bWeight .
+            |        ?b  :displacement ?bDisp .
+            |        FILTER ( sameTerm(?aWeight, ?bWeight) && !sameTerm(?aDisp, ?bDisp)) }
+            |""".stripMargin
+
+        val result = Compiler.compile(df, query, config)
+
+        result shouldBe a[Right[_, _]]
+        result.right.get.collect.length shouldEqual 2
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("\"Container 1\"", "\"Container 2\""),
+          Row("\"Container 2\"", "\"Container 1\"")
+        )
+      }
     }
   }
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
@@ -1,14 +1,11 @@
 package com.gsk.kg.engine.functions
 
-import com.gsk.kg.engine.RdfFormatter
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import com.gsk.kg.engine.compiler.SparkSpec
-import com.gsk.kg.engine.functions.Literals.LocalizedLiteral
 import com.gsk.kg.engine.scalacheck.CommonGenerators
-
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
@@ -1,11 +1,12 @@
 package com.gsk.kg.engine.functions
 
+import com.gsk.kg.engine.RdfFormatter
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
-
 import com.gsk.kg.engine.compiler.SparkSpec
+import com.gsk.kg.engine.functions.Literals.LocalizedLiteral
 import com.gsk.kg.engine.scalacheck.CommonGenerators
 
 import java.time.LocalDateTime
@@ -13,7 +14,6 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAccessor
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -1648,6 +1648,29 @@ class FuncFormsSpec
         result shouldEqual Array(
           Row(null)
         )
+      }
+    }
+
+    "FuncForms.sameTerm" should {
+
+      "return expected results" in {
+
+        val df = List(
+          ("\"hello\"@en", "\"hello\"@en", true),
+          ("\"hello\"@en", "hello", true),
+          ("\"hello\"@en", "\"hello\"@es", false),
+          ("\"hello\"@en", "\"hi\"@en", false),
+          ("\"1\"^^xsd:int", "\"1\"^^xsd:int", true),
+          ("\"1\"^^xsd:int", "1", true),
+          ("\"1\"^^xsd:int", "\"1\"^^xsd:integer", false),
+          ("\"1\"^^xsd:int", "\"2\"^^xsd:int", false)
+        ).toDF("expr1", "expr2", "expected")
+
+        val result =
+          df.select(FuncForms.sameTerm(df("expr1"), df("expr2"))).collect
+        val expected = df.select(df("expected")).collect()
+
+        result shouldEqual expected
       }
     }
   }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncFormsSpec.scala
@@ -3,14 +3,18 @@ package com.gsk.kg.engine.functions
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.functions._
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.lit
+
 import com.gsk.kg.engine.compiler.SparkSpec
 import com.gsk.kg.engine.scalacheck.CommonGenerators
+
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAccessor
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ConditionalParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ConditionalParser.scala
@@ -17,6 +17,7 @@ object ConditionalParser {
   def negate[_: P]: P[Unit]    = P("!")
   def in[_: P]: P[Unit]        = P("in")
   def notIn[_: P]: P[Unit]     = P("notin")
+  def sameTerm[_: P]: P[Unit]  = P("sameTerm")
 
   def equalsParen[_: P]: P[EQUALS] =
     P("(" ~ equals ~ ExpressionParser.parser ~ ExpressionParser.parser ~ ")")
@@ -71,6 +72,10 @@ object ConditionalParser {
     )
       .map(f => NEGATE(IN(f._1, f._2.toList)))
 
+  def sameTermParen[_: P]: P[SAMETERM] =
+    P("(" ~ sameTerm ~ ExpressionParser.parser ~ ExpressionParser.parser ~ ")")
+      .map(f => SAMETERM(f._1, f._2))
+
   def parser[_: P]: P[Conditional] =
     P(
       notEqualsParen
@@ -84,5 +89,6 @@ object ConditionalParser {
         | negateParen
         | inParen
         | notInParen
+        | sameTermParen
     )
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -18,6 +18,7 @@ object Conditional {
   final case class AND(l: Expression, r: Expression)       extends Conditional
   final case class NEGATE(s: Expression)                   extends Conditional
   final case class IN(e: Expression, xs: List[Expression]) extends Conditional
+  final case class SAMETERM(l: Expression, r: Expression)  extends Conditional
 }
 
 sealed trait StringLike extends Expression

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ConditionalParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ConditionalParserSpec.scala
@@ -91,4 +91,16 @@ class ConditionalParserSpec extends AnyFlatSpec {
       case _ => fail
     }
   }
+
+  "SameTerm parser" should "return SAMETERM type" in {
+    val p =
+      fastparse.parse(
+        """(sameTerm ?mbox1 ?mbox2)""",
+        ConditionalParser.parser(_)
+      )
+    p.get.value match {
+      case SAMETERM(VARIABLE("?mbox1"), VARIABLE("?mbox2")) => succeed
+      case _                                                => fail
+    }
+  }
 }

--- a/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
+++ b/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
@@ -155,6 +155,8 @@ object prelude {
       RefTree.Ref(dag, Seq(vars.refTree.toField, r.toField))
     case dag @ DAG.Order(conds, r) =>
       RefTree.Ref(dag, Seq(conds.refTree.toField, r.toField))
+    case dag @ DAG.Minus(l, r) =>
+      RefTree.Ref(dag, Seq(l.toField, r.toField))
     case dag @ DAG.Table(vars, rows) =>
       RefTree.Ref(dag, vars.map(_.refTree.toField))
     case dag @ DAG.Exists(not, p, r) =>


### PR DESCRIPTION
This PR adds support for SAMETERM function. E.g:

```
PREFIX foaf: <http://xmlns.com/foaf/0.1/>

SELECT ?name1 ?name2
WHERE { 
 ?x foaf:name  ?name1 ;
 foaf:mbox  ?mbox1 .
 ?y foaf:name  ?name2 ;
 foaf:mbox  ?mbox2 .
 FILTER (sameTerm(?mbox1, ?mbox2) && !sameTerm(?name1, ?name2))
} 
```

It also correct a bug that was causing failing some queries when some join conditions. See: https://github.com/gsk-aiops/bellman/issues/357

Closes #259 
Closes #357 