### PR TITLE
added implementation for seq property path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -315,7 +315,6 @@ lazy val `bellman-rdf-tests` = project
   .dependsOn(`bellman-algebra-parser` % "compile->compile;test->test")
   .dependsOn(`bellman-spark-engine` % "compile->compile;test->test")
 
-
 addCommandAlias(
   "build-microsite",
   ";bellman-site/run ;bellman-site/makeMicrosite"

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -257,8 +257,7 @@ object Engine {
       Foldable[ChunkedList].fold(
         quads.mapChunks { chunk =>
           val condition = composedConditionFromChunk(df, chunk)
-          val a         = applyChunkToDf(chunk, condition, df)
-          a
+          applyChunkToDf(chunk, condition, df)
         }
       )
     }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
@@ -1,24 +1,96 @@
 package com.gsk.kg.engine.properties
 
-import org.apache.spark.sql.Column
+import cats.implicits.catsSyntaxEitherId
+import cats.syntax.either._
+
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions._
 
+import com.gsk.kg.engine.PropertyExpressionF.ColOrDf
 import com.gsk.kg.engine.functions.FuncForms
+import com.gsk.kg.sparqlparser.EngineError
+import com.gsk.kg.sparqlparser.Result
 
 object FuncProperty {
 
-  def alternative(df: DataFrame, pel: Column, per: Column): Column = {
+  def alternative(
+      df: DataFrame,
+      pel: ColOrDf,
+      per: ColOrDf
+  ): Result[ColOrDf] = {
     val col = df("p")
-    when(
-      col.startsWith("\"") && col.endsWith("\""),
-      FuncForms.equals(trim(col, "\""), pel) ||
-        FuncForms.equals(trim(col, "\""), per)
-    ).otherwise(
-      FuncForms.equals(col, pel) ||
-        FuncForms.equals(col, per)
-    )
+
+    (pel, per) match {
+      case (Left(l), Left(r)) =>
+        Left(
+          when(
+            col.startsWith("\"") && col.endsWith("\""),
+            FuncForms.equals(trim(col, "\""), l) ||
+              FuncForms.equals(trim(col, "\""), r)
+          ).otherwise(
+            FuncForms.equals(col, l) ||
+              FuncForms.equals(col, r)
+          )
+        ).asRight
+      case _ =>
+        EngineError
+          .InvalidPropertyPathArguments(
+            s"Invalid arguments on property path: seq, pel: ${pel.toString}, per: ${per.toString}," +
+              s" both should be of type column"
+          )
+          .asLeft
+    }
   }
 
-  def uri(s: String): Column = lit(s)
+  def seq(
+      df: DataFrame,
+      pel: ColOrDf,
+      per: ColOrDf
+  ): Result[ColOrDf] = {
+
+    val resultL: Result[DataFrame] = (pel match {
+      case Left(col)    => df.filter(df("p") === col)
+      case Right(accDf) => accDf
+    })
+      .withColumnRenamed("s", "sl")
+      .withColumnRenamed("p", "pl")
+      .withColumnRenamed("o", "ol")
+      .asRight[EngineError]
+
+    val resultR: Result[DataFrame] = per match {
+      case Left(col) =>
+        (df
+          .filter(df("p") === col)
+          .withColumnRenamed("s", "sr")
+          .withColumnRenamed("p", "pr")
+          .withColumnRenamed("o", "or"))
+          .asRight[EngineError]
+      case Right(df) =>
+        EngineError
+          .InvalidPropertyPathArguments(
+            s"Invalid arguments on property path: seq, per: ${per.toString} should be of type column"
+          )
+          .asLeft[DataFrame]
+    }
+
+    for {
+      l <- resultL
+      r <- resultR
+    } yield {
+      Right(
+        l
+          .join(
+            r,
+            l("ol") <=> r("sr"),
+            "inner"
+          )
+          .select(l("sl"), r("or"))
+          .withColumnRenamed("sl", "s")
+          .withColumnRenamed("or", "o")
+      )
+    }
+  }
+
+  def uri(s: String): ColOrDf =
+    Left(lit(s))
 }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
@@ -59,9 +59,7 @@ class PropertyPathsSpec
         )
       }
 
