### PR TITLE
add support property path zero or one

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
@@ -37,7 +37,8 @@ object PropertyExpressionF {
             M.liftF(FuncProperty.oneOrMore(df, e))
           case ZeroOrMoreF(e) =>
             M.liftF(FuncProperty.zeroOrMore(df, e))
-          case ZeroOrOneF(e)          => unknownPropertyPath("zeroOrOne")
+          case ZeroOrOneF(e) =>
+            M.liftF(FuncProperty.zeroOrOne(df, e))
           case NotOneOfF(es)          => unknownPropertyPath("notOneOf")
           case BetweenNAndMF(n, m, e) => unknownPropertyPath("betweenNAndM")
           case ExactlyNF(n, e)        => unknownPropertyPath("exactlyN")

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
@@ -142,6 +142,20 @@ object FuncProperty {
     }
   }
 
+  def zeroOrOne(df: DataFrame, e: ColOrDf): Result[ColOrDf] = {
+
+    val onePath = (e match {
+      case Right(predDf) => predDf
+      case Left(predCol) => df.filter(predCol <=> df("p"))
+    }).drop("g")
+
+    val zeroPath = getZeroPaths(df)
+
+    (onePath union zeroPath)
+      .asRight[Column]
+      .asRight[EngineError]
+  }
+
   def uri(s: String): ColOrDf =
     Left(lit(s))
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
@@ -228,18 +228,23 @@ class PropertyPathsSpec
         )
       }
 
-      "optional ? property path" ignore {
+      "optional ? property path" in {
 
         val df = List(
           (
-            "<http://example.org/alice>",
+            "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/bob>"
+            "<http://example.org/Bob>"
           ),
           (
-            "<http://example.org/bob>",
+            "<http://example.org/Bob>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/charles>"
+            "<http://example.org/Charles>"
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/name>",
+            "\"Charles\""
           )
         ).toDF("s", "p", "o")
 
@@ -255,7 +260,14 @@ class PropertyPathsSpec
 
         val result = Compiler.compile(df, query, config)
 
-        result.right.get.collect.toSet shouldEqual Set()
+        result.right.get.collect.toSet shouldEqual Set(
+          Row("\"Charles\"", "\"Charles\""),
+          Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
+          Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+          Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
+          Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
+          Row("<http://example.org/Alice>", "<http://example.org/Bob>")
+        )
       }
 
       "negated ! property path" ignore {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
@@ -258,6 +258,68 @@ class FuncPropertySpec
         )
       }
     }
-  }
 
+    "ZeroOrOne function" should {
+
+      "return expected values" in {
+
+        val df = List(
+          (
+            "<http://example.org/Alice>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Bob>"
+          ),
+          (
+            "<http://example.org/Bob>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Charles>"
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/name>",
+            "\"Charles\""
+          )
+        ).toDF("s", "p", "o")
+
+        // ?s foaf:knows? ?o
+        lazy val knowsUriFunc =
+          FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+        val result = FuncProperty.zeroOrOne(df, knowsUriFunc)
+
+        result.right.get.right.get.collect().toSet shouldEqual Set(
+          Row(
+            "<http://example.org/Alice>",
+            null,
+            "<http://example.org/Alice>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            null,
+            "<http://example.org/Bob>"
+          ),
+          Row(
+            "<http://example.org/Charles>",
+            null,
+            "<http://example.org/Charles>"
+          ),
+          Row(
+            "\"Charles\"",
+            null,
+            "\"Charles\""
+          ),
+          Row(
+            "<http://example.org/Alice>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Bob>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Charles>"
+          )
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Description

This PR adds support for zero or one property path (optional). E.g:

```
PREFIX foaf: <http://xmlns.org/foaf/0.1/>

SELECT ?s ?o
WHERE {
 ?s foaf:knows? ?o .
}
```

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

Merge after #487 
