### PR TITLE
constrain the number off shuffle partitions to 1 in test

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -40,8 +40,12 @@ jobs:
           path: ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('build.sbt') }}-${{ hashFiles('project/*.scala') }}
           restore-keys: ${{ runner.os }}-sbt-
-      - name: Run checks
-        run: sbt ci-test
+      - name: Lint code
+        run: sbt ";scalafixAll --check ;scalafmtCheckAll ;scalastyle"
+      - name: Run tests
+        run: sbt ";clean ;coverage ;+test"
+      - name: Build microsite
+        run: sbt ";build-microsite"
       - name: Coverage Report
         run: sbt coverageReport
       - name: "Upload coverage to Codecov"

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Bug3255Spec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Bug3255Spec.scala
@@ -7,7 +7,7 @@ import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class Bug3255Spec extends AnyWordSpec with Matchers with DataFrameSuiteBase {
+class Bug3255Spec extends AnyWordSpec with Matchers with SparkSpec {
 
   override implicit def reuseContextIfPossible: Boolean = true
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Bug3255Spec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/Bug3255Spec.scala
@@ -3,7 +3,6 @@ package compiler
 
 import com.gsk.kg.engine.syntax._
 
-import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/SparkSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/SparkSpec.scala
@@ -18,6 +18,7 @@ trait SparkSpec extends DataFrameSuiteBase { self: Suite =>
       .set("spark.app.id", appID)
       .set("spark.driver.host", "localhost")
       .set("spark.sql.codegen.wholeStage", "false")
+      .set("spark.sql.shuffle.partitions", "1")
   }
 
 }


### PR DESCRIPTION
# Description

this PR modifies the default shuffle partitions for spark, which in local environments can help with performance

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->