### PR TITLE
add support zero or more property path (*)

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
@@ -35,7 +35,8 @@ object PropertyExpressionF {
             M.liftF(FuncProperty.seq(df, pel, per))
           case OneOrMoreF(e) =>
             M.liftF(FuncProperty.oneOrMore(df, e))
-          case ZeroOrMoreF(e)         => unknownPropertyPath("zeroOrMore")
+          case ZeroOrMoreF(e) =>
+            M.liftF(FuncProperty.zeroOrMore(df, e))
           case ZeroOrOneF(e)          => unknownPropertyPath("zeroOrOne")
           case NotOneOfF(es)          => unknownPropertyPath("notOneOf")
           case BetweenNAndMF(n, m, e) => unknownPropertyPath("betweenNAndM")

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
@@ -206,7 +206,7 @@ object FuncProperty {
     }
   }
 
-  /** It returns a dataframe with all the vertex that points to itselft (0 length path), the predicate column will
+  /** It returns a dataframe with all the vertices that point to itself (0 length path), the predicate column will
     * contain null values.
     * @param df
     * @return

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
@@ -96,8 +96,6 @@ class PropertyPathsSpec
         )
       }
 
-      // TODO: Un-ignore test when implemented support on property paths
-
       "inverse ^ property path" ignore {
 
         val df = List(
@@ -187,18 +185,23 @@ class PropertyPathsSpec
         )
       }
 
-      "arbitrary length * property path" ignore {
+      "arbitrary length * property path" in {
 
         val df = List(
           (
-            "<http://example.org/alice>",
+            "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/bob>"
+            "<http://example.org/Bob>"
           ),
           (
-            "<http://example.org/bob>",
+            "<http://example.org/Bob>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/charles>"
+            "<http://example.org/Charles>"
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/name>",
+            "\"Charles\""
           )
         ).toDF("s", "p", "o")
 
@@ -214,7 +217,15 @@ class PropertyPathsSpec
 
         val result = Compiler.compile(df, query, config)
 
-        result.right.get.collect.toSet shouldEqual Set()
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("\"Charles\"", "\"Charles\""),
+          Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
+          Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
+          Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+          Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
+          Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+          Row("<http://example.org/Alice>", "<http://example.org/Charles>")
+        )
       }
 
       "optional ? property path" ignore {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
@@ -190,6 +190,74 @@ class FuncPropertySpec
         )
       }
     }
+
+    "ZeroOrMore function" should {
+
+      "return expected values" in {
+
+        val df = List(
+          (
+            "<http://example.org/Alice>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Bob>"
+          ),
+          (
+            "<http://example.org/Bob>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Charles>"
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/name>",
+            "\"Charles\""
+          )
+        ).toDF("s", "p", "o")
+
+        // ?s foaf:knows* ?o
+        lazy val knowsUriFunc =
+          FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+        val result = FuncProperty.zeroOrMore(df, knowsUriFunc)
+
+        result.right.get.right.get.collect().toSet shouldEqual Set(
+          Row(
+            "<http://example.org/Alice>",
+            null,
+            "<http://example.org/Alice>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            null,
+            "<http://example.org/Bob>"
+          ),
+          Row(
+            "<http://example.org/Charles>",
+            null,
+            "<http://example.org/Charles>"
+          ),
+          Row(
+            "\"Charles\"",
+            null,
+            "\"Charles\""
+          ),
+          Row(
+            "<http://example.org/Alice>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Bob>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Charles>"
+          ),
+          Row(
+            "<http://example.org/Alice>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Charles>"
+          )
+        )
+      }
+    }
   }
 
 }


### PR DESCRIPTION
# Description

This PR adds support for zero or more property path. E.g:

```
PREFIX foaf: <http://xmlns.org/foaf/0.1/>

SELECT ?s ?o
WHERE {
 ?s foaf:knows* ?o .
}
```

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

Merge after #485 
