### PR TITLE
Add support reduced modifier

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -56,6 +56,7 @@ object Engine {
       case DAG.Offset(offset, r)       => evaluateOffset(offset, r)
       case DAG.Limit(limit, r)         => evaluateLimit(limit, r)
       case DAG.Distinct(r)             => evaluateDistinct(r)
+      case DAG.Reduced(r)              => evaluateReduced(r)
       case DAG.Group(vars, func, r)    => evaluateGroup(vars, func, r)
       case DAG.Order(conds, r)         => evaluateOrder(conds, r)
       case DAG.Table(vars, rows)       => evaluateTable(vars, rows)
@@ -212,6 +213,11 @@ object Engine {
   }
 
   private def evaluateDistinct(r: Multiset): M[Multiset] =
+    M.liftF(r.distinct)
+
+  private def evaluateReduced(r: Multiset): M[Multiset] =
+    // It is up to the implementation to eliminate duplicates or not.
+    // See: https://www.w3.org/TR/sparql11-query/#modReduced
     M.liftF(r.distinct)
 
   private def evaluateGroup(

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -55,6 +55,7 @@ object QueryExtractor {
       case ProjectF(vars, r)                 => r
       case QuadF(s, p, o, g)                 => Nil
       case DistinctF(r)                      => r
+      case ReducedF(r)                       => r
       case GroupF(vars, func, r)             => r
       case OrderF(conds, r)                  => r
       case OffsetLimitF(None, None, r)       => r
@@ -213,6 +214,7 @@ object QueryExtractor {
       case ProjectF(vars, r)     => r
       case QuadF(s, p, o, g)     => s"QuadF(s, p, o, g)"
       case DistinctF(r)          => s"$r DISTINCT"
+      case ReducedF(r)           => s"$r REDUCED"
       case GroupF(vars, func, r) => s"$r GROUP BY ${printVars(vars)}"
       case OrderF(conds, r) =>
         s"$r ORDER BY ${conds.asInstanceOf[Seq[Expression]].map(printExpression).mkString(" ")}"

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -91,6 +91,7 @@ object FindUnboundVariables {
       case Offset(offset, r) => r
       case Limit(limit, r)   => r
       case Distinct(r)       => r
+      case Reduced(r)        => r
       case Group(vars, func, (declared, unbound)) =>
         (declared, (vars.toSet diff declared) ++ unbound)
       case DAG.Order(conds, (declared, unbound)) =>

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -106,6 +106,7 @@ object ToTree extends LowPriorityToTreeInstances0 {
           case DAG.Order(conds, r) =>
             Node("Order", conds.map(_.toTree).toList.toStream #::: Stream(r))
           case DAG.Distinct(r) => Node("Distinct", Stream(r))
+          case DAG.Reduced(r)  => Node("Reduced", Stream(r))
           case DAG.Table(vars, rows) =>
             val v: List[Expression] = vars
             val rs: List[List[(Expression, Expression)]] =

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
@@ -164,6 +164,7 @@ object GraphsPushdown {
             graphsOrList => DAG.offsetR(o, r(graphsOrList))
           case DAG.Limit(l, r) => graphsOrList => DAG.limitR(l, r(graphsOrList))
           case DAG.Distinct(r) => graphsOrList => DAG.distinctR(r(graphsOrList))
+          case DAG.Reduced(r)  => graphsOrList => DAG.reducedR(r(graphsOrList))
           case DAG.Group(vars, func, r) =>
             graphsOrList => DAG.groupR(vars, func, r(graphsOrList))
           case DAG.Order(variable, r) =>

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/SubqueryPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/SubqueryPushdown.scala
@@ -201,6 +201,8 @@ object SubqueryPushdown {
           isFromSubquery => DAG.limitR(l, r(isFromSubquery))
         case DAG.Distinct(r) =>
           isFromSubquery => DAG.distinctR(r(isFromSubquery))
+        case DAG.Reduced(r) =>
+          isFromSubquery => DAG.reducedR(r(isFromSubquery))
         case DAG.Group(vars, func, r) =>
           isFromSubquery => DAG.groupR(vars, func, r(isFromSubquery))
         case DAG.Order(variable, r) =>

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ReducedSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ReducedSpec.scala
@@ -1,9 +1,11 @@
 package com.gsk.kg.engine.compiler
 
-import com.gsk.kg.engine.Compiler
-import com.gsk.kg.sparqlparser.TestConfig
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -50,9 +52,8 @@ class ReducedSpec
 
       val result = Compiler.compile(df, query, config).right.get
 
-      result.collect.length shouldEqual 2
+      result.collect.length shouldEqual 1
       result.collect.toSet shouldEqual Set(
-        Row("\"Alice\""),
         Row("\"Alice\"")
       )
     }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ReducedSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/ReducedSpec.scala
@@ -1,0 +1,60 @@
+package com.gsk.kg.engine.compiler
+
+import com.gsk.kg.engine.Compiler
+import com.gsk.kg.sparqlparser.TestConfig
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ReducedSpec
+    extends AnyWordSpec
+    with Matchers
+    with SparkSpec
+    with TestConfig {
+
+  import sqlContext.implicits._
+
+  "perform query with REDUCED modifier" when {
+
+    "simple query" in {
+
+      val df: DataFrame = List(
+        ("_:x", "<http://xmlns.com/foaf/0.1/name>", "Alice"),
+        (
+          "_:x",
+          "<http://xmlns.com/foaf/0.1/mbox>",
+          "<mailto:alice@example.com>"
+        ),
+        ("_:y", "<http://xmlns.com/foaf/0.1/name>", "Alice"),
+        (
+          "_:y",
+          "<http://xmlns.com/foaf/0.1/mbox>",
+          "<mailto:asmith@example.com>"
+        ),
+        ("_:z", "<http://xmlns.com/foaf/0.1/name>", "Alice"),
+        (
+          "_:z",
+          "<http://xmlns.com/foaf/0.1/mbox>",
+          "<mailto:alice.smith@example.com>"
+        )
+      ).toDF("s", "p", "o")
+
+      val query =
+        """
+          |PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+          |
+          |SELECT REDUCED ?name
+          |WHERE { ?x foaf:name ?name }
+          |""".stripMargin
+
+      val result = Compiler.compile(df, query, config).right.get
+
+      result.collect.length shouldEqual 2
+      result.collect.toSet shouldEqual Set(
+        Row("\"Alice\""),
+        Row("\"Alice\"")
+      )
+    }
+  }
+}

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -109,6 +109,7 @@ object Expr {
   )                                                           extends Expr
   final case class Order(conds: Seq[ConditionOrder], r: Expr) extends Expr
   final case class Distinct(r: Expr)                          extends Expr
+  final case class Reduced(r: Expr)                           extends Expr
   final case class Table(vars: Seq[VARIABLE], rows: Seq[Row]) extends Expr
   final case class Row(tuples: Seq[(VARIABLE, StringVal)])    extends Expr
   final case class Exists(not: Boolean, p: Expr, r: Expr)     extends Expr

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -22,6 +22,7 @@ object ExprParser {
   def select[_: P]: P[Unit]      = P("project")
   def offsetLimit[_: P]: P[Unit] = P("slice")
   def distinct[_: P]: P[Unit]    = P("distinct")
+  def reduced[_: P]: P[Unit]     = P("reduced")
   def group[_: P]: P[Unit]       = P("group")
   def order[_: P]: P[Unit]       = P("order")
   def table[_: P]: P[Unit]       = P("table")
@@ -52,7 +53,10 @@ object ExprParser {
   }
 
   def distinctParen[_: P]: P[Distinct] =
-    P("(" ~ distinct ~ graphPattern).map(Distinct(_))
+    P("(" ~ distinct ~ graphPattern).map(Distinct)
+
+  def reducedParen[_: P]: P[Reduced] =
+    P("(" ~ reduced ~ graphPattern).map(Reduced)
 
   def triple[_: P]: P[Quad] =
     P(
@@ -62,7 +66,7 @@ object ExprParser {
         StringValParser.tripleValParser ~ ")"
     ).map(t => Quad(t._1, t._2, t._3, GRAPH_VARIABLE :: Nil))
 
-  def bgpParen[_: P]: P[BGP] = P("(" ~ bgp ~ triple.rep(1) ~ ")").map(BGP(_))
+  def bgpParen[_: P]: P[BGP] = P("(" ~ bgp ~ triple.rep(1) ~ ")").map(BGP)
 
   def exprFunc[_: P]: P[Expression] =
     ConditionalParser.parser | BuiltInFuncParser.parser | AggregateParser.parser
@@ -192,6 +196,7 @@ object ExprParser {
       selectParen
         | offsetLimitParen
         | distinctParen
+        | reducedParen
         | leftJoinParen
         | filteredLeftJoinParen
         | joinParen

--- a/modules/parser/src/test/resources/queries/q49-reduced-simple-query.sparql
+++ b/modules/parser/src/test/resources/queries/q49-reduced-simple-query.sparql
@@ -1,0 +1,4 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+SELECT REDUCED ?name
+WHERE { ?x foaf:name ?name }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
@@ -865,7 +865,7 @@ class ExprParserSpec extends AnyFlatSpec with TestUtils {
     }
   }
 
-  "Not exists" should "return property when simple query" in {
+  "Not exists" should "return proper type when simple query" in {
     val p = fastparse.parse(
       sparql2Algebra(
         "/queries/q48-not-exists-simple-query.sparql"
@@ -900,6 +900,35 @@ class ExprParserSpec extends AnyFlatSpec with TestUtils {
                     VARIABLE("?s"),
                     URIVAL("<http://xmlns.com/foaf/0.1/age>"),
                     VARIABLE("?age"),
+                    List(GRAPH_VARIABLE)
+                  )
+                )
+              )
+            )
+          ) =>
+        succeed
+      case _ => fail
+    }
+  }
+
+  "Reduced" should "return proper type when simple query" in {
+    val p = fastparse.parse(
+      sparql2Algebra(
+        "/queries/q49-reduced-simple-query.sparql"
+      ),
+      ExprParser.parser(_)
+    )
+
+    p.get.value match {
+      case Reduced(
+            Project(
+              Seq(VARIABLE("?name")),
+              BGP(
+                Seq(
+                  Quad(
+                    VARIABLE("?x"),
+                    URIVAL("<http://xmlns.com/foaf/0.1/name>"),
+                    VARIABLE("?name"),
                     List(GRAPH_VARIABLE)
                   )
                 )

--- a/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
+++ b/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
@@ -151,6 +151,7 @@ object prelude {
     case dag @ DAG.Limit(l, r) =>
       RefTree.Ref(dag, Seq(l.refTree.toField, r.toField))
     case dag @ DAG.Distinct(r) => RefTree.Ref(dag, Seq(r.toField))
+    case dag @ DAG.Reduced(r)  => RefTree.Ref(dag, Seq(r.toField))
     case dag @ DAG.Group(vars, func, r) =>
       RefTree.Ref(dag, Seq(vars.refTree.toField, r.toField))
     case dag @ DAG.Order(conds, r) =>


### PR DESCRIPTION
This PR add support for REDUCED solutions modifier. E.g:

```
PREFIX foaf: <http://xmlns.com/foaf/0.1/>

SELECT REDUCED ?name
WHERE { ?x foaf:name ?name }
```

Note: It has been implemented as distinct as it is up to the Sparql endpoint whether to eliminate duplicates or not.
See: https://www.w3.org/TR/sparql11-query/#modReduced

Closes #295
Merge after #424 
Merge after #425 