-      // TODO: Un-ignore test when implemented support on property paths
-
-      "sequence / property path" ignore {
+      "sequence / property path" in {
 
         val df = List(
           (
@@ -97,6 +95,8 @@ class PropertyPathsSpec
           Row("\"Charles\"")
         )
       }
+
+      // TODO: Un-ignore test when implemented support on property paths
 
       "inverse ^ property path" ignore {
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
@@ -1,0 +1,147 @@
+package com.gsk.kg.engine.properties
+
+import cats.syntax.either._
+
+import org.apache.spark.sql.Row
+
+import com.gsk.kg.engine.compiler.SparkSpec
+import com.gsk.kg.engine.scalacheck.CommonGenerators
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class FuncPropertySpec
+    extends AnyWordSpec
+    with Matchers
+    with SparkSpec
+    with ScalaCheckDrivenPropertyChecks
+    with CommonGenerators {
+
+  import sqlContext.implicits._
+
+  override implicit def reuseContextIfPossible: Boolean = true
+
+  override implicit def enableHiveSupport: Boolean = false
+
+  "Funcs on Properties" when {
+
+    "Uri function" should {
+
+      "return expected column" in {
+
+        val df = List(
+          (
+            "<http://example.org/Alice>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Bob>"
+          ),
+          (
+            "<http://example.org/Bob>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Charles>"
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/name>",
+            "\"Charles\""
+          )
+        ).toDF("s", "p", "o")
+
+        val uriFunc = FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+        uriFunc shouldBe a[Left[_, _]]
+
+        val result = df.select(uriFunc.left.get)
+        result.collect().toSet shouldEqual Set(
+          Row("<http://xmlns.org/foaf/0.1/knows>"),
+          Row("<http://xmlns.org/foaf/0.1/knows>")
+        )
+      }
+    }
+
+    "Alternative function" should {
+
+      "return expected column" in {
+
+        val df = List(
+          (
+            "<http://example.org/book1>",
+            "<http://purl.org/dc/elements/1.1/title>",
+            "SPARQL Tutorial"
+          ),
+          (
+            "<http://example.org/book2>",
+            "<http://www.w3.org/2000/01/rdf-schema#label>",
+            "From Earth To The Moon"
+          ),
+          (
+            "<http://example.org/book3>",
+            "<http://www.w3.org/2000/01/rdf-schema#label2>",
+            "Another title"
+          )
+        ).toDF("s", "p", "o")
+
+        lazy val titleUriFunc =
+          FuncProperty.uri("<http://purl.org/dc/elements/1.1/title>")
+        lazy val labelUriFunc =
+          FuncProperty.uri("<http://www.w3.org/2000/01/rdf-schema#label>")
+        val alternativeFunc =
+          FuncProperty.alternative(df, titleUriFunc, labelUriFunc)
+
+        alternativeFunc.right.get shouldBe a[Left[_, _]]
+
+        val result = df.select(alternativeFunc.right.get.left.get).collect()
+        result.toSet shouldEqual Set(Row(true), Row(true), Row(false))
+      }
+    }
+
+    "Seq function" should {
+
+      "return expected dataframe" in {
+
+        val df = List(
+          (
+            "<http://example.org/Alice>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Bob>"
+          ),
+          (
+            "<http://example.org/Bob>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Charles>"
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/name>",
+            "\"Charles\""
+          )
+        ).toDF("s", "p", "o")
+
+        lazy val knowsUriFunc =
+          FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+        lazy val nameUriFunc =
+          FuncProperty.uri("<http://xmlns.org/foaf/0.1/name>")
+
+        val result = for {
+          // (seq <http://xmlns.org/foaf/0.1/knows> <http://xmlns.org/foaf/0.1/knows>)
+          innerSeq <- FuncProperty.seq(
+            df,
+            knowsUriFunc,
+            knowsUriFunc
+          )
+          // (seq (seq <http://xmlns.org/foaf/0.1/knows> <http://xmlns.org/foaf/0.1/knows>) <http://xmlns.org/foaf/0.1/name>)
+          outerSeq <- FuncProperty.seq(
+            df,
+            innerSeq,
+            nameUriFunc
+          )
+        } yield outerSeq
+
+        result.right.get.right.get.collect().toSet shouldEqual Set(
+          Row("<http://example.org/Alice>", "\"Charles\"")
+        )
+      }
+    }
+  }
+
+}

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/EngineError.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/EngineError.scala
@@ -14,7 +14,8 @@ object EngineError {
   final case class FunctionError(description: String) extends EngineError
   final case class AnalyzerError(errors: NonEmptyChain[String])
       extends EngineError
-  final case class InvalidInputDataFrame(msg: String)  extends EngineError
-  final case class ParsingError(description: String)   extends EngineError
-  final case class UnExpectedType(description: String) extends EngineError
+  final case class InvalidInputDataFrame(msg: String)        extends EngineError
+  final case class InvalidPropertyPathArguments(msg: String) extends EngineError
+  final case class ParsingError(description: String)         extends EngineError
+  final case class UnExpectedType(description: String)       extends EngineError
 }


### PR DESCRIPTION
# Description

This PR adds support for `seq` property path. E.g:

```
PREFIX foaf: <http://xmlns.org/foaf/0.1/>

SELECT ?o
WHERE {
 ?s foaf:knows/foaf:knows/foaf:name ?o .
}
```

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->
