### PR TITLE
Query extractor

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -20,7 +20,10 @@ object QueryExtractor {
   final case class QueryParam(param: String, value: String)
 
   def extractInfo(q: String): (String, Map[String, List[QueryParam]]) = {
-    val (query, graphs) = QueryConstruct.parse(q, Config.default).right.get
+    val (query, graphs) = QueryConstruct.parse(q, Config.default) match {
+      case Left(a) => throw new Exception(a.toString)
+      case Right(b) => b
+    }
 
     (
       queryToString(query, graphs),
@@ -73,7 +76,7 @@ object QueryExtractor {
       case Query.Construct(vars, bgp, r) =>
         s"CONSTRUCT { ${bgp.quads.map(printQuad).mkString(" ")} }$g WHERE { ${toString(r)} }"
       case Query.Select(vars, r) =>
-        s"SELECT ${printVars(vars)} $g WHERE { ${toString(r)} }"
+        s"SELECT ${printVars(vars)}$g WHERE { ${toString(r)} }"
     }
   }
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -21,7 +21,7 @@ object QueryExtractor {
 
   def extractInfo(q: String): (String, Map[String, List[QueryParam]]) = {
     val (query, graphs) = QueryConstruct.parse(q, Config.default) match {
-      case Left(a) => throw new Exception(a.toString)
+      case Left(a)  => throw new Exception(a.toString)
       case Right(b) => b
     }
 
@@ -31,14 +31,17 @@ object QueryExtractor {
         .filterNot(_.s.isEmpty)
         .map { uriVal =>
           val uriString = uriVal.s.stripPrefix("<").stripSuffix(">")
-          val uri = new URI(uriString)
-          val params = extractQueryParams(uri)
+          val uri       = new URI(uriString)
+          val params    = extractQueryParams(uri)
 
           (getCleanUri(uriVal), params)
         }
         .toMap
     )
   }
+
+  private def isKnowledgeGraph(graphUri: String): Boolean =
+    graphUri.contains("/kg?")
 
   private def getGraphs(expr: Expr): List[StringVal] = {
     val extractGraphs: Algebra[ExprF, List[StringVal]] = Algebra {
@@ -74,16 +77,21 @@ object QueryExtractor {
 
   private def getCleanUri(uriVal: StringVal): String = {
     val uriString = uriVal.s.stripPrefix("<").stripSuffix(">")
-    val uri = new URI(uriString)
-    new URI(
-      uri.getScheme,
-      uri.getUserInfo,
-      uri.getHost,
-      uri.getPort,
-      uri.getPath,
-      null,
-      null
-    ).toString
+
+    if (isKnowledgeGraph(uriString)) {
+      ""
+    } else {
+      val uri = new URI(uriString)
+      new URI(
+        uri.getScheme,
+        uri.getUserInfo,
+        uri.getHost,
+        uri.getPort,
+        uri.getPath,
+        null,
+        null
+      ).toString
+    }
   }
 
   private def printQuad(quad: Expr.Quad): String =
@@ -92,12 +100,25 @@ object QueryExtractor {
   private def printVars(vars: Seq[VARIABLE]) =
     vars.map(_.s).mkString("", " ", ".")
 
+  private def getFromStatement(uri: StringVal, isNamed: Boolean): String = {
+    val cleanUri = getCleanUri(uri)
+
+    if (cleanUri.isEmpty) {
+      ""
+    } else if (isNamed) {
+      s"FROM NAMED <$cleanUri>"
+    } else {
+      s"FROM <$cleanUri>"
+    }
+  }
+
   private def queryToString(query: Query, graphs: Graphs): String = {
     val toString = scheme.cata(exprToString)
 
-    val g = (
-      graphs.default.filterNot(_.s.isEmpty).map(g => s"FROM <${getCleanUri(g)}>") ++ 
-      graphs.named.filterNot(_.s.isEmpty).map(g => s"FROM NAMED <${getCleanUri(g)}>"))
+    val g = (graphs.default
+      .filterNot(_.s.isEmpty)
+      .map(g => getFromStatement(g, false)) ++
+      graphs.named.filterNot(_.s.isEmpty).map(g => getFromStatement(g, true)))
       .mkString("\n", "\n", "\n")
 
     query match {
@@ -113,87 +134,95 @@ object QueryExtractor {
   }
 
   private def printExpression(expression: Expression): String =
-    scheme.cata[ExpressionF, Expression, String](expressionToString).apply(expression)
+    scheme
+      .cata[ExpressionF, Expression, String](expressionToString)
+      .apply(expression)
 
-  private val expressionToString: Algebra[ExpressionF, String] = 
+  private val expressionToString: Algebra[ExpressionF, String] =
     Algebra {
-        case REGEX(s, pattern, flags) => s"REGEX($s, $pattern, $flags)"
-        case REPLACE(st, pattern, by, flags) => s"REPLACE($st, $pattern, $by, $flags)"
-        case STRENDS(s, f) => s"STRENDS($s, $f)"
-        case STRSTARTS(s, f) => s"STRSTARTS($s, $f)"
-        case STRDT(s, uri) => s"STRDT($s, $uri)"
-        case STRAFTER(s, f) => s"""STRAFTER($s, "$f")"""
-        case STRBEFORE(s, f) => s"STRBEFORE($s, $f)"
-        case SUBSTR(s, pos, len) => s"SUBSTR($s, $pos, $len)"
-        case STRLEN(s) => s"STRLEN($s)"
-        case EQUALS(l, r) => s"EQUALS($l, $r)"
-        case GT(l, r) => s"GT($l, $r)"
-        case LT(l, r) => s"LT($l, $r)"
-        case GTE(l, r) => s"GTE($l, $r)"
-        case LTE(l, r) => s"LTE($l, $r)"
-        case OR(l, r) => s"OR($l, $r)"
-        case AND(l, r) => s"AND($l, $r)"
-        case NEGATE(s) => s"NEGATE($s)"
-        case ExpressionF.URI(s) => s"URI($s)"
-        case LANG(s) => s"LANG($s)"
-        case LANGMATCHES(s, range) => s"LANGMATCHES($s, $range)"
-        case LCASE(s) => s"LCASE($s)"
-        case UCASE(s) => s"UCASE($s)"
-        case ISLITERAL(s) => s"ISLITERAL($s)"
-        case CONCAT(appendTo, append) => s"CONCAT($appendTo, $append)"
-        case STR(s) => s"STR($s)"
-        case ISBLANK(s) => s"ISBLANK($s)"
-        case ISNUMERIC(s) => s"ISNUMERIC($s)"
-        case COUNT(e) => s"COUNT($e)"
-        case SUM(e) => s"SUM($e)"
-        case MIN(e) => s"MIN($e)"
-        case MAX(e) => s"MAX($e)"
-        case AVG(e) => s"AVG($e)"
-        case SAMPLE(e) => s"SAMPLE($e)"
-        case GROUP_CONCAT(e, separator) => s"GROUP_CONCAT($e, $separator)"
-        case ENCODE_FOR_URI(s) => s"ENCODE_FOR_URI($s)"
-        case MD5(s) => s"MD5($s)"
-        case SHA1(s) => s"SHA1($s)"
-        case SHA256(s) => s"SHA256($s)"
-        case SHA384(s) => s"SHA384($s)"
-        case SHA512(s) => s"SHA512($s)"
-        case ExpressionF.STRING(s) => s"ExpressionF.STRING($s)"
-        case ExpressionF.DT_STRING(s, tag) => s"ExpressionF.DT_STRING($s, $tag)"
-        case ExpressionF.LANG_STRING(s, tag) => s"ExpressionF.LANG_STRING($s, $tag)"
-        case ExpressionF.NUM(s) => s"ExpressionF.NUM($s)"
-        case ExpressionF.VARIABLE(s) => s
-        case ExpressionF.URIVAL(s) => s
-        case ExpressionF.BLANK(s) => s
-        case ExpressionF.BOOL(s) => s
-        case ASC(e) => s"ASC($e)"
-        case DESC(e) => s"DESC($e)"
+      case REGEX(s, pattern, flags) => s"REGEX($s, $pattern, $flags)"
+      case REPLACE(st, pattern, by, flags) =>
+        s"REPLACE($st, $pattern, $by, $flags)"
+      case STRENDS(s, f)                 => s"STRENDS($s, $f)"
+      case STRSTARTS(s, f)               => s"STRSTARTS($s, $f)"
+      case STRDT(s, uri)                 => s"STRDT($s, $uri)"
+      case STRAFTER(s, f)                => s"""STRAFTER($s, "$f")"""
+      case STRBEFORE(s, f)               => s"STRBEFORE($s, $f)"
+      case SUBSTR(s, pos, len)           => s"SUBSTR($s, $pos, $len)"
+      case STRLEN(s)                     => s"STRLEN($s)"
+      case EQUALS(l, r)                  => s"EQUALS($l, $r)"
+      case GT(l, r)                      => s"GT($l, $r)"
+      case LT(l, r)                      => s"LT($l, $r)"
+      case GTE(l, r)                     => s"GTE($l, $r)"
+      case LTE(l, r)                     => s"LTE($l, $r)"
+      case OR(l, r)                      => s"OR($l, $r)"
+      case AND(l, r)                     => s"AND($l, $r)"
+      case NEGATE(s)                     => s"NEGATE($s)"
+      case ExpressionF.URI(s)            => s"URI($s)"
+      case LANG(s)                       => s"LANG($s)"
+      case LANGMATCHES(s, range)         => s"LANGMATCHES($s, $range)"
+      case LCASE(s)                      => s"LCASE($s)"
+      case UCASE(s)                      => s"UCASE($s)"
+      case ISLITERAL(s)                  => s"ISLITERAL($s)"
+      case CONCAT(appendTo, append)      => s"CONCAT($appendTo, $append)"
+      case STR(s)                        => s"STR($s)"
+      case ISBLANK(s)                    => s"ISBLANK($s)"
+      case ISNUMERIC(s)                  => s"ISNUMERIC($s)"
+      case COUNT(e)                      => s"COUNT($e)"
+      case SUM(e)                        => s"SUM($e)"
+      case MIN(e)                        => s"MIN($e)"
+      case MAX(e)                        => s"MAX($e)"
+      case AVG(e)                        => s"AVG($e)"
+      case SAMPLE(e)                     => s"SAMPLE($e)"
+      case GROUP_CONCAT(e, separator)    => s"GROUP_CONCAT($e, $separator)"
+      case ENCODE_FOR_URI(s)             => s"ENCODE_FOR_URI($s)"
+      case MD5(s)                        => s"MD5($s)"
+      case SHA1(s)                       => s"SHA1($s)"
+      case SHA256(s)                     => s"SHA256($s)"
+      case SHA384(s)                     => s"SHA384($s)"
+      case SHA512(s)                     => s"SHA512($s)"
+      case ExpressionF.STRING(s)         => s"ExpressionF.STRING($s)"
+      case ExpressionF.DT_STRING(s, tag) => s"ExpressionF.DT_STRING($s, $tag)"
+      case ExpressionF.LANG_STRING(s, tag) =>
+        s"ExpressionF.LANG_STRING($s, $tag)"
+      case ExpressionF.NUM(s)      => s"ExpressionF.NUM($s)"
+      case ExpressionF.VARIABLE(s) => s
+      case ExpressionF.URIVAL(s)   => s
+      case ExpressionF.BLANK(s)    => s
+      case ExpressionF.BOOL(s)     => s
+      case ASC(e)                  => s"ASC($e)"
+      case DESC(e)                 => s"DESC($e)"
     }
 
   private val exprToString: Algebra[ExprF, String] =
     Algebra {
-      case ExtendF(bindTo, bindFrom, r)      => s"$r BIND(${printExpression(bindFrom)} as ${bindTo.s})"
-      case FilteredLeftJoinF(l, r, f)        => s"{ $l } OPTIONAL { $r FILTER(${f.map(printExpression).mkString(", ")}) }"
-      case UnionF(l, r)                      => s"{ $l } UNION { $r }"
-      case BGPF(quads)                       => quads.map(printQuad).mkString(" ")
-      case GraphF(g, e)                      => s"GRAPH <${getCleanUri(g)}> { $e }"
-      case JoinF(l, r)                       => s"{ $l } JOIN { $r }"
-      case LeftJoinF(l, r)                   => s"{ $l } OPTIONAL { $r }"
-      case ProjectF(vars, r)                 => r
-      case QuadF(s, p, o, g)                 => s"QuadF(s, p, o, g)"
-      case DistinctF(r)                      => s"$r DISTINCT"
-      case GroupF(vars, func, r)             => s"$r GROUP BY ${printVars(vars)}"
-      case OrderF(conds, r)                  => s"$r ORDER BY ${conds.asInstanceOf[Seq[Expression]].map(printExpression).mkString(" ")}"
+      case ExtendF(bindTo, bindFrom, r) =>
+        s"$r BIND(${printExpression(bindFrom)} as ${bindTo.s})"
+      case FilteredLeftJoinF(l, r, f) =>
+        s"{ $l } OPTIONAL { $r FILTER(${f.map(printExpression).mkString(", ")}) }"
+      case UnionF(l, r)          => s"{ $l } UNION { $r }"
+      case BGPF(quads)           => quads.map(printQuad).mkString(" ")
+      case GraphF(g, e)          => s"GRAPH <${getCleanUri(g)}> { $e }"
+      case JoinF(l, r)           => s"{ $l } JOIN { $r }"
+      case LeftJoinF(l, r)       => s"{ $l } OPTIONAL { $r }"
+      case ProjectF(vars, r)     => r
+      case QuadF(s, p, o, g)     => s"QuadF(s, p, o, g)"
+      case DistinctF(r)          => s"$r DISTINCT"
+      case GroupF(vars, func, r) => s"$r GROUP BY ${printVars(vars)}"
+      case OrderF(conds, r) =>
+        s"$r ORDER BY ${conds.asInstanceOf[Seq[Expression]].map(printExpression).mkString(" ")}"
       case OffsetLimitF(None, None, r)       => s"OffsetLimitF(None, None, r)"
       case OffsetLimitF(None, Some(l), r)    => s"OffsetLimitF(None, Some(l)"
       case OffsetLimitF(Some(o), None, r)    => s"OffsetLimitF(Some(o)"
       case OffsetLimitF(Some(o), Some(l), r) => s"OffsetLimitF(Some(o)"
-      case FilterF(funcs, expr)              => s"$expr FILTER(${funcs.map(printExpression).mkString(" ")})"
-      case TableF(vars, rows)                => s"TableF(vars, rows)"
-      case RowF(tuples)                      => s"RowF(tuples)"
-      case TabUnitF()                        => s"TabUnitF()"
-      case MinusF(l, r) => s"{ $l } MINUS { $r }"
-      case OpNilF()     => s"OpNilF()"
-      case ExistsF(not, p, r)                => 
+      case FilterF(funcs, expr) =>
+        s"$expr FILTER(${funcs.map(printExpression).mkString(" ")})"
+      case TableF(vars, rows) => s"TableF(vars, rows)"
+      case RowF(tuples)       => s"RowF(tuples)"
+      case TabUnitF()         => s"TabUnitF()"
+      case MinusF(l, r)       => s"{ $l } MINUS { $r }"
+      case OpNilF()           => s"OpNilF()"
+      case ExistsF(not, p, r) =>
         val n = if (not) "NOT" else ""
         s"$r $n EXISTS { $p }"
     }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -211,10 +211,10 @@ object QueryExtractor {
       case GroupF(vars, func, r) => s"$r GROUP BY ${printVars(vars)}"
       case OrderF(conds, r) =>
         s"$r ORDER BY ${conds.asInstanceOf[Seq[Expression]].map(printExpression).mkString(" ")}"
-      case OffsetLimitF(None, None, r)       => s"OffsetLimitF(None, None, r)"
-      case OffsetLimitF(None, Some(l), r)    => s"OffsetLimitF(None, Some(l)"
-      case OffsetLimitF(Some(o), None, r)    => s"OffsetLimitF(Some(o)"
-      case OffsetLimitF(Some(o), Some(l), r) => s"OffsetLimitF(Some(o)"
+      case OffsetLimitF(None, None, r)       => r
+      case OffsetLimitF(None, Some(l), r)    => s"$r LIMIT $l"
+      case OffsetLimitF(Some(o), None, r)    => s"$r OFFSET $o"
+      case OffsetLimitF(Some(o), Some(l), r) => s"$r OFFSET $o LIMIT $l"
       case FilterF(funcs, expr) =>
         s"$expr FILTER(${funcs.map(printExpression).mkString(" ")})"
       case TableF(vars, rows) => s"TableF(vars, rows)"

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -1,65 +1,175 @@
 package com.gsk.kg.engine
 
-import higherkindness.droste.Algebra
+import higherkindness.droste._
 
 import com.gsk.kg.config.Config
+import com.gsk.kg.engine.ExpressionF.{VARIABLE => _, _}
+import com.gsk.kg.sparqlparser.Expr
 import com.gsk.kg.sparqlparser.Expr.fixedpoint._
+import com.gsk.kg.sparqlparser.Expression
+import com.gsk.kg.sparqlparser.Query
 import com.gsk.kg.sparqlparser.QueryConstruct
+import com.gsk.kg.sparqlparser.StringVal
+import com.gsk.kg.sparqlparser.StringVal._
 
 import java.net.URI
+import com.gsk.kg.Graphs
 
 object QueryExtractor {
 
   final case class QueryParam(param: String, value: String)
 
-  def extractInfo(query: String): (String, Map[String, List[QueryParam]]) = {
-    val (_, graphs) = QueryConstruct.parse(query, Config.default).right.get
+  def extractInfo(q: String): (String, Map[String, List[QueryParam]]) = {
+    val (query, graphs) = QueryConstruct.parse(q, Config.default).right.get
 
-    ("", (graphs.default ++ graphs.named)
-      .filterNot(_.s.isEmpty)
-      .map(s => new URI(s.s.stripPrefix("<").stripSuffix(">")))
-      .map(uri => {
-        val params = extractQueryParams(uri)
-        val cleanUri = new URI(
-          uri.getScheme, uri.getUserInfo, uri.getHost, uri.getPort, uri.getPath, null, null)
+    (
+      queryToString(query, graphs),
+      (graphs.default ++ graphs.named)
+        .filterNot(_.s.isEmpty)
+        .map { uriVal =>
+          val uriString = uriVal.s.stripPrefix("<").stripSuffix(">")
+          val uri = new URI(uriString)
+          val params = extractQueryParams(uri)
 
-        (cleanUri.toString, params)
-      }) 
-      .toMap)
+          (getCleanUri(uriVal), params)
+        }
+        .toMap
+    )
   }
 
-  
+  private def getCleanUri(uriVal: StringVal): String = {
+    val uriString = uriVal.s.stripPrefix("<").stripSuffix(">")
+    val uri = new URI(uriString)
+    new URI(
+      uri.getScheme,
+      uri.getUserInfo,
+      uri.getHost,
+      uri.getPort,
+      uri.getPath,
+      null,
+      null
+    ).toString
+  }
+
+  private def printQuad(quad: Expr.Quad): String =
+    s"${quad.s.s} ${quad.p.s} ${quad.o.s} ."
+
+  private def printVars(vars: Seq[VARIABLE]) =
+    vars.map(_.s).mkString("", " ", ".")
+
+  private def queryToString(query: Query, graphs: Graphs): String = {
+    val toString = scheme.cata(exprToString)
+
+    val g = (
+      graphs.default.filterNot(_.s.isEmpty).map(g => s"FROM <${getCleanUri(g)}>") ++ 
+      graphs.named.filterNot(_.s.isEmpty).map(g => s"FROM NAMED <${getCleanUri(g)}>"))
+      .mkString("\n", "\n", "\n")
+
+    query match {
+      case Query.Describe(vars, r) =>
+        s"DESCRIBE ${printVars(vars)} $g WHERE { ${toString(r)} }"
+      case Query.Ask(r) =>
+        s"ASK $g { ${toString(r)} }"
+      case Query.Construct(vars, bgp, r) =>
+        s"CONSTRUCT { ${bgp.quads.map(printQuad).mkString(" ")} }$g WHERE { ${toString(r)} }"
+      case Query.Select(vars, r) =>
+        s"SELECT ${printVars(vars)} $g WHERE { ${toString(r)} }"
+    }
+  }
+
+  private def printExpression(expression: Expression): String =
+    scheme.cata[ExpressionF, Expression, String](expressionToString).apply(expression)
+
+  private val expressionToString: Algebra[ExpressionF, String] = 
+    Algebra {
+        case REGEX(s, pattern, flags) => s"REGEX($s, $pattern, $flags)"
+        case REPLACE(st, pattern, by, flags) => s"REPLACE($st, $pattern, $by, $flags)"
+        case STRENDS(s, f) => s"STRENDS($s, $f)"
+        case STRSTARTS(s, f) => s"STRSTARTS($s, $f)"
+        case STRDT(s, uri) => s"STRDT($s, $uri)"
+        case STRAFTER(s, f) => s"""STRAFTER($s, "$f")"""
+        case STRBEFORE(s, f) => s"STRBEFORE($s, $f)"
+        case SUBSTR(s, pos, len) => s"SUBSTR($s, $pos, $len)"
+        case STRLEN(s) => s"STRLEN($s)"
+        case EQUALS(l, r) => s"EQUALS($l, $r)"
+        case GT(l, r) => s"GT($l, $r)"
+        case LT(l, r) => s"LT($l, $r)"
+        case GTE(l, r) => s"GTE($l, $r)"
+        case LTE(l, r) => s"LTE($l, $r)"
+        case OR(l, r) => s"OR($l, $r)"
+        case AND(l, r) => s"AND($l, $r)"
+        case NEGATE(s) => s"NEGATE($s)"
+        case ExpressionF.URI(s) => s"URI($s)"
+        case LANG(s) => s"LANG($s)"
+        case LANGMATCHES(s, range) => s"LANGMATCHES($s, $range)"
+        case LCASE(s) => s"LCASE($s)"
+        case UCASE(s) => s"UCASE($s)"
+        case ISLITERAL(s) => s"ISLITERAL($s)"
+        case CONCAT(appendTo, append) => s"CONCAT($appendTo, $append)"
+        case STR(s) => s"STR($s)"
+        case ISBLANK(s) => s"ISBLANK($s)"
+        case ISNUMERIC(s) => s"ISNUMERIC($s)"
+        case COUNT(e) => s"COUNT($e)"
+        case SUM(e) => s"SUM($e)"
+        case MIN(e) => s"MIN($e)"
+        case MAX(e) => s"MAX($e)"
+        case AVG(e) => s"AVG($e)"
+        case SAMPLE(e) => s"SAMPLE($e)"
+        case GROUP_CONCAT(e, separator) => s"GROUP_CONCAT($e, $separator)"
+        case ENCODE_FOR_URI(s) => s"ENCODE_FOR_URI($s)"
+        case MD5(s) => s"MD5($s)"
+        case SHA1(s) => s"SHA1($s)"
+        case SHA256(s) => s"SHA256($s)"
+        case SHA384(s) => s"SHA384($s)"
+        case SHA512(s) => s"SHA512($s)"
+        case ExpressionF.STRING(s) => s"ExpressionF.STRING($s)"
+        case ExpressionF.DT_STRING(s, tag) => s"ExpressionF.DT_STRING($s, $tag)"
+        case ExpressionF.LANG_STRING(s, tag) => s"ExpressionF.LANG_STRING($s, $tag)"
+        case ExpressionF.NUM(s) => s"ExpressionF.NUM($s)"
+        case ExpressionF.VARIABLE(s) => s
+        case ExpressionF.URIVAL(s) => s
+        case ExpressionF.BLANK(s) => s
+        case ExpressionF.BOOL(s) => s
+        case ASC(e) => s"ASC($e)"
+        case DESC(e) => s"DESC($e)"
+    }
+
   private val exprToString: Algebra[ExprF, String] =
     Algebra {
-      case ExtendF(bindTo, bindFrom, r) => ??? 
-      case FilteredLeftJoinF(l, r, f)   => ??? 
-      case UnionF(l, r)                 => ??? 
-      case BGPF(quads)                  => ??? 
-      case OpNilF()                     => ??? 
-      case GraphF(g, e)                 => ??? 
-      case JoinF(l, r)                  => ??? 
-      case LeftJoinF(l, r)              => ??? 
-      case ProjectF(vars, r)            => ??? 
-      case QuadF(s, p, o, g)            => ??? 
-      case DistinctF(r)                 => ??? 
-      case GroupF(vars, func, r)        => ??? 
-      case OrderF(conds, r) => ???
-      case OffsetLimitF(None, None, r)       => ??? 
-      case OffsetLimitF(None, Some(l), r)    => ??? 
-      case OffsetLimitF(Some(o), None, r)    => ??? 
-      case OffsetLimitF(Some(o), Some(l), r) => ??? 
-      case FilterF(funcs, expr) => ???
-      case TableF(vars, rows) => ???
-      case RowF(tuples)       => ???
-      case TabUnitF()         => ???
-   }
+      case ExtendF(bindTo, bindFrom, r)      => s"$r BIND(${printExpression(bindFrom)} as ${bindTo.s})"
+      case FilteredLeftJoinF(l, r, f)        => s"{ $l } OPTIONAL { $r FILTER(${f.map(printExpression).mkString(", ")}) }"
+      case UnionF(l, r)                      => s"{ $l } UNION { $r }"
+      case BGPF(quads)                       => quads.map(printQuad).mkString(" ")
+      case GraphF(g, e)                      => s"GRAPH <${getCleanUri(g)}> { $e }"
+      case JoinF(l, r)                       => s"{ $l } JOIN { $r }"
+      case LeftJoinF(l, r)                   => s"{ $l } OPTIONAL { $r }"
+      case ProjectF(vars, r)                 => r
+      case QuadF(s, p, o, g)                 => s"QuadF(s, p, o, g)"
+      case DistinctF(r)                      => s"$r DISTINCT"
+      case GroupF(vars, func, r)             => s"$r GROUP BY ${printVars(vars)}"
+      case OrderF(conds, r)                  => s"$r ORDER BY ${conds.asInstanceOf[Seq[Expression]].map(printExpression).mkString(" ")}"
+      case OffsetLimitF(None, None, r)       => s"OffsetLimitF(None, None, r)"
+      case OffsetLimitF(None, Some(l), r)    => s"OffsetLimitF(None, Some(l)"
+      case OffsetLimitF(Some(o), None, r)    => s"OffsetLimitF(Some(o)"
+      case OffsetLimitF(Some(o), Some(l), r) => s"OffsetLimitF(Some(o)"
+      case FilterF(funcs, expr)              => s"$expr FILTER(${funcs.map(printExpression).mkString(" ")})"
+      case TableF(vars, rows)                => s"TableF(vars, rows)"
+      case RowF(tuples)                      => s"RowF(tuples)"
+      case TabUnitF()                        => s"TabUnitF()"
+      case MinusF(l, r) => s"{ $l } MINUS { $r }"
+      case OpNilF()     => s"OpNilF()"
+      case ExistsF(not, p, r)                => 
+        val n = if (not) "NOT" else ""
+        s"$r $n EXISTS { $p }"
+    }
 
   private def extractQueryParams(uri: URI): List[QueryParam] =
-    uri.getQuery.split("&")
-      .map(qp => {
+    uri.getQuery
+      .split("&")
+      .map { qp =>
         val Array(param, value) = qp.split("=")
         QueryParam(param, value)
-      })
+      }
       .toList
 
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -1,0 +1,65 @@
+package com.gsk.kg.engine
+
+import higherkindness.droste.Algebra
+
+import com.gsk.kg.config.Config
+import com.gsk.kg.sparqlparser.Expr.fixedpoint._
+import com.gsk.kg.sparqlparser.QueryConstruct
+
+import java.net.URI
+
+object QueryExtractor {
+
+  final case class QueryParam(param: String, value: String)
+
+  def extractInfo(query: String): (String, Map[String, List[QueryParam]]) = {
+    val (_, graphs) = QueryConstruct.parse(query, Config.default).right.get
+
+    ("", (graphs.default ++ graphs.named)
+      .filterNot(_.s.isEmpty)
+      .map(s => new URI(s.s.stripPrefix("<").stripSuffix(">")))
+      .map(uri => {
+        val params = extractQueryParams(uri)
+        val cleanUri = new URI(
+          uri.getScheme, uri.getUserInfo, uri.getHost, uri.getPort, uri.getPath, null, null)
+
+        (cleanUri.toString, params)
+      }) 
+      .toMap)
+  }
+
+  
+  private val exprToString: Algebra[ExprF, String] =
+    Algebra {
+      case ExtendF(bindTo, bindFrom, r) => ??? 
+      case FilteredLeftJoinF(l, r, f)   => ??? 
+      case UnionF(l, r)                 => ??? 
+      case BGPF(quads)                  => ??? 
+      case OpNilF()                     => ??? 
+      case GraphF(g, e)                 => ??? 
+      case JoinF(l, r)                  => ??? 
+      case LeftJoinF(l, r)              => ??? 
+      case ProjectF(vars, r)            => ??? 
+      case QuadF(s, p, o, g)            => ??? 
+      case DistinctF(r)                 => ??? 
+      case GroupF(vars, func, r)        => ??? 
+      case OrderF(conds, r) => ???
+      case OffsetLimitF(None, None, r)       => ??? 
+      case OffsetLimitF(None, Some(l), r)    => ??? 
+      case OffsetLimitF(Some(o), None, r)    => ??? 
+      case OffsetLimitF(Some(o), Some(l), r) => ??? 
+      case FilterF(funcs, expr) => ???
+      case TableF(vars, rows) => ???
+      case RowF(tuples)       => ???
+      case TabUnitF()         => ???
+   }
+
+  private def extractQueryParams(uri: URI): List[QueryParam] =
+    uri.getQuery.split("&")
+      .map(qp => {
+        val Array(param, value) = qp.split("=")
+        QueryParam(param, value)
+      })
+      .toList
+
+}

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -2,6 +2,7 @@ package com.gsk.kg.engine
 
 import higherkindness.droste._
 
+import com.gsk.kg.Graphs
 import com.gsk.kg.config.Config
 import com.gsk.kg.engine.ExpressionF.{VARIABLE => _, _}
 import com.gsk.kg.sparqlparser.Expr
@@ -13,7 +14,6 @@ import com.gsk.kg.sparqlparser.StringVal
 import com.gsk.kg.sparqlparser.StringVal._
 
 import java.net.URI
-import com.gsk.kg.Graphs
 
 object QueryExtractor {
 
@@ -88,8 +88,8 @@ object QueryExtractor {
         uri.getHost,
         uri.getPort,
         uri.getPath,
-        null,
-        null
+        null, // scalastyle:off
+        null  // scalastyle:off
       ).toString
     }
   }
@@ -231,8 +231,8 @@ object QueryExtractor {
     uri.getQuery
       .split("&")
       .map { qp =>
-        val Array(param, value) = qp.split("=")
-        QueryParam(param, value)
+        val arr = qp.split("=")
+        QueryParam(arr(0), arr(1))
       }
       .toList
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
@@ -33,6 +33,25 @@ class QueryExtractorSpec extends AnyWordSpec with Matchers {
       )
     }
 
-  }
+    "clean query from metadata in URIs" in {
+      val query = """
+        PREFIX  dm:   <http://gsk-kg.rdip.gsk.com/dm/1.0/>
+        
+        CONSTRUCT {
+           ?te dm:contains ?docid .
+        }
+        FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/kg?type=snapshot&t=20200109>
+        WHERE { 
+            ?d a dm:Document .
+            ?d dm:contains ?ds .
+            ?ds dm:contains ?te .
+            BIND(STRAFTER(str(?d), "#") as ?docid) .
+        }
+        """
 
+      QueryExtractor.extractInfo(query)._1 shouldEqual """CONSTRUCT { ?te <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?docid . }
+FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/kg>
+ WHERE { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . BIND(STRAFTER(STR(?d), "#") as ?docid) }"""
+    }
+  }
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
@@ -53,5 +53,46 @@ class QueryExtractorSpec extends AnyWordSpec with Matchers {
 FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/kg>
  WHERE { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . BIND(STRAFTER(STR(?d), "#") as ?docid) }"""
     }
+
+    "clean query with GRAPH statements" in {
+      val query = """
+        PREFIX  dm:   <http://gsk-kg.rdip.gsk.com/dm/1.0/>
+        CONSTRUCT {
+          ?te dm:contains ?docid .
+        }
+        FROM NAMED <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier?type=incremental&t=20200109>
+        FROM NAMED <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed?type=snapshot&t=20200309>
+        WHERE {
+           GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed?type=snapshot&t=20200309>
+           {
+             ?ds dm:contains ?te .
+           }
+           GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier?type=incremental&t=20200109>
+           {
+             ?d a dm:Document .
+             ?d dm:contains ?ds .
+             BIND(STRAFTER(str(?d), "#") as ?docid) .
+           }
+        }"""
+
+      val result = QueryExtractor.extractInfo(query)
+
+      result._2 shouldEqual Map(
+        "http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier" ->
+        List(
+          QueryParam("type","incremental"),
+          QueryParam("t","20200109")),
+        "http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed" ->
+        List(
+          QueryParam("type","snapshot"),
+          QueryParam("t","20200309"))
+      )
+
+
+      result._1 shouldEqual """CONSTRUCT { ?te <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?docid . }
+FROM NAMED <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier>
+FROM NAMED <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed>
+ WHERE { { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed> { ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . } } JOIN { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier> { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . BIND(STRAFTER(STR(?d), "#") as ?docid) } } }"""
+    }
   }
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
@@ -97,5 +97,39 @@ WHERE {
 
  WHERE { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . BIND(STRAFTER(STR(?d), "#") as ?docid) }"""
     }
+
+    "work correctly when more than one FROM statement appears" in {
+      val query  = """
+PREFIX  dm:   <http://gsk-kg.rdip.gsk.com/dm/1.0/>
+CONSTRUCT {
+  ?te dm:contains ?docid .
+}
+FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/ccc?type=snapshot&t=20200109>
+FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/semmed?type=snapshot&t=20200109>
+WHERE {
+   ?d a dm:Document .
+   ?d dm:contains ?ds .
+   ?ds dm:contains ?te .
+   BIND(STRAFTER(str(?d), "#") as ?docid) .
+}
+    """
+      val result = QueryExtractor.extractInfo(query)
+
+      result._2 shouldEqual Map(
+        "http://gsk-kg.rdip.gsk.com/dm/1.0/semmed" -> List(
+          QueryParam("type", "snapshot"),
+          QueryParam("t", "20200109")
+        ),
+        "http://gsk-kg.rdip.gsk.com/dm/1.0/ccc" -> List(
+          QueryParam("type", "snapshot"),
+          QueryParam("t", "20200109")
+        )
+      )
+
+      result._1 shouldEqual """CONSTRUCT { ?te <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?docid . }
+FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/ccc>
+FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/semmed>
+ WHERE { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . BIND(STRAFTER(STR(?d), "#") as ?docid) }"""
+    }
   }
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
@@ -131,5 +131,40 @@ FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/ccc>
 FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/semmed>
  WHERE { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . BIND(STRAFTER(STR(?d), "#") as ?docid) }"""
     }
+
+    "handle GRAPH unions correctly" in {
+      val query = """
+        PREFIX  dm:   <http://gsk-kg.rdip.gsk.com/dm/1.0/>
+        CONSTRUCT {
+          ?te dm:contains ?docid .
+        }
+        WHERE {
+           { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed?type=snapshot&t=20200309>
+             {
+               ?ds dm:contains ?te .
+             } 
+           } UNION {
+             GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier?type=incremental&t=20200109>
+             {
+               ?d a dm:Document .
+               ?d dm:contains ?ds .
+             }
+           }
+           BIND(STRAFTER(str(?d), "#") as ?docid) .
+        }"""
+
+      val result = QueryExtractor.extractInfo(query)
+
+      result._2 shouldEqual Map(
+        "http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier" ->
+          List(QueryParam("type", "incremental"), QueryParam("t", "20200109")),
+        "http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed" ->
+          List(QueryParam("type", "snapshot"), QueryParam("t", "20200309"))
+      )
+
+      result._1 shouldEqual """CONSTRUCT { ?te <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?docid . }
+
+ WHERE { { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed> { ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . } } UNION { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier> { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . } } BIND(STRAFTER(STR(?d), "#") as ?docid) }"""
+    }
   }
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
@@ -1,0 +1,38 @@
+package com.gsk.kg.engine
+
+import com.gsk.kg.engine.QueryExtractor.QueryParam
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class QueryExtractorSpec extends AnyWordSpec with Matchers {
+  
+  "QueryExtractor" must {
+
+    "extract info from the query" in {
+      val query = """
+        PREFIX  dm:   <http://gsk-kg.rdip.gsk.com/dm/1.0/>
+        
+        CONSTRUCT {
+           ?te dm:contains ?docid .
+        }
+        FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/kg?type=snapshot&t=20200109>
+        WHERE { 
+            ?d a dm:Document .
+            ?d dm:contains ?ds .
+            ?ds dm:contains ?te .
+            BIND(STRAFTER(str(?d), "#") as ?docid) .
+        }
+        """
+
+      QueryExtractor.extractInfo(query)._2 shouldEqual Map(
+        "http://gsk-kg.rdip.gsk.com/dm/1.0/kg" -> List(
+          QueryParam("type","snapshot"),
+          QueryParam("t","20200109")
+        )
+      )
+    }
+
+  }
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
@@ -60,8 +60,6 @@ FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/kg>
         CONSTRUCT {
           ?te dm:contains ?docid .
         }
-        FROM NAMED <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier?type=incremental&t=20200109>
-        FROM NAMED <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed?type=snapshot&t=20200309>
         WHERE {
            GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed?type=snapshot&t=20200309>
            {
@@ -90,8 +88,7 @@ FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/kg>
 
 
       result._1 shouldEqual """CONSTRUCT { ?te <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?docid . }
-FROM NAMED <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier>
-FROM NAMED <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed>
+
  WHERE { { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed> { ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . } } JOIN { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier> { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . BIND(STRAFTER(STR(?d), "#") as ?docid) } } }"""
     }
   }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
@@ -24,8 +24,8 @@ class QueryExtractorSpec extends AnyWordSpec with Matchers {
            {
              ?d a dm:Document .
              ?d dm:contains ?ds .
-             BIND(STRAFTER(str(?d), "#") as ?docid) .
            }
+           BIND(STRAFTER(str(?d), "#") as ?docid) .
         }"""
 
       val result = QueryExtractor.extractInfo(query)
@@ -39,7 +39,7 @@ class QueryExtractorSpec extends AnyWordSpec with Matchers {
 
       result._1 shouldEqual """CONSTRUCT { ?te <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?docid . }
 
- WHERE { { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed> { ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . } } JOIN { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier> { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . BIND(STRAFTER(STR(?d), "#") as ?docid) } } }"""
+ WHERE { { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed> { ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . } } JOIN { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier> { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . } } BIND(STRAFTER(STR(?d), "#") as ?docid) }"""
     }
 
     "extract info from FROM statement" in {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/QueryExtractorSpec.scala
@@ -91,5 +91,34 @@ FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/kg>
 
  WHERE { { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Semmed> { ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . } } JOIN { GRAPH <http://gsk-kg.rdip.gsk.com/dm/1.0/Elsevier> { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . BIND(STRAFTER(STR(?d), "#") as ?docid) } } }"""
     }
+
+    "extract info from FROM statement" in {
+    val query = """
+PREFIX  dm:   <http://gsk-kg.rdip.gsk.com/dm/1.0/>
+CONSTRUCT {
+  ?te dm:contains ?docid .
+}
+FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/ccc?type=snapshot&t=20200109>
+WHERE {
+   ?d a dm:Document .
+   ?d dm:contains ?ds .
+   ?ds dm:contains ?te .
+   BIND(STRAFTER(str(?d), "#") as ?docid) .
+}
+    """
+      val result = QueryExtractor.extractInfo(query)
+
+      result._2 shouldEqual Map(
+        "http://gsk-kg.rdip.gsk.com/dm/1.0/ccc" -> List(
+          QueryParam("type","snapshot"), 
+          QueryParam("t","20200109")
+        )
+      )
+
+      result._1 shouldEqual """CONSTRUCT { ?te <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?docid . }
+FROM <http://gsk-kg.rdip.gsk.com/dm/1.0/ccc>
+ WHERE { ?d <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://gsk-kg.rdip.gsk.com/dm/1.0/Document> . ?d <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?ds . ?ds <http://gsk-kg.rdip.gsk.com/dm/1.0/contains> ?te . BIND(STRAFTER(STR(?d), "#") as ?docid) }"""
+    }
   }
 }
+


### PR DESCRIPTION
This PR introduces a new QueryExtractor object.

`QueryExtractor` has a `extractInfo` method that receives a query as a string and returns a tuple with a map of all query params related to their respective graph URIs, and a _clean_ query.  The _clean_ query has all the graph URIs stripped from query parameters.

Closes AIPL-3209