### PR TITLE
add support for alternative property path

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/DAG.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/DAG.scala
@@ -3,18 +3,21 @@ package com.gsk.kg.engine
 import cats._
 import cats.data.NonEmptyList
 import cats.implicits._
+
 import higherkindness.droste._
 import higherkindness.droste.syntax.all._
 import higherkindness.droste.util.DefaultTraverse
+
 import com.gsk.kg.engine.data.ChunkedList
 import com.gsk.kg.sparqlparser.ConditionOrder
 import com.gsk.kg.sparqlparser.Expr
+import com.gsk.kg.sparqlparser.Expr.fixedpoint._
 import com.gsk.kg.sparqlparser.Expression
 import com.gsk.kg.sparqlparser.PropertyExpression
 import com.gsk.kg.sparqlparser.Query
 import com.gsk.kg.sparqlparser.StringVal
-import com.gsk.kg.sparqlparser.Expr.fixedpoint._
 import com.gsk.kg.sparqlparser.StringVal.VARIABLE
+
 import monocle._
 import monocle.macros.Lenses
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
@@ -3,7 +3,6 @@ package com.gsk.kg.engine
 import cats.implicits._
 
 import higherkindness.droste._
-import higherkindness.droste.macros.deriveTraverse
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
@@ -11,66 +10,10 @@ import org.apache.spark.sql.DataFrame
 import com.gsk.kg.config.Config
 import com.gsk.kg.engine.properties.FuncProperty
 import com.gsk.kg.sparqlparser.EngineError
-import com.gsk.kg.sparqlparser.PropertyExpression
+import com.gsk.kg.sparqlparser.PropertyExpression.fixedpoint._
 import com.gsk.kg.sparqlparser.Result
 
