### PR TITLE
fixed quotation on plain literal already quotated

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/RdfFormatter.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/RdfFormatter.scala
@@ -68,7 +68,12 @@ object RdfFormatter {
       isNull(col),
       col.cast(DataTypes.StringType)
     ).otherwise(
-      format_string("\"%s\"", col)
+      when(
+        isQuoted(col),
+        col.cast(DataTypes.StringType)
+      ).otherwise(
+        format_string("\"%s\"", col)
+      )
     )
   }
 
@@ -100,4 +105,6 @@ object RdfFormatter {
   def isLocalizedString(column: Column): Column =
     column.contains("\"@")
 
+  def isQuoted(column: Column): Column =
+    column.startsWith("\"") && column.endsWith("\"")
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/RdfFormatterSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/RdfFormatterSpec.scala
@@ -27,6 +27,7 @@ class RdfFormatterSpec
       ("\"string\"@en", "_:blanknode", "<http://uri.com>"),
       ("\"string\"@en", "_:blanknode", "<http://uri.com>"),
       ("false", "true", "another string"),
+      ("un-quoted string", "\"quoted string\"", ""),
       ("\"false\"^^xsd:boolean", "\"true\"^^xsd:boolean", "1")
     ).toDF("s", "p", "o")
 
@@ -35,6 +36,7 @@ class RdfFormatterSpec
       ("\"string\"@en", "_:blanknode", "<http://uri.com>"),
       ("\"string\"@en", "_:blanknode", "<http://uri.com>"),
       ("false", "true", "\"another string\""),
+      ("\"un-quoted string\"", "\"quoted string\"", "\"\""),
       ("\"false\"^^xsd:boolean", "\"true\"^^xsd:boolean", "1")
     ).toDF("s", "p", "o")
 


### PR DESCRIPTION
This PR fixes quotation when plain literals are already quoted so extra double quotes won't be added.

Closes #393 