### PR TITLE
Add datatype function

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/ExpressionF.scala
@@ -63,6 +63,7 @@ object ExpressionF {
   final case class COALESCE[A](xs: List[A])             extends ExpressionF[A]
   final case class URI[A](s: A)                         extends ExpressionF[A]
   final case class LANG[A](s: A)                        extends ExpressionF[A]
+  final case class DATATYPE[A](s: A)                    extends ExpressionF[A]
   final case class LANGMATCHES[A](s: A, range: String)  extends ExpressionF[A]
   final case class LCASE[A](s: A)                       extends ExpressionF[A]
   final case class UCASE[A](s: A)                       extends ExpressionF[A]
@@ -133,6 +134,7 @@ object ExpressionF {
       case Conditional.BOUND(e)                 => BOUND(e)
       case Conditional.COALESCE(xs)             => COALESCE(xs)
       case BuiltInFunc.URI(s)                   => URI(s)
+      case BuiltInFunc.DATATYPE(s)              => DATATYPE(s)
       case BuiltInFunc.LANG(s)                  => LANG(s)
       case BuiltInFunc.LANGMATCHES(s, StringVal.STRING(range)) =>
         LANGMATCHES(s, range)
@@ -252,6 +254,8 @@ object ExpressionF {
         BuiltInFunc.UCASE(s.asInstanceOf[StringLike])
       case LANG(s) =>
         BuiltInFunc.LANG(s.asInstanceOf[StringLike])
+      case DATATYPE(s) =>
+        BuiltInFunc.DATATYPE(s.asInstanceOf[StringLike])
       case LANGMATCHES(s, range) =>
         BuiltInFunc.LANGMATCHES(
           s.asInstanceOf[StringLike],
@@ -419,6 +423,7 @@ object ExpressionF {
         case STRLANG(e, tag)            => FuncTerms.strlang(e, tag).pure[M]
         case URI(s)                     => FuncTerms.iri(s).pure[M]
         case LANG(s)                    => FuncTerms.lang(s).pure[M]
+        case DATATYPE(s)                => FuncTerms.datatype(s).pure[M]
         case ISLITERAL(s)               => FuncTerms.isLiteral(s).pure[M]
         case ISBLANK(s)                 => FuncTerms.isBlank(s).pure[M]
         case ISNUMERIC(s)               => FuncTerms.isNumeric(s).pure[M]

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/QueryExtractor.scala
@@ -242,6 +242,7 @@ object QueryExtractor {
       case COALESCE(xs)                    => s"(coalesce ${xs.mkString(", ")})"
       case ExpressionF.URI(s)              => s"(uri $s)"
       case LANG(s)                         => s"(lang $s)"
+      case DATATYPE(s)                     => s"(datatype $s)"
       case LANGMATCHES(s, range)           => s"(langmatches $s $range)"
       case LCASE(s)                        => s"(lcase $s)"
       case UCASE(s)                        => s"(ucase $s)"

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/analyzer/FindUnboundVariables.scala
@@ -175,6 +175,7 @@ object FindVariablesOnExpression {
         case MAX(e)                          => e
         case AVG(e)                          => e
         case SAMPLE(e)                       => e
+        case DATATYPE(e)                     => e
         case LANG(e)                         => e
         case LANGMATCHES(e, range)           => e
         case LCASE(e)                        => e

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/data/ToTree.scala
@@ -174,6 +174,7 @@ object ToTree extends LowPriorityToTreeInstances0 {
           case ExpressionF.LANGMATCHES(s, range) =>
             Node("LANGMATCHES", Stream(s, Leaf(range.toString)))
           case ExpressionF.LANG(s)      => Node("LANG", Stream(s))
+          case ExpressionF.DATATYPE(s)  => Node("DATATYPE", Stream(s))
           case ExpressionF.LCASE(s)     => Node("LCASE", Stream(s))
           case ExpressionF.UCASE(s)     => Node("UCASE", Stream(s))
           case ExpressionF.ISLITERAL(s) => Node("ISLITERAL", Stream(s))

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncTerms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncTerms.scala
@@ -108,7 +108,7 @@ object FuncTerms {
         when( // if the literal is a simple literal, return xsd:string
           isLiteral(col),
           "xsd:string"
-        ).otherwise( // not a literal. not defined by w3 spec. return lit("") or fail/exception/other?
+        ).otherwise( // input not a literal; not defined by w3 spec
           lit("")
         )
       )

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncTerms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncTerms.scala
@@ -3,9 +3,10 @@ package com.gsk.kg.engine.functions
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{concat => cc, _}
+
 import com.gsk.kg.engine.functions.Literals.TypedLiteral
-import com.gsk.kg.engine.functions.Literals.nullLiteral
 import com.gsk.kg.engine.functions.Literals.TypedLiteral.isTypedLiteral
+import com.gsk.kg.engine.functions.Literals.nullLiteral
 
 object FuncTerms {
 

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncTerms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncTerms.scala
@@ -3,8 +3,8 @@ package com.gsk.kg.engine.functions
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{concat => cc, _}
-
 import com.gsk.kg.engine.functions.Literals.TypedLiteral
+import com.gsk.kg.engine.functions.Literals.nullLiteral
 import com.gsk.kg.engine.functions.Literals.TypedLiteral.isTypedLiteral
 
 object FuncTerms {
@@ -108,8 +108,8 @@ object FuncTerms {
         when( // if the literal is a simple literal, return xsd:string
           isLiteral(col),
           "xsd:string"
-        ).otherwise( // input not a literal; not defined by w3 spec
-          lit("")
+        ).otherwise( // input was not a literal; behavior not defined by w3 spec
+          nullLiteral
         )
       )
     )

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncTerms.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/FuncTerms.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{concat => cc, _}
 
 import com.gsk.kg.engine.functions.Literals.TypedLiteral
+import com.gsk.kg.engine.functions.Literals.TypedLiteral.isTypedLiteral
 
 object FuncTerms {
 
@@ -19,7 +20,7 @@ object FuncTerms {
 
   /** Returns the string representation of a column.  It only modifies the data in the column if
     * it contains an URI wrapped in angle brackets, in which case it removes it.
-    * @param col
+    * @param value
     * @return
     */
   def str(value: String): Column =
@@ -88,6 +89,30 @@ object FuncTerms {
     * @return
     */
   def uri(col: Column): Column = iri(col)
+
+  /** Implementation of SparQL DATATYPE on Spark dataframes
+    *
+    * @see [[https://www.w3.org/TR/sparql11-query/#func-datatype]]
+    * @param col
+    * @return a Column containing the datatype IRI of for each literal
+    */
+  def datatype(col: Column): Column =
+    when( // if the literal is a typed literal, return the datatype IRI
+      isTypedLiteral(col),
+      TypedLiteral(col).tag
+    ).otherwise(
+      when( // if the literal has a language tag, return rdf:langString
+        !lang(col).equalTo(lit("")),
+        "rdf:langString"
+      ).otherwise(
+        when( // if the literal is a simple literal, return xsd:string
+          isLiteral(col),
+          "xsd:string"
+        ).otherwise( // not a literal. not defined by w3 spec. return lit("") or fail/exception/other?
+          lit("")
+        )
+      )
+    )
 
   /** Implementation of SparQL LANG on Spark dataframes.
     *

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncTermsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncTermsSpec.scala
@@ -3,7 +3,6 @@ package com.gsk.kg.engine.functions
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
 import com.gsk.kg.engine.compiler.SparkSpec
-import com.gsk.kg.engine.functions.Literals.TypedLiteral
 import com.gsk.kg.engine.scalacheck.CommonGenerators
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncTermsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncTermsSpec.scala
@@ -2,8 +2,10 @@ package com.gsk.kg.engine.functions
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
+
 import com.gsk.kg.engine.compiler.SparkSpec
 import com.gsk.kg.engine.scalacheck.CommonGenerators
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncTermsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncTermsSpec.scala
@@ -110,7 +110,7 @@ class FuncTermsSpec
           Row("xsd:double"),
           Row("xsd:string"),
           Row("rdf:langString"),
-          Row("")
+          Row(null)
         )
       }
     }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncTermsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/functions/FuncTermsSpec.scala
@@ -2,10 +2,9 @@ package com.gsk.kg.engine.functions
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
-
 import com.gsk.kg.engine.compiler.SparkSpec
+import com.gsk.kg.engine.functions.Literals.TypedLiteral
 import com.gsk.kg.engine.scalacheck.CommonGenerators
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -93,6 +92,26 @@ class FuncTermsSpec
         result shouldEqual Array(
           Row("\"chat\"@es"),
           Row("\"foo\"@es")
+        )
+      }
+    }
+
+    "FuncTerms.datatype" should {
+      "return the datatype IRI of a literal" in {
+        val df = List(
+          "\"1.1\"^^xsd:double", // a typed literal
+          "\"1\"",               // a simple literal
+          "\"foo\"@es",          // a literal with a language tag
+          "not a literal"
+        ).toDF("literals")
+
+        df.select(
+          FuncTerms.datatype(df("literals"))
+        ).collect shouldEqual Array(
+          Row("xsd:double"),
+          Row("xsd:string"),
+          Row("rdf:langString"),
+          Row("")
         )
       }
     }

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/BuiltInFuncParser.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/BuiltInFuncParser.scala
@@ -28,6 +28,7 @@ object BuiltInFuncParser {
   def isLiteral[_: P]: P[Unit]    = P("isLiteral")
   def isNumeric[_: P]: P[Unit]    = P("isNumeric")
   def encodeForURI[_: P]: P[Unit] = P("encode_for_uri")
+  def datatype[_: P]: P[Unit]     = P("datatype")
   def lang[_: P]: P[Unit]         = P("lang")
   def langMatches[_: P]: P[Unit]  = P("langMatches")
   def md5[_: P]: P[Unit]          = P("md5" | "MD5")
@@ -138,6 +139,10 @@ object BuiltInFuncParser {
     P("(" ~ encodeForURI ~ ExpressionParser.parser ~ ")")
       .map(f => ENCODE_FOR_URI(f))
 
+  def datatypeParen[_: P]: P[DATATYPE] =
+    P("(" ~ datatype ~ ExpressionParser.parser ~ ")")
+      .map(f => DATATYPE(f))
+
   def langParen[_: P]: P[LANG] =
     P("(" ~ lang ~ ExpressionParser.parser ~ ")")
       .map(f => LANG(f))
@@ -200,6 +205,7 @@ object BuiltInFuncParser {
         | isLiteralParen
         | isNumericParen
         | encodeForURIParen
+        | datatypeParen
         | langParen
         | langMatchesParen
         | md5Paren

--- a/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/sparqlparser/Expression.scala
@@ -45,9 +45,10 @@ object BuiltInFunc {
   final case class CONCAT(
       appendTo: Expression,
       append: List[Expression]
-  )                                    extends BuiltInFunc
-  final case class STR(s: Expression)  extends BuiltInFunc
-  final case class LANG(s: Expression) extends BuiltInFunc
+  )                                        extends BuiltInFunc
+  final case class STR(s: Expression)      extends BuiltInFunc
+  final case class LANG(s: Expression)     extends BuiltInFunc
+  final case class DATATYPE(s: Expression) extends BuiltInFunc
   final case class LANGMATCHES(s: Expression, range: Expression)
       extends BuiltInFunc
   final case class LCASE(s: Expression)                    extends BuiltInFunc

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/BuiltInFuncParserSpec.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/BuiltInFuncParserSpec.scala
@@ -314,6 +314,16 @@ class BuiltInFuncParserSpec extends AnyFlatSpec {
     }
   }
 
+  "DATATYPE parser" should "return DATATYPE type" in {
+    val p =
+      fastparse.parse("""(datatype ?d)""", BuiltInFuncParser.datatypeParen(_))
+    p.get.value match {
+      case DATATYPE(VARIABLE("?d")) =>
+        succeed
+      case _ => fail
+    }
+  }
+
   "LANG parser" should "return LANG type" in {
     val p =
       fastparse.parse("""(lang ?d)""", BuiltInFuncParser.langParen(_))

--- a/modules/rdf-tests/src/test/scala/com/gsk/kg/RdfTests.scala
+++ b/modules/rdf-tests/src/test/scala/com/gsk/kg/RdfTests.scala
@@ -161,7 +161,9 @@ class RdfTests extends AnyWordSpec with Matchers with SparkSpec {
       .toDF()
 
     RdfFormatter.formatDataFrame(
-      formatDF(df.select(explode(col(df.columns.head)))), Config.default.copy(formatRdfOutput = true))
+      formatDF(df.select(explode(col(df.columns.head)))),
+      Config.default.copy(formatRdfOutput = true)
+    )
   }
 
   def formatDF(df: DataFrame): DataFrame =


### PR DESCRIPTION
Implementation of the datatype function.

```
iri  DATATYPE (literal literal)
Returns the datatype IRI of a literal.

If the literal is a typed literal, return the datatype IRI.
If the literal is a simple literal, return xsd:string
If the literal is literal with a language tag, return rdf:langString
```
More at https://www.w3.org/TR/sparql11-query/#func-datatype

Closes #263 
