### PR TITLE
testing out typed dataframes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val Versions = Map(
   "scalatestplus"        -> "3.2.3.0",
   "sansa"                -> "0.7.1",
   "monocle"              -> "1.5.0",
+  "frameless"            -> "0.8.0",
   "discipline"           -> "1.1.2",
   "discipline-scalatest" -> "2.0.1",
   "reftree"              -> "1.4.0",
@@ -130,6 +131,7 @@ lazy val `bellman-spark-engine` = project
   .settings(
     libraryDependencies ++= Seq(
       "io.verizon.quiver"          %% "core"         % Versions("quiver"),
+      "org.typelevel"              %% "frameless-dataset" % Versions("frameless"),
       "org.apache.spark"           %% "spark-sql"    % Versions("spark") % Provided,
       "com.github.julien-truffaut" %% "monocle-core" % Versions("monocle"),
       "com.github.julien-truffaut" %% "monocle-macro" % Versions("monocle"),

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/rdf/RdfValues.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/rdf/RdfValues.scala
@@ -1,0 +1,47 @@
+package com.gsk.kg.engine.rdf
+
+import com.gsk.kg.engine.rdf.RdfValue._
+
+import frameless.Injection
+
+sealed trait RdfValue {
+  override def toString(): String =
+    this match {
+      case RdfUri(value)                => s"<$value>"
+      case RdfString(value, None)       => s""""$value""""
+      case RdfString(value, Some(lang)) => s"""""$value"@$lang"""
+      case RdfLiteral(value, datatype)  => s""""$value"^^<$datatype>"""
+      case RdfInt(value) =>
+        s""""$value"^^<http://www.w3.org/2001/XMLSchema#int>"""
+      case RdfBoolean(value) =>
+        s""""$value"^^<http://www.w3.org/2001/XMLSchema#boolean>"""
+      case RdfDouble(value) =>
+        s""""$value"^^<http://www.w3.org/2001/XMLSchema#double>"""
+      case RdfDecimal(value) =>
+        s""""$value"^^<http://www.w3.org/2001/XMLSchema#decimal>"""
+      case RdfBlank(value) =>
+        s"""_:$value"""
+    }
+}
+object RdfValue {
+
+  final case class RdfString(value: String, tag: Option[String])
+      extends RdfValue
+  final case class RdfUri(value: String)                       extends RdfValue
+  final case class RdfLiteral(value: String, datatype: String) extends RdfValue
+  final case class RdfBoolean(value: Boolean)                  extends RdfValue
+  final case class RdfInt(value: Int)                          extends RdfValue
+  final case class RdfDouble(value: Double)                    extends RdfValue
+  final case class RdfDecimal(value: BigDecimal)               extends RdfValue
+  final case class RdfBlank(value: String)                     extends RdfValue
+
+  implicit val injection: Injection[RdfValue, String] =
+    new Injection[RdfValue, String] {
+      def invert(a: String): RdfValue =
+        fastparse.parse(a, parser.parse(_)).get.value
+      def apply(b: RdfValue): String =
+        b.toString
+    }
+}
+
+final case class RdfTriple(s: RdfValue, p: RdfValue, o: RdfValue)

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/rdf/parser.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/rdf/parser.scala
@@ -1,0 +1,102 @@
+package com.gsk.kg.engine.rdf
+
+import com.gsk.kg.sparqlparser.StringValParser._
+
+import fastparse.MultiLineWhitespace._
+import fastparse._
+
+object parser {
+
+  def uri[_: P]: P[RdfValue.RdfUri] = iri.map(RdfValue.RdfUri.apply)
+
+  def literal[_: P]: P[RdfValue.RdfLiteral] =
+    (emptyDataTypeString | dataTypeString).map { dt =>
+      RdfValue.RdfLiteral(dt.s, dt.tag)
+    }
+
+  def int[A](implicit P: P[A]): P[RdfValue.RdfInt] =
+    (emptyDataTypeString | dataTypeString).flatMap { dt =>
+      val ints = Set(
+        "http://www.w3.org/2001/XMLSchema#int",
+        "http://www.w3.org/2001/XMLSchema#integer",
+        "xsd:int",
+        "xsd:integer"
+      )
+      if (ints.contains(dt.tag)) {
+        P.freshSuccess(RdfValue.RdfInt(dt.s.toInt))
+      } else {
+        P.freshFailure()
+      }
+    }
+
+  def double[A](implicit P: P[A]): P[RdfValue.RdfDouble] =
+    (emptyDataTypeString | dataTypeString).flatMap { dt =>
+      val doubles = Set(
+        "http://www.w3.org/2001/XMLSchema#double",
+        "xsd:double"
+      )
+      if (doubles.contains(dt.tag)) {
+        P.freshSuccess(RdfValue.RdfDouble(dt.s.toDouble))
+      } else {
+        P.freshFailure()
+      }
+    }
+
+  def decimal[A](implicit P: P[A]): P[RdfValue.RdfDecimal] =
+    (emptyDataTypeString | dataTypeString).flatMap { dt =>
+      val decimals = Set(
+        "http://www.w3.org/2001/XMLSchema#decimal",
+        "xsd:decimal"
+      )
+      if (decimals.contains(dt.tag)) {
+        P.freshSuccess(RdfValue.RdfDecimal(dt.s.toInt))
+      } else {
+        P.freshFailure()
+      }
+    }
+
+  def boolean[A](implicit P: P[A]): P[RdfValue.RdfBoolean] =
+    (emptyDataTypeString | dataTypeString).flatMap { dt =>
+      val booleans = Set(
+        "http://www.w3.org/2001/XMLSchema#boolean",
+        "xsd:boolean"
+      )
+      if (booleans.contains(dt.tag)) {
+        P.freshSuccess(RdfValue.RdfBoolean(dt.s.toBoolean))
+      } else {
+        P.freshFailure()
+      }
+    }
+
+  def stringFromLiteral[A](implicit P: P[A]): P[RdfValue.RdfString] =
+    (emptyDataTypeString | dataTypeString).flatMap { dt =>
+      val strings = Set(
+        "http://www.w3.org/2001/XMLSchema#string",
+        "xsd:string"
+      )
+      if (strings.contains(dt.tag)) {
+        P.freshSuccess(RdfValue.RdfString(dt.s, None))
+      } else {
+        P.freshFailure()
+      }
+    }
+
+  def stringFromLangString[_: P]: P[RdfValue.RdfString] =
+    (emptyLangString | langString).map(ls =>
+      RdfValue.RdfString(ls.s, Some(ls.tag))
+    )
+
+  def stringFromPlainString[_: P]: P[RdfValue.RdfString] =
+    (emptyString | plainString).map(ls => RdfValue.RdfString(ls.s, None))
+
+  def rdfString[_: P]: P[RdfValue.RdfString] =
+    stringFromLangString | stringFromLiteral | stringFromPlainString
+
+  def blank[_: P]: P[RdfValue.RdfBlank] =
+    blankNode.map(bn => RdfValue.RdfBlank(bn.s))
+
+  def parse[_: P]: P[RdfValue] = P(
+    blank | uri | rdfString | boolean | int | double | decimal | literal
+  )
+
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/rdf/RdfValuesSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/rdf/RdfValuesSpec.scala
@@ -1,0 +1,77 @@
+package com.gsk.kg.engine.rdf
+
+import org.apache.spark.sql.DataFrame
+
+import com.gsk.kg.engine.compiler.SparkSpec
+import com.gsk.kg.engine.compiler.readNTtoDF
+import com.gsk.kg.engine.rdf.RdfValue._
+
+import frameless._
+import frameless.syntax._
+import org.scalatest.wordspec.AnyWordSpec
+import com.gsk.kg.engine.functions.FuncStrings
+
+class RdfValuesSpec extends AnyWordSpec with SparkSpec {
+
+  "parser" should {
+
+    "convert Rdf values to their String representation" in {
+      implicit val sparkSession = spark
+
+      val rdfValues: List[RdfValue] =
+        List(
+          RdfValue.RdfBoolean(false),
+          RdfValue.RdfDecimal(BigDecimal(4.3))
+        )
+
+      TypedDataset.create(rdfValues).show().run()
+    }
+
+    "example" in {
+      val dataFrame: DataFrame =
+        readNTtoDF("fixtures/reference-q1-input.nt")
+
+      val typed: TypedDataset[RdfTriple] = dataFrame.unsafeTyped[RdfTriple]
+
+      spark.time(
+        typed.deserialized
+          .map(triple => Func.strAfter(triple.s, "#"))
+          .collect
+          .run()
+          .foreach(println)
+      )
+
+      spark.time(
+        dataFrame
+          .select(FuncStrings.strafter(dataFrame("s"), "#"))
+          .collect
+          .foreach(println)
+      )
+    }
+  }
+
+}
+
+object Func {
+
+  def strAfter(
+      rdf: RdfValue,
+      sequence: String
+  ): RdfValue =
+    rdf match {
+      case s @ RdfString(value, tag) =>
+        val i = value.lastIndexOf(sequence)
+        if (i != -1)
+          s.copy(value = value.substring(i))
+        else
+          RdfString("", None)
+      case RdfUri(value) =>
+        val i = value.lastIndexOf(sequence)
+        if (i != -1)
+          RdfString(value.substring(i), None)
+        else
+          RdfString("", None)
+      case otherwise => otherwise
+    }
+
+}

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/StringValParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/StringValParserSpec.scala
@@ -192,4 +192,36 @@ class StringValParserSpec extends AnyFlatSpec with Matchers {
       p.get.value shouldEqual expected
     }
   }
+
+  "parse blank node" should "work correctly" in {
+    val strings = List(
+      (
+        "_:Ncdddad69172c41bf841e9974021ec93c",
+        StringVal.BLANK("Ncdddad69172c41bf841e9974021ec93c")
+      ),
+      (
+        "_:Nd399f2f35123439ab23ffa6f842467a7",
+        StringVal.BLANK("Nd399f2f35123439ab23ffa6f842467a7")
+      ),
+      (
+        "_:Nf40a89247d7d46a99bdc6302aac23dd4",
+        StringVal.BLANK("Nf40a89247d7d46a99bdc6302aac23dd4")
+      ),
+      (
+        "_:N91f8124526c2476c9d06f5854727c7fc",
+        StringVal.BLANK("N91f8124526c2476c9d06f5854727c7fc")
+      ),
+      (
+        "_:Nb757b546a3454984a69a66bcd3a4b6c1",
+        StringVal.BLANK("Nb757b546a3454984a69a66bcd3a4b6c1")
+      )
+    )
+
+    strings foreach { case (str, expected) =>
+      val p = fastparse.parse(str, StringValParser.blankNode(_))
+
+      p.get.value shouldEqual expected
+    }
+
+  }
 }


### PR DESCRIPTION
# Description

Here's my attempt at a more typed core for Bellman.  I'm creating this PR as more documentation and conversation space than something I'd like to merge to `master`.

**TLDR;**: Our hypothesis in which, by parsing strings to actual values would improve time, didn't work.

I think using using a more typed approach (either with Frameless, or plain Datasets) makes sense for ETLs, if someone is moving data from point to point and performing transformations inside.  On the other hand if what you (we in this case) is to create a general purpose query engine, and the shape of data can change on every expression that the user adds to the query, we need to use the most genera API possible, `DataFrames` in our case.  Otherwise, the performance penalty described in **`Deserialization`** is just too high.

In the file `RdfValuesSpec` you can see the two simple tests I wanted to perform.  On one hand I'm just calling a function implemented for untyped columns, and then the sample functino implemented for `RdfValues`. 

The first one is **noticeably** faster, and has far less heap & metaspace fingerprint.

# Conclusion

I think we shouldn't go for this approach for now.  It won't solve the issue as we expected.

Some takeaways of this spike:

## 👍🏻 Types

our functions could be typed when using this approach. See `def strafter` in the diff.  It looks much better than working with Spark column ops, and is less error prone.

## 👎🏻 Deserialization

If we want to use the typed APIs of either `frameless.TypedDataset`, or `spark.sql.DataSet`, we need our functions to operate on values on the heap.  In order to do that, these operations **must** run outside of catalyst, and Catalyst needs to convert from Tungsten representation to JVM and back again.

I expected typed functions to do the opposite, be serialized to catalyst operations instead.