### PR TITLE
use strict non-whitespace combinator to capture whitespace inside

### DIFF
--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringValParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/StringValParser.scala
@@ -11,7 +11,7 @@ object StringValParser {
   // RDF string literal could have optional language or optional iri
 
   def langString[_: P]: P[LANG_STRING] = P(
-    "\"" ~ CharsWhile(_ != '\"').! ~ "\"" ~ lang
+    "\"" ~~ CharsWhile(_ != '\"').! ~~ "\"" ~ lang
   ).map { case (s, tag) =>
     LANG_STRING(s, tag)
   }
@@ -21,7 +21,7 @@ object StringValParser {
   ).map(tag => LANG_STRING("", tag))
 
   def dataTypeString[_: P]: P[DT_STRING] = P(
-    "\"" ~ CharsWhile(_ != '\"').! ~ "\"" ~ "^^" ~ iri
+    "\"" ~~ CharsWhile(_ != '\"').! ~~ "\"" ~ "^^" ~ iri
   ).map { case (s, tag) =>
     DT_STRING(s, tag)
   }
@@ -31,7 +31,7 @@ object StringValParser {
   ).map(tag => DT_STRING("", tag))
 
   def plainString[_: P]: P[STRING] = P(
-    "\"" ~ CharsWhile(_ != '\"').! ~ "\""
+    "\"" ~~ CharsWhile(_ != '\"').! ~~ "\""
   ).map { s =>
     STRING(s)
   }

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/StringValParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/StringValParserSpec.scala
@@ -3,8 +3,9 @@ package com.gsk.kg.sparqlparser
 import com.gsk.kg.sparqlparser.StringVal._
 
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class StringValParserSpec extends AnyFlatSpec {
+class StringValParserSpec extends AnyFlatSpec with Matchers {
   "parse the string literal with tag" should "create proper STRING cass class" in {
     val s = "\"abc\"@en"
     val p = fastparse.parse(s, StringValParser.tripleValParser(_))
@@ -93,4 +94,102 @@ class StringValParserSpec extends AnyFlatSpec {
     }
   }
 
+  "parse string" should "parse nonempty strings correctly" in {
+    val strings: List[(String, StringVal.STRING)] =
+      List(
+        ("\"hello\"", StringVal.STRING("hello")),
+        ("\"hello goodbye\"", StringVal.STRING("hello goodbye"))
+      )
+
+    strings foreach { case (str, expected) =>
+      val p = fastparse.parse(str, StringValParser.plainString(_))
+
+      p.get.value shouldEqual expected
+    }
+  }
+
+  it should "parse strings containing whitespace correctly" in {
+    val strings: List[(String, StringVal.STRING)] =
+      List(
+        ("\" hello\"", StringVal.STRING(" hello")),
+        ("\" hello goodbye \"", StringVal.STRING(" hello goodbye "))
+      )
+
+    strings foreach { case (str, expected) =>
+      val p = fastparse.parse(str, StringValParser.plainString(_))
+
+      p.get.value shouldEqual expected
+    }
+  }
+
+  "parse typed literal" should "parse nonempty typed literals correctly" in {
+    val strings: List[(String, StringVal.DT_STRING)] =
+      List(
+        (
+          "\"hello\"^^<http://example.org/string>",
+          StringVal.DT_STRING("hello", "<http://example.org/string>")
+        ),
+        (
+          "\"hello goodbye\"^^<http://example.org/string>",
+          StringVal.DT_STRING("hello goodbye", "<http://example.org/string>")
+        )
+      )
+
+    strings foreach { case (str, expected) =>
+      val p = fastparse.parse(str, StringValParser.dataTypeString(_))
+
+      p.get.value shouldEqual expected
+    }
+  }
+
+  it should "parse strings containing whitespace correctly" in {
+    val strings: List[(String, StringVal.DT_STRING)] =
+      List(
+        (
+          "\" hello\"^^<http://example.org/string>",
+          StringVal.DT_STRING(" hello", "<http://example.org/string>")
+        ),
+        (
+          "\" hello goodbye \"^^<http://example.org/string>",
+          StringVal.DT_STRING(" hello goodbye ", "<http://example.org/string>")
+        )
+      )
+
+    strings foreach { case (str, expected) =>
+      val p = fastparse.parse(str, StringValParser.dataTypeString(_))
+
+      p.get.value shouldEqual expected
+    }
+  }
+
+  "parse l10n string" should "parse nonempty l10n strings correctly" in {
+    val strings: List[(String, StringVal.LANG_STRING)] =
+      List(
+        ("\"hello\"@en", StringVal.LANG_STRING("hello", "en")),
+        ("\"hello goodbye\"@en", StringVal.LANG_STRING("hello goodbye", "en"))
+      )
+
+    strings foreach { case (str, expected) =>
+      val p = fastparse.parse(str, StringValParser.langString(_))
+
+      p.get.value shouldEqual expected
+    }
+  }
+
+  it should "parse l10n strings with whitespace correctly" in {
+    val strings: List[(String, StringVal.LANG_STRING)] =
+      List(
+        ("\" hello\"@en", StringVal.LANG_STRING(" hello", "en")),
+        (
+          "\" hello goodbye \"@en",
+          StringVal.LANG_STRING(" hello goodbye ", "en")
+        )
+      )
+
+    strings foreach { case (str, expected) =>
+      val p = fastparse.parse(str, StringValParser.langString(_))
+
+      p.get.value shouldEqual expected
+    }
+  }
 }


### PR DESCRIPTION
# Description

This PR fixes AIPL-3429, using the strict `~~` fastparse combinator so we're able to capture whitespace within the string

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->