### PR TITLE
Add support for numeric types

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncNumerics.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncNumerics.scala
@@ -1,14 +1,14 @@
 package com.gsk.kg.engine.functions
 
-import com.gsk.kg.engine.functions.Literals.NumericLiteral
-import com.gsk.kg.engine.functions.Literals.isNumericLiteral
-import com.gsk.kg.engine.functions.Literals.isPlainLiteral
-import com.gsk.kg.engine.functions.Literals.nullLiteral
-
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.format_string
 import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.functions.{ceil => sCeil}
+
+import com.gsk.kg.engine.functions.Literals.NumericLiteral
+import com.gsk.kg.engine.functions.Literals.isNumericLiteral
+import com.gsk.kg.engine.functions.Literals.isPlainLiteral
+import com.gsk.kg.engine.functions.Literals.nullLiteral
 
 object FuncNumerics {
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncNumerics.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncNumerics.scala
@@ -1,6 +1,11 @@
 package com.gsk.kg.engine.functions
 
+import com.gsk.kg.engine.functions.Literals.NumericLiteral
+import com.gsk.kg.engine.functions.Literals.isNumericLiteral
+import com.gsk.kg.engine.functions.Literals.nullLiteral
+import com.gsk.kg.engine.functions.Literals.promoteBooleanBoolean
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.functions.{ceil => sCeil}
 
 object FuncNumerics {
@@ -24,7 +29,14 @@ object FuncNumerics {
     * @param col
     * @return
     */
-  def ceil(col: Column): Column = sCeil(col)
+  def ceil(col: Column): Column = {
+    when(
+      isNumericLiteral(col), {
+        val n = NumericLiteral(col).value
+        sCeil(n)
+      }
+    ).otherwise(nullLiteral)
+  }
 
   /** Returns the largest (closest to positive infinity) number with no fractional part that is not greater
     * than the value of arg. An error is raised if arg is not a numeric value.

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncNumerics.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncNumerics.scala
@@ -2,9 +2,11 @@ package com.gsk.kg.engine.functions
 
 import com.gsk.kg.engine.functions.Literals.NumericLiteral
 import com.gsk.kg.engine.functions.Literals.isNumericLiteral
+import com.gsk.kg.engine.functions.Literals.isPlainLiteral
 import com.gsk.kg.engine.functions.Literals.nullLiteral
-import com.gsk.kg.engine.functions.Literals.promoteBooleanBoolean
+
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.format_string
 import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.functions.{ceil => sCeil}
 
@@ -30,12 +32,16 @@ object FuncNumerics {
     * @return
     */
   def ceil(col: Column): Column = {
-    when(
-      isNumericLiteral(col), {
-        val n = NumericLiteral(col).value
-        sCeil(n)
-      }
-    ).otherwise(nullLiteral)
+    when(isPlainLiteral(col), sCeil(col))
+      .when(
+        isNumericLiteral(col), {
+          val numericLiteral = NumericLiteral(col)
+          val n              = numericLiteral.value
+          val tag            = numericLiteral.tag
+          format_string("\"%s\"^^%s", sCeil(n), tag)
+        }
+      )
+      .otherwise(nullLiteral)
   }
 
   /** Returns the largest (closest to positive infinity) number with no fractional part that is not greater

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Ceilspec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Ceilspec.scala
@@ -43,6 +43,12 @@ class Ceilspec
       val expected = Row(null)
       eval(term, expected)
     }
+
+    "term is xsd:double" in {
+      val term     = "\"10.5\"^^xsd:string"
+      val expected = Row("\"11\"^^xsd:string")
+      eval(term, expected)
+    }
   }
 
   private def eval(term: String, expected: Row): Assertion = {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncNumericsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncNumericsSpec.scala
@@ -27,27 +27,19 @@ class FuncNumericsSpec
       val elems    = List(1, 1.4, -0.3, 1.8, 10.5, -10.5)
       val df       = elems.toDF()
       val dfR      = df.select(FuncNumerics.ceil(col(df.columns.head)))
-      val expected = List(1, 2, 0, 2, 11, -10).map(Row(_))
-
-      dfR.collect().toList shouldEqual expected
-    }
-
-    "string representing numeric value" in {
-      val elems    = List("2.8")
-      val df       = elems.toDF()
-      val dfR      = df.select(FuncNumerics.ceil(col(df.columns.head)))
-      val expected = List(3).map(Row(_))
+      val expected = List("1", "2", "0", "2", "11", "-10").map(Row(_))
 
       dfR.collect().toList shouldEqual expected
     }
 
     "multiple numeric types" in {
       val elems = List(
-        ("\"2\"^^xsd:int", 2),
-        ("\"1\"^^xsd:integer", 1),
-        ("\"-0.3\"^^xsd:decimal", 0),
-        ("\"10.5\"^^xsd:float", 11),
-        ("\"-10.5\"^^xsd:double", -10)
+        ("\"2\"^^xsd:int", "\"2\"^^xsd:int"),
+        ("\"1\"^^xsd:integer", "\"1\"^^xsd:integer"),
+        ("\"-0.3\"^^xsd:decimal", "\"0\"^^xsd:decimal"),
+        ("\"10.5\"^^xsd:float", "\"11\"^^xsd:float"),
+        ("\"-10.5\"^^xsd:double", "\"-10\"^^xsd:double"),
+        ("2.8", "3")
       )
       val df       = elems.toDF("in", "expected")
       val result   = df.select(FuncNumerics.ceil(df("in")))

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncNumericsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncNumericsSpec.scala
@@ -40,5 +40,20 @@ class FuncNumericsSpec
 
       dfR.collect().toList shouldEqual expected
     }
+
+    "multiple numeric types" in {
+      val elems = List(
+        ("\"2\"^^xsd:int", 2),
+        ("\"1\"^^xsd:integer", 1),
+        ("\"-0.3\"^^xsd:decimal", 0),
+        ("\"10.5\"^^xsd:float", 11),
+        ("\"-10.5\"^^xsd:double", -10)
+      )
+      val df       = elems.toDF("in", "expected")
+      val result   = df.select(FuncNumerics.ceil(df("in")))
+      val expected = df.select(col("expected"))
+
+      result.collect() shouldEqual expected.collect()
+    }
   }
 }


### PR DESCRIPTION
The ceil, round, ... functions must process these data types: xs:float, xs:double, xs:decimal and xs:integer