### PR TITLE
Property paths n or more and zero to n

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
@@ -44,9 +44,11 @@ object PropertyExpressionF {
             M.liftF(FuncProperty.betweenNAndM(df, Some(n), Some(m), e))
           case ExactlyNF(n, e) =>
             M.liftF(FuncProperty.exactlyN(df, n, e))
-          case NOrMoreF(n, e)         => unknownPropertyPath("nOrMore")
-          case BetweenZeroAndNF(n, e) => unknownPropertyPath("betweenZeroAndN")
-          case UriF(s)                => FuncProperty.uri(s).pure[M]
+          case NOrMoreF(n, e) =>
+            M.liftF(FuncProperty.betweenNAndM(df, Some(n), None, e))
+          case BetweenZeroAndNF(n, e) =>
+            M.liftF(FuncProperty.betweenNAndM(df, None, Some(n), e))
+          case UriF(s) => FuncProperty.uri(s).pure[M]
         }
 
       val eval = scheme.cataM[M, PropertyExpressionF, T, ColOrDf](algebraM)

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
@@ -350,18 +350,33 @@ class PropertyPathsSpec
         )
       }
 
-      "fixed length {n,} property path" ignore {
+      "fixed length {n,} property path" in {
 
         val df = List(
           (
-            "<http://example.org/alice>",
+            "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/bob>"
+            "<http://example.org/Bob>"
           ),
           (
-            "<http://example.org/bob>",
+            "<http://example.org/Bob>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/charles>"
+            "<http://example.org/Charles>"
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/name>",
+            "\"Charles\""
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Daniel>"
+          ),
+          (
+            "<http://example.org/Daniel>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Erick>"
           )
         ).toDF("s", "p", "o")
 
@@ -371,27 +386,67 @@ class PropertyPathsSpec
             |
             |SELECT ?s ?o
             |WHERE {
-            | ?s foaf:knows{1,} ?o .
+            | ?s foaf:knows{2,} ?o .
             |}
             |""".stripMargin
 
         val result = Compiler.compile(df, query, config)
 
-        result.right.get.collect.toSet shouldEqual Set()
+        result.right.get.collect.toSet shouldEqual Set(
+          Row(
+            "<http://example.org/Alice>",
+            "<http://example.org/Charles>"
+          ),
+          Row(
+            "<http://example.org/Alice>",
+            "<http://example.org/Daniel>"
+          ),
+          Row(
+            "<http://example.org/Alice>",
+            "<http://example.org/Erick>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            "<http://example.org/Daniel>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            "<http://example.org/Erick>"
+          ),
+          Row(
+            "<http://example.org/Charles>",
+            "<http://example.org/Erick>"
+          )
+        )
       }
 
-      "fixed length {,n} property path" ignore {
+      "fixed length {,n} property path" in {
 
         val df = List(
           (
-            "<http://example.org/alice>",
+            "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/bob>"
+            "<http://example.org/Bob>"
           ),
           (
-            "<http://example.org/bob>",
+            "<http://example.org/Bob>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/charles>"
+            "<http://example.org/Charles>"
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/name>",
+            "\"Charles\""
+          ),
+          (
+            "<http://example.org/Charles>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Daniel>"
+          ),
+          (
+            "<http://example.org/Daniel>",
+            "<http://xmlns.org/foaf/0.1/knows>",
+            "<http://example.org/Erick>"
           )
         ).toDF("s", "p", "o")
 
@@ -401,13 +456,66 @@ class PropertyPathsSpec
             |
             |SELECT ?s ?o
             |WHERE {
-            | ?s foaf:knows{,1} ?o .
+            | ?s foaf:knows{,2} ?o .
             |}
             |""".stripMargin
 
         val result = Compiler.compile(df, query, config)
 
-        result.right.get.collect.toSet shouldEqual Set()
+        result.right.get.collect.toSet shouldEqual Set(
+          Row(
+            "\"Charles\"",
+            "\"Charles\""
+          ),
+          Row(
+            "<http://example.org/Alice>",
+            "<http://example.org/Alice>"
+          ),
+          Row(
+            "<http://example.org/Alice>",
+            "<http://example.org/Bob>"
+          ),
+          Row(
+            "<http://example.org/Alice>",
+            "<http://example.org/Charles>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            "<http://example.org/Bob>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            "<http://example.org/Charles>"
+          ),
+          Row(
+            "<http://example.org/Bob>",
+            "<http://example.org/Daniel>"
+          ),
+          Row(
+            "<http://example.org/Charles>",
+            "<http://example.org/Charles>"
+          ),
+          Row(
+            "<http://example.org/Charles>",
+            "<http://example.org/Daniel>"
+          ),
+          Row(
+            "<http://example.org/Charles>",
+            "<http://example.org/Erick>"
+          ),
+          Row(
+            "<http://example.org/Daniel>",
+            "<http://example.org/Daniel>"
+          ),
+          Row(
+            "<http://example.org/Daniel>",
+            "<http://example.org/Erick>"
+          ),
+          Row(
+            "<http://example.org/Erick>",
+            "<http://example.org/Erick>"
+          )
+        )
       }
 
       "fixed length {n} property path" in {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
@@ -383,7 +383,7 @@ class FuncPropertySpec
 
     "BetweenNAndM function" should {
 
-      "return expected values " when {
+      "return expected values" when {
 
         "from Some(1) to Some(3) path length (n < m)" in {
 
@@ -734,7 +734,225 @@ class FuncPropertySpec
           result shouldBe a[Left[_, _]]
         }
 
-        // TODO: add cases for n = None and m = None
+        "from Some(2) to None path length" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+          val n = 2
+
+          // ?s foaf:knows{2,} ?o
+          val result =
+            FuncProperty.betweenNAndM(df, Some(n), None, knowsUriFunc)
+
+          result.right.get.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          )
+        }
+
+        "from None to Some(2) path length" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+          val n = 2
+
+          // ?s foaf:knows{,2} ?o
+          val result =
+            FuncProperty.betweenNAndM(df, None, Some(n), knowsUriFunc)
+
+          result.right.get.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "\"Charles\"",
+              null,
+              "\"Charles\""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              null,
+              "<http://example.org/Alice>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              null,
+              "<http://example.org/Bob>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              null,
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              null,
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Erick>",
+              null,
+              "<http://example.org/Erick>"
+            )
+          )
+        }
+
+        "from None to None path length (error)" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+          val result =
+            FuncProperty.betweenNAndM(df, None, None, knowsUriFunc)
+
+          result shouldBe a[Left[_, _]]
+        }
       }
     }
   }


### PR DESCRIPTION
# Description
This PR adds support for two property paths:

- N or More paths:

```
PREFIX foaf: <http://xmlns.org/foaf/0.1/>

SELECT ?s ?o
WHERE {
 ?s foaf:knows{2,} ?o .
}
```

- Zero to N paths:

```
PREFIX foaf: <http://xmlns.org/foaf/0.1/>

SELECT ?s ?o
WHERE {
 ?s foaf:knows{,2} ?o .
}
```

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->

Merge after #502 