-@deriveTraverse sealed trait PropertyExpressionF[+A]
-
 object PropertyExpressionF {
-
-  final case class Alternative[A](pel: A, per: A) extends PropertyExpressionF[A]
-  final case class Reverse[A](e: A)               extends PropertyExpressionF[A]
-  final case class SeqExpression[A](pel: A, per: A)
-      extends PropertyExpressionF[A]
-  final case class OneOrMore[A](e: A)       extends PropertyExpressionF[A]
-  final case class ZeroOrMore[A](e: A)      extends PropertyExpressionF[A]
-  final case class ZeroOrOne[A](e: A)       extends PropertyExpressionF[A]
-  final case class NotOneOf[A](es: List[A]) extends PropertyExpressionF[A]
-  final case class BetweenNAndM[A](n: Int, m: Int, e: A)
-      extends PropertyExpressionF[A]
-  final case class ExactlyN[A](n: Int, e: A) extends PropertyExpressionF[A]
-  final case class NOrMore[A](n: Int, e: A)  extends PropertyExpressionF[A]
-  final case class BetweenZeroAndN[A](n: Int, e: A)
-      extends PropertyExpressionF[A]
-  final case class Uri[A](s: String) extends PropertyExpressionF[A]
-
-  val fromPropExprCoalg: Coalgebra[PropertyExpressionF, PropertyExpression] =
-    Coalgebra {
-      case PropertyExpression.Alternative(pel, per)   => Alternative(pel, per)
-      case PropertyExpression.Reverse(e)              => Reverse(e)
-      case PropertyExpression.SeqExpression(pel, per) => SeqExpression(pel, per)
-      case PropertyExpression.OneOrMore(e)            => OneOrMore(e)
-      case PropertyExpression.ZeroOrMore(e)           => ZeroOrMore(e)
-      case PropertyExpression.ZeroOrOne(e)            => ZeroOrOne(e)
-      case PropertyExpression.NotOneOf(es)            => NotOneOf(es)
-      case PropertyExpression.BetweenNAndM(n, m, e)   => BetweenNAndM(n, m, e)
-      case PropertyExpression.ExactlyN(n, e)          => ExactlyN(n, e)
-      case PropertyExpression.NOrMore(n, e)           => NOrMore(n, e)
-      case PropertyExpression.BetweenZeroAndN(n, e)   => BetweenZeroAndN(n, e)
-      case PropertyExpression.Uri(s)                  => Uri(s)
-    }
-
-  val toPropExprAlg: Algebra[PropertyExpressionF, PropertyExpression] =
-    Algebra {
-      case Alternative(pel, per)   => PropertyExpression.Alternative(pel, per)
-      case Reverse(e)              => PropertyExpression.Reverse(e)
-      case SeqExpression(pel, per) => PropertyExpression.SeqExpression(pel, per)
-      case OneOrMore(e)            => PropertyExpression.OneOrMore(e)
-      case ZeroOrMore(e)           => PropertyExpression.ZeroOrMore(e)
-      case ZeroOrOne(e)            => PropertyExpression.ZeroOrOne(e)
-      case NotOneOf(es)            => PropertyExpression.NotOneOf(es)
-      case BetweenNAndM(n, m, e)   => PropertyExpression.BetweenNAndM(n, m, e)
-      case ExactlyN(n, e)          => PropertyExpression.ExactlyN(n, e)
-      case NOrMore(n, e)           => PropertyExpression.NOrMore(n, e)
-      case BetweenZeroAndN(n, e)   => PropertyExpression.BetweenZeroAndN(n, e)
-      case Uri(s)                  => PropertyExpression.Uri(s)
-    }
-
-  implicit val basis: Basis[PropertyExpressionF, PropertyExpression] =
-    Basis.Default[PropertyExpressionF, PropertyExpression](
-      algebra = toPropExprAlg,
-      coalgebra = fromPropExprCoalg
-    )
 
   def compile[T](
       t: T,
@@ -79,19 +22,19 @@ object PropertyExpressionF {
     df => {
       val algebraM: AlgebraM[M, PropertyExpressionF, Column] =
         AlgebraM.apply[M, PropertyExpressionF, Column] {
-          case Alternative(pel, per) =>
+          case AlternativeF(pel, per) =>
             FuncProperty.alternative(df, pel, per).pure[M]
-          case Reverse(e)              => unknownPropertyPath("reverse")
-          case SeqExpression(pel, per) => unknownPropertyPath("seqExpression")
-          case OneOrMore(e)            => unknownPropertyPath("oneOrMore")
-          case ZeroOrMore(e)           => unknownPropertyPath("zeroOrMore")
-          case ZeroOrOne(e)            => unknownPropertyPath("zeroOrOne")
-          case NotOneOf(es)            => unknownPropertyPath("notOneOf")
-          case BetweenNAndM(n, m, e)   => unknownPropertyPath("betweenNAndM")
-          case ExactlyN(n, e)          => unknownPropertyPath("exactlyN")
-          case NOrMore(n, e)           => unknownPropertyPath("nOrMore")
-          case BetweenZeroAndN(n, e)   => unknownPropertyPath("betweenZeroAndN")
-          case Uri(s)                  => FuncProperty.uri(s).pure[M]
+          case ReverseF(e)              => unknownPropertyPath("reverse")
+          case SeqExpressionF(pel, per) => unknownPropertyPath("seqExpression")
+          case OneOrMoreF(e)            => unknownPropertyPath("oneOrMore")
+          case ZeroOrMoreF(e)           => unknownPropertyPath("zeroOrMore")
+          case ZeroOrOneF(e)            => unknownPropertyPath("zeroOrOne")
+          case NotOneOfF(es)            => unknownPropertyPath("notOneOf")
+          case BetweenNAndMF(n, m, e)   => unknownPropertyPath("betweenNAndM")
+          case ExactlyNF(n, e)          => unknownPropertyPath("exactlyN")
+          case NOrMoreF(n, e)           => unknownPropertyPath("nOrMore")
+          case BetweenZeroAndNF(n, e)   => unknownPropertyPath("betweenZeroAndN")
+          case UriF(s)                  => FuncProperty.uri(s).pure[M]
         }
 
       val eval = scheme.cataM[M, PropertyExpressionF, T, Column](algebraM)

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
@@ -1,0 +1,103 @@
+package com.gsk.kg.engine
+
+import cats.implicits._
+
+import higherkindness.droste._
+import higherkindness.droste.macros.deriveTraverse
+
+import org.apache.spark.sql.DataFrame
+
+import com.gsk.kg.config.Config
+import com.gsk.kg.sparqlparser.EngineError
+import com.gsk.kg.sparqlparser.PropertyExpression
+import com.gsk.kg.sparqlparser.Result
+
+@deriveTraverse sealed trait PropertyExpressionF[+A]
+
+object PropertyExpressionF {
+
+  final case class Alternative[A](pel: A, per: A) extends PropertyExpressionF[A]
+  final case class Reverse[A](e: A)               extends PropertyExpressionF[A]
+  final case class SeqExpression[A](pel: A, per: A)
+      extends PropertyExpressionF[A]
+  final case class OneOrMore[A](e: A)       extends PropertyExpressionF[A]
+  final case class ZeroOrMore[A](e: A)      extends PropertyExpressionF[A]
+  final case class ZeroOrOne[A](e: A)       extends PropertyExpressionF[A]
+  final case class NotOneOf[A](es: List[A]) extends PropertyExpressionF[A]
+  final case class BetweenNAndM[A](n: Int, m: Int, e: A)
+      extends PropertyExpressionF[A]
+  final case class ExactlyN[A](n: Int, e: A) extends PropertyExpressionF[A]
+  final case class NOrMore[A](n: Int, e: A)  extends PropertyExpressionF[A]
+  final case class BetweenZeroAndN[A](n: Int, e: A)
+      extends PropertyExpressionF[A]
+  final case class Uri[A](s: String) extends PropertyExpressionF[A]
+
+  val fromPropExprCoalg: Coalgebra[PropertyExpressionF, PropertyExpression] =
+    Coalgebra {
+      case PropertyExpression.Alternative(pel, per)   => Alternative(pel, per)
+      case PropertyExpression.Reverse(e)              => Reverse(e)
+      case PropertyExpression.SeqExpression(pel, per) => SeqExpression(pel, per)
+      case PropertyExpression.OneOrMore(e)            => OneOrMore(e)
+      case PropertyExpression.ZeroOrMore(e)           => ZeroOrMore(e)
+      case PropertyExpression.ZeroOrOne(e)            => ZeroOrOne(e)
+      case PropertyExpression.NotOneOf(es)            => NotOneOf(es)
+      case PropertyExpression.BetweenNAndM(n, m, e)   => BetweenNAndM(n, m, e)
+      case PropertyExpression.ExactlyN(n, e)          => ExactlyN(n, e)
+      case PropertyExpression.NOrMore(n, e)           => NOrMore(n, e)
+      case PropertyExpression.BetweenZeroAndN(n, e)   => BetweenZeroAndN(n, e)
+      case PropertyExpression.Uri(s)                  => Uri(s)
+    }
+
+  val toPropExprAlg: Algebra[PropertyExpressionF, PropertyExpression] =
+    Algebra {
+      case Alternative(pel, per)   => PropertyExpression.Alternative(pel, per)
+      case Reverse(e)              => PropertyExpression.Reverse(e)
+      case SeqExpression(pel, per) => PropertyExpression.SeqExpression(pel, per)
+      case OneOrMore(e)            => PropertyExpression.OneOrMore(e)
+      case ZeroOrMore(e)           => PropertyExpression.ZeroOrMore(e)
+      case ZeroOrOne(e)            => PropertyExpression.ZeroOrOne(e)
+      case NotOneOf(es)            => PropertyExpression.NotOneOf(es)
+      case BetweenNAndM(n, m, e)   => PropertyExpression.BetweenNAndM(n, m, e)
+      case ExactlyN(n, e)          => PropertyExpression.ExactlyN(n, e)
+      case NOrMore(n, e)           => PropertyExpression.NOrMore(n, e)
+      case BetweenZeroAndN(n, e)   => PropertyExpression.BetweenZeroAndN(n, e)
+      case Uri(s)                  => PropertyExpression.Uri(s)
+    }
+
+  implicit val basis: Basis[PropertyExpressionF, PropertyExpression] =
+    Basis.Default[PropertyExpressionF, PropertyExpression](
+      algebra = toPropExprAlg,
+      coalgebra = fromPropExprCoalg
+    )
+
+  def compile[T](
+      t: T,
+      config: Config
+  )(implicit T: Basis[PropertyExpressionF, T]): DataFrame => Result[DataFrame] =
+    df => {
+      val algebraM: AlgebraM[M, PropertyExpressionF, DataFrame] =
+        AlgebraM.apply[M, PropertyExpressionF, DataFrame] {
+          case Alternative(pel, per)   => unknownPropertyPath("alternative")
+          case Reverse(e)              => unknownPropertyPath("reverse")
+          case SeqExpression(pel, per) => unknownPropertyPath("seqExpression")
+          case OneOrMore(e)            => unknownPropertyPath("oneOrMore")
+          case ZeroOrMore(e)           => unknownPropertyPath("zeroOrMore")
+          case ZeroOrOne(e)            => unknownPropertyPath("zeroOrOne")
+          case NotOneOf(es)            => unknownPropertyPath("notOneOf")
+          case BetweenNAndM(n, m, e)   => unknownPropertyPath("betweenNAndM")
+          case ExactlyN(n, e)          => unknownPropertyPath("exactlyN")
+          case NOrMore(n, e)           => unknownPropertyPath("nOrMore")
+          case BetweenZeroAndN(n, e)   => unknownPropertyPath("betweenZeroAndN")
+          case Uri(s)                  => unknownPropertyPath("uri")
+        }
+
+      val eval = scheme.cataM[M, PropertyExpressionF, T, DataFrame](algebraM)
+
+      eval(t).runA(config, df)
+    }
+
+  private def unknownPropertyPath(name: String): M[DataFrame] =
+    M.liftF[Result, Config, Log, DataFrame, DataFrame](
+      EngineError.UnknownPropertyPath(name).asLeft[DataFrame]
+    )
+}

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -66,7 +66,7 @@ object QueryExtractor {
       case JoinF(l, r)                       => l ++ r
       case LeftJoinF(l, r)                   => l ++ r
       case ProjectF(vars, r)                 => r
-      case PathQuadF(s, p, o, g)             => Nil
+      case PathF(s, p, o, g)                 => Nil
       case QuadF(s, p, o, g)                 => Nil
       case DistinctF(r)                      => r
       case ReducedF(r)                       => r
@@ -112,7 +112,7 @@ object QueryExtractor {
   private def printQuad(quad: Expr.Quad): String =
     s"(triple ${quad.s.s} ${quad.p.s} ${quad.o.s})"
 
-  private def printPathQuad(
+  private def printPath(
       s: StringVal,
       p: PropertyExpression,
       o: StringVal,
@@ -297,7 +297,7 @@ object QueryExtractor {
       case JoinF(l, r)           => s"(join $l $r)"
       case LeftJoinF(l, r)       => s"(leftjoin $l $r)"
       case ProjectF(vars, r)     => r
-      case PathQuadF(s, p, o, g) => printPathQuad(s, p, o, g)
+      case PathF(s, p, o, g)     => printPath(s, p, o, g)
       case QuadF(s, p, o, g)     => s"(quadf s p o g)"
       case DistinctF(r)          => s"(distinct $r)"
       case ReducedF(r)           => s"(reduced $r)"

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -80,6 +80,14 @@ object FindUnboundVariables {
           case ((declaredAcc, unboundAcc), (declaredElem, unboundElem)) =>
             (declaredAcc ++ declaredElem, unboundAcc ++ unboundElem)
         }
+      case Path(s, p, o, g) =>
+        val vars = (List(s, o)
+          .filter(_.isVariable) ++ g.collect { case e if e.isVariable => e })
+          .filterNot(_ == GRAPH_VARIABLE)
+          .map(_.asInstanceOf[VARIABLE])
+          .toSet
+
+        (vars, Set.empty)
       case BGP(triples) =>
         val vars = Traverse[ChunkedList]
           .toList(triples)

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -15,6 +15,7 @@ import com.gsk.kg.sparqlparser.ConditionOrder.ASC
 import com.gsk.kg.sparqlparser.ConditionOrder.DESC
 import com.gsk.kg.sparqlparser.Expr
 import com.gsk.kg.sparqlparser.Expression
+import com.gsk.kg.sparqlparser.PropertyExpression.fixedpoint._
 
 import scala.collection.immutable.Nil
 
@@ -246,29 +247,29 @@ object ToTree extends LowPriorityToTreeInstances0 {
       def toTree(tree: T): TreeRep[String] = {
         import TreeRep._
         val alg = Algebra[PropertyExpressionF, TreeRep[String]] {
-          case PropertyExpressionF.Alternative(pel, per) =>
+          case AlternativeF(pel, per) =>
             Node("Alternative", Stream(pel, per))
-          case PropertyExpressionF.Reverse(e) => Node("Reverse", Stream(e))
-          case PropertyExpressionF.SeqExpression(pel, per) =>
+          case ReverseF(e) => Node("Reverse", Stream(e))
+          case SeqExpressionF(pel, per) =>
             Node("SeqExpression", Stream(pel, per))
-          case PropertyExpressionF.OneOrMore(e) => Node("OneOrMore", Stream(e))
-          case PropertyExpressionF.ZeroOrMore(e) =>
+          case OneOrMoreF(e) => Node("OneOrMore", Stream(e))
+          case ZeroOrMoreF(e) =>
             Node("ZeroOrMore", Stream(e))
-          case PropertyExpressionF.ZeroOrOne(e) => Node("ZeroOrOne", Stream(e))
-          case PropertyExpressionF.NotOneOf(es) =>
+          case ZeroOrOneF(e) => Node("ZeroOrOne", Stream(e))
+          case NotOneOfF(es) =>
             Node("NotOnOf", es.toStream)
-          case PropertyExpressionF.BetweenNAndM(n, m, e) =>
+          case BetweenNAndMF(n, m, e) =>
             Node("BetweenNAndM", Stream(Leaf(n.toString), Leaf(m.toString), e))
-          case PropertyExpressionF.ExactlyN(n, e) =>
+          case ExactlyNF(n, e) =>
             Node("ExactlyN", Stream(Leaf(n.toString), e))
-          case PropertyExpressionF.NOrMore(n, e) =>
+          case NOrMoreF(n, e) =>
             Node("NOrMore", Stream(Leaf(n.toString), e))
-          case PropertyExpressionF.BetweenZeroAndN(n, e) =>
+          case BetweenZeroAndNF(n, e) =>
             Node("BetweenZeroAndN", Stream(Leaf(n.toString), e))
-          case PropertyExpressionF.Uri(s) => Node("Uri", Stream(Leaf(s)))
+          case UriF(s) => Node("Uri", Stream(Leaf(s)))
         }
 
-        val t = scheme.cata(alg)
+        val t = scheme.cata[PropertyExpressionF, T, TreeRep[String]](alg)
 
         t(tree)
       }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -5,9 +5,11 @@ import cats.Show
 import cats.data.NonEmptyChain
 import cats.data.NonEmptyList
 import cats.implicits._
+
 import higherkindness.droste.Algebra
 import higherkindness.droste.Basis
 import higherkindness.droste.scheme
+
 import com.gsk.kg.sparqlparser.ConditionOrder
 import com.gsk.kg.sparqlparser.ConditionOrder.ASC
 import com.gsk.kg.sparqlparser.ConditionOrder.DESC

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
@@ -142,6 +142,8 @@ object GraphsPushdown {
             graphsOrList => DAG.bindR(variable, expression, r(graphsOrList))
           case DAG.Sequence(bps) =>
             graphsOrList => DAG.sequenceR(bps.map(_(graphsOrList)))
+          case DAG.Path(s, p, o, g) =>
+            graphsOrList => DAG.pathR(s, p, o, g)
           case DAG.BGP(quads) =>
             graphsOrList =>
               graphsOrList.fold(

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/SubqueryPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/SubqueryPushdown.scala
@@ -185,6 +185,8 @@ object SubqueryPushdown {
           isFromSubquery => DAG.bindR(variable, expression, r(isFromSubquery))
         case DAG.Sequence(bps) =>
           isFromSubquery => DAG.sequenceR(bps.map(_(isFromSubquery)))
+        case DAG.Path(s, p, o, g) =>
+          isFromSubquery => DAG.pathR(s, p, o, g)
         case DAG.BGP(quads) => _ => DAG.bgpR(quads)
         case DAG.LeftJoin(l, r, filters) =>
           isFromSubquery =>

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
@@ -1,0 +1,24 @@
+package com.gsk.kg.engine.properties
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+
+import com.gsk.kg.engine.functions.FuncForms
+
+object FuncProperty {
+
+  def alternative(df: DataFrame, pel: Column, per: Column): Column = {
+    val col = df("p")
+    when(
+      col.startsWith("\"") && col.endsWith("\""),
+      FuncForms.equals(trim(col, "\""), pel) ||
+        FuncForms.equals(trim(col, "\""), per)
+    ).otherwise(
+      FuncForms.equals(col, pel) ||
+        FuncForms.equals(col, per)
+    )
+  }
+
+  def uri(s: String): Column = lit(s)
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
@@ -20,9 +20,7 @@ class PropertyPathsSpec
 
     "perform on simple queries" when {
 
-      // TODO: Un-ignore test when implemented support on property paths
-
-      "alternative | property path" ignore {
+      "alternative | property path" in {
 
         val df = List(
           (
@@ -34,6 +32,11 @@ class PropertyPathsSpec
             "<http://example.org/book2>",
             "<http://www.w3.org/2000/01/rdf-schema#label>",
             "From Earth To The Moon"
+          ),
+          (
+            "<http://example.org/book3>",
+            "<http://www.w3.org/2000/01/rdf-schema#label2>",
+            "Another title"
           )
         ).toDF("s", "p", "o")
 
@@ -50,8 +53,13 @@ class PropertyPathsSpec
 
         val result = Compiler.compile(df, query, config)
 
-        result.right.get.collect.toSet shouldEqual Set()
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("<http://example.org/book1>", "\"SPARQL Tutorial\""),
+          Row("<http://example.org/book2>", "\"From Earth To The Moon\"")
+        )
       }
+
+      // TODO: Un-ignore test when implemented support on property paths
 
       "sequence / property path" ignore {
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/EngineError.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/EngineError.scala
@@ -7,6 +7,7 @@ sealed trait EngineError
 object EngineError {
   final case class General(description: String)            extends EngineError
   final case class UnknownFunction(fn: String)             extends EngineError
+  final case class UnknownPropertyPath(pp: String)         extends EngineError
   final case class UnexpectedNegative(description: String) extends EngineError
   final case class NumericTypesDoNotMatch(description: String)
       extends EngineError

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -46,14 +46,7 @@ object Expr {
       p: PropertyExpression,
       o: StringVal,
       g: List[StringVal]
-  ) extends Expr {
-    def getVariables: List[(StringVal, String)] =
-      getNamesAndPositions.filterNot(_._1 == GRAPH_VARIABLE)
-
-    def getNamesAndPositions: List[(StringVal, String)] =
-      List((s, "s"), (o, "o")).filter(_._1.isVariable) ++
-        g.collect { case e if e.isVariable => e -> "g" }
-  }
+  ) extends Expr
   final case class Quad(
       s: StringVal,
       p: StringVal,

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expr.scala
@@ -41,12 +41,19 @@ object Query {
 object Expr {
   final case class Sequence(seq: List[Expr]) extends Expr
   final case class BGP(quads: Seq[Quad])     extends Expr
-  final case class PathQuad(
+  final case class Path(
       s: StringVal,
       p: PropertyExpression,
       o: StringVal,
       g: List[StringVal]
-  ) extends Expr
+  ) extends Expr {
+    def getVariables: List[(StringVal, String)] =
+      getNamesAndPositions.filterNot(_._1 == GRAPH_VARIABLE)
+
+    def getNamesAndPositions: List[(StringVal, String)] =
+      List((s, "s"), (o, "o")).filter(_._1.isVariable) ++
+        g.collect { case e if e.isVariable => e -> "g" }
+  }
   final case class Quad(
       s: StringVal,
       p: StringVal,

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/ExprParser.scala
@@ -76,9 +76,9 @@ object ExprParser {
 
   def bgpParen[_: P]: P[BGP] = P("(" ~ bgp ~ triple.rep(1) ~ ")").map(BGP)
 
-  def pathQuadParen[_: P]: P[PathQuad] = P(
+  def pathQuadParen[_: P]: P[Path] = P(
     "(" ~ path ~ StringValParser.tripleValParser ~ PropertyPathParser.parser ~ StringValParser.tripleValParser ~ ")"
-  ).map(p => PathQuad(p._1, p._2, p._3, GRAPH_VARIABLE :: Nil))
+  ).map(p => Path(p._1, p._2, p._3, GRAPH_VARIABLE :: Nil))
 
   def exprFunc[_: P]: P[Expression] =
     ConditionalParser.parser |

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/PropertyExpression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/PropertyExpression.scala
@@ -1,8 +1,8 @@
 package com.gsk.kg.sparqlparser
 
-import higherkindness.droste.macros.deriveFixedPoint
-
 import cats.implicits._
+
+import higherkindness.droste.macros.deriveFixedPoint
 
 @deriveFixedPoint trait PropertyExpression
 

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/PropertyExpression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/PropertyExpression.scala
@@ -1,25 +1,31 @@
 package com.gsk.kg.sparqlparser
 
-sealed trait PropertyExpression
+import higherkindness.droste.macros.deriveFixedPoint
 
-final case class Alternative(pel: PropertyExpression, per: PropertyExpression)
-    extends PropertyExpression
-final case class Reverse(e: PropertyExpression) extends PropertyExpression
-final case class SeqExpression(
-    pel: PropertyExpression,
-    per: PropertyExpression
-)                                                  extends PropertyExpression
-final case class OneOrMore(e: PropertyExpression)  extends PropertyExpression
-final case class ZeroOrMore(e: PropertyExpression) extends PropertyExpression
-final case class ZeroOrOne(e: PropertyExpression)  extends PropertyExpression
-final case class NotOneOf(es: List[PropertyExpression])
-    extends PropertyExpression
-final case class BetweenNAndM(n: Int, m: Int, e: PropertyExpression)
-    extends PropertyExpression
-final case class ExactlyN(n: Int, e: PropertyExpression)
-    extends PropertyExpression
-final case class NOrMore(n: Int, e: PropertyExpression)
-    extends PropertyExpression
-final case class BetweenZeroAndN(n: Int, e: PropertyExpression)
-    extends PropertyExpression
-final case class Uri(s: String) extends PropertyExpression
+import cats.implicits._
+
+@deriveFixedPoint trait PropertyExpression
+
+object PropertyExpression {
+  final case class Alternative(pel: PropertyExpression, per: PropertyExpression)
+      extends PropertyExpression
+  final case class Reverse(e: PropertyExpression) extends PropertyExpression
+  final case class SeqExpression(
+      pel: PropertyExpression,
+      per: PropertyExpression
+  )                                                  extends PropertyExpression
+  final case class OneOrMore(e: PropertyExpression)  extends PropertyExpression
+  final case class ZeroOrMore(e: PropertyExpression) extends PropertyExpression
+  final case class ZeroOrOne(e: PropertyExpression)  extends PropertyExpression
+  final case class NotOneOf(es: List[PropertyExpression])
+      extends PropertyExpression
+  final case class BetweenNAndM(n: Int, m: Int, e: PropertyExpression)
+      extends PropertyExpression
+  final case class ExactlyN(n: Int, e: PropertyExpression)
+      extends PropertyExpression
+  final case class NOrMore(n: Int, e: PropertyExpression)
+      extends PropertyExpression
+  final case class BetweenZeroAndN(n: Int, e: PropertyExpression)
+      extends PropertyExpression
+  final case class Uri(s: String) extends PropertyExpression
+}

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/PropertyPathParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/PropertyPathParser.scala
@@ -1,5 +1,7 @@
 package com.gsk.kg.sparqlparser
 
+import com.gsk.kg.sparqlparser.PropertyExpression._
+
 import fastparse.MultiLineWhitespace._
 import fastparse._
 

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
@@ -1148,7 +1148,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?book"), VARIABLE("?displayString")),
-                PathQuad(
+                Path(
                   VARIABLE("?book"),
                   Alternative(
                     Uri("<http://purl.org/dc/elements/1.1/title>"),
@@ -1173,7 +1173,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?o"), VARIABLE("?s")),
-                PathQuad(
+                Path(
                   VARIABLE("?o"),
                   Reverse(Uri("<http://xmlns.org/foaf/0.1/mbox>")),
                   VARIABLE("?s"),
@@ -1195,7 +1195,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   SeqExpression(
                     SeqExpression(
@@ -1223,7 +1223,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   OneOrMore(Uri("<http://xmlns.org/foaf/0.1/knows>")),
                   VARIABLE("?o"),
@@ -1245,7 +1245,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   ZeroOrMore(Uri("<http://xmlns.org/foaf/0.1/knows>")),
                   VARIABLE("?o"),
@@ -1267,7 +1267,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   ZeroOrOne(Uri("<http://xmlns.org/foaf/0.1/knows>")),
                   VARIABLE("?o"),
@@ -1289,7 +1289,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   NotOneOf(List(Uri("<http://xmlns.org/foaf/0.1/name>"))),
                   VARIABLE("?o"),
@@ -1311,7 +1311,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   BetweenNAndM(1, 2, Uri("<http://xmlns.org/foaf/0.1/knows>")),
                   VARIABLE("?o"),
@@ -1333,7 +1333,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   ExactlyN(1, Uri("<http://xmlns.org/foaf/0.1/knows>")),
                   VARIABLE("?o"),
@@ -1355,7 +1355,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   NOrMore(1, Uri("<http://xmlns.org/foaf/0.1/knows>")),
                   VARIABLE("?o"),
@@ -1377,7 +1377,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   BetweenZeroAndN(1, Uri("<http://xmlns.org/foaf/0.1/knows>")),
                   VARIABLE("?o"),
@@ -1402,7 +1402,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
         p.get.value match {
           case Project(
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
-                PathQuad(
+                Path(
                   VARIABLE("?s"),
                   Alternative(
                     SeqExpression(
@@ -1436,7 +1436,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
                 Seq(VARIABLE("?s"), VARIABLE("?o")),
                 Sequence(
                   List(
-                    PathQuad(
+                    Path(
                       VARIABLE("?s"),
                       Alternative(
                         Alternative(
@@ -1448,7 +1448,7 @@ class ExprParserSpec extends AnyWordSpec with TestUtils {
                       VARIABLE("?o"),
                       List(GRAPH_VARIABLE)
                     ),
-                    PathQuad(
+                    Path(
                       VARIABLE("?s"),
                       Alternative(
                         SeqExpression(

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
@@ -7,6 +7,7 @@ import com.gsk.kg.sparqlparser.Conditional._
 import com.gsk.kg.sparqlparser.Expr._
 import com.gsk.kg.sparqlparser.PropertyExpression._
 import com.gsk.kg.sparqlparser.StringVal._
+
 import org.scalatest.wordspec.AnyWordSpec
 
 class ExprParserSpec extends AnyWordSpec with TestUtils {

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/ExprParserSpec.scala
@@ -5,8 +5,8 @@ import com.gsk.kg.sparqlparser.ConditionOrder.ASC
 import com.gsk.kg.sparqlparser.ConditionOrder.DESC
 import com.gsk.kg.sparqlparser.Conditional._
 import com.gsk.kg.sparqlparser.Expr._
+import com.gsk.kg.sparqlparser.PropertyExpression._
 import com.gsk.kg.sparqlparser.StringVal._
-
 import org.scalatest.wordspec.AnyWordSpec
 
 class ExprParserSpec extends AnyWordSpec with TestUtils {

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/PropertyExpressionParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/PropertyExpressionParserSpec.scala
@@ -1,5 +1,7 @@
 package com.gsk.kg.sparqlparser
 
+import com.gsk.kg.sparqlparser.PropertyExpression._
+
 import org.scalatest.wordspec.AnyWordSpec
 
 class PropertyExpressionParserSpec extends AnyWordSpec {

--- a/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
+++ b/modules/site/src/main/scala/com/gsk/kg/site/contrib/reftree/prelude.scala
@@ -140,6 +140,17 @@ object prelude {
       )
     case dag @ DAG.Sequence(bps) =>
       RefTree.Ref(dag, bps.map(_.refTree.toField))
+    case dag @ DAG.Path(s, p, o, g) =>
+      RefTree.Ref(
+        dag,
+        Seq(
+          s.refTree.toField,
+          p.toString.refTree.toField,
+          o.refTree.toField
+        ) ++ g.map(
+          _.refTree.toField
+        )
+      )
     case dag @ DAG.BGP(quads) =>
       RefTree.Ref(dag, Seq(quads.refTree.toField))
     case dag @ DAG.LeftJoin(l, r, filters) =>


### PR DESCRIPTION
# Description

This PR adds support for alternative property path. E.g:

```
PREFIX dc: <http://purl.org/dc/elements/1.1/>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

SELECT ?book ?displayString
WHERE {
 ?book dc:title|rdfs:label ?displayString .
}
```

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->
