### PR TITLE
added support for not one of property path

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
@@ -34,17 +34,16 @@ object PropertyExpressionF {
           case SeqExpressionF(pel, per) =>
             M.liftF(FuncProperty.seq(df, pel, per))
           case OneOrMoreF(e) =>
-            M.liftF(FuncProperty.oneOrMore(df, e))
+            M.liftF(FuncProperty.betweenNAndM(df, Some(1), None, e))
           case ZeroOrMoreF(e) =>
-            M.liftF(FuncProperty.zeroOrMore(df, e))
+            M.liftF(FuncProperty.betweenNAndM(df, Some(0), None, e))
           case ZeroOrOneF(e) =>
-            M.liftF(FuncProperty.zeroOrOne(df, e))
+            M.liftF(FuncProperty.betweenNAndM(df, Some(0), Some(1), e))
           case NotOneOfF(es) =>
             M.liftF(FuncProperty.notOneOf(df, es))
           case BetweenNAndMF(n, m, e) =>
             M.liftF(FuncProperty.betweenNAndM(df, Some(n), Some(m), e))
           case ExactlyNF(n, e) =>
-//            M.liftF(FuncProperty.exactlyN(df, n, e))
             M.liftF(FuncProperty.betweenNAndM(df, Some(n), Some(n), e))
           case NOrMoreF(n, e) =>
             M.liftF(FuncProperty.betweenNAndM(df, Some(n), None, e))

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/PropertyExpressionF.scala
@@ -39,11 +39,13 @@ object PropertyExpressionF {
             M.liftF(FuncProperty.zeroOrMore(df, e))
           case ZeroOrOneF(e) =>
             M.liftF(FuncProperty.zeroOrOne(df, e))
-          case NotOneOfF(es) => unknownPropertyPath("notOneOf")
+          case NotOneOfF(es) =>
+            M.liftF(FuncProperty.notOneOf(df, es))
           case BetweenNAndMF(n, m, e) =>
             M.liftF(FuncProperty.betweenNAndM(df, Some(n), Some(m), e))
           case ExactlyNF(n, e) =>
-            M.liftF(FuncProperty.exactlyN(df, n, e))
+//            M.liftF(FuncProperty.exactlyN(df, n, e))
+            M.liftF(FuncProperty.betweenNAndM(df, Some(n), Some(n), e))
           case NOrMoreF(n, e) =>
             M.liftF(FuncProperty.betweenNAndM(df, Some(n), None, e))
           case BetweenZeroAndNF(n, e) =>

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/functions/PathFrame.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/functions/PathFrame.scala
@@ -13,7 +13,6 @@ import scala.util.Try
 
 object PathFrame {
 
-  // scalastyle: off
   /** PathFrame is an alias for a dataframe which contains paths of different lengths. E.g:
     *
     * For this DataFrame which contains SPO triples (path of 1 length):
@@ -35,14 +34,22 @@ object PathFrame {
     * |<http://example.org/Charles>|<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Daniel> |
     * |<http://example.org/Daniel> |<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Erick>  |
     * +----------------------------+---------------------------------+----------------------------+
-    * +---------------------------------+----------------------------+---------------------------------+---------------------------+
-    * |4                                |5                           |6                                |7                          |
-    * +---------------------------------+----------------------------+---------------------------------+---------------------------+
-    * |<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Charles>|<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Daniel>|
-    * |<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Daniel> |<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Erick> |
-    * |<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Erick>  |null                             |null                       |
-    * |null                             |null                        |null                             |null                       |
-    * +---------------------------------+----------------------------+---------------------------------+---------------------------+
+    * +---------------------------------+----------------------------+---------------------------------+
+    * |4                                |5                           |6                                |
+    * +---------------------------------+----------------------------+---------------------------------+
+    * |<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Charles>|<http://xmlns.org/foaf/0.1/knows>|
+    * |<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Daniel> |<http://xmlns.org/foaf/0.1/knows>|
+    * |<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Erick>  |null                             |
+    * |null                             |null                        |null                             |
+    * +---------------------------------+----------------------------+---------------------------------+
+    * +---------------------------+---------------------------------+---------------------------+
+    * |7                          |8                                |9                          |
+    * +---------------------------+---------------------------------+---------------------------+
+    * |<http://example.org/Daniel>|<http://xmlns.org/foaf/0.1/knows>|<http://example.org/Erick> |
+    * |<http://example.org/Erick> |<http://xmlns.org/foaf/0.1/knows>|null                       |
+    * |null                       |null                             |null                       |
+    * |null                       |null                             |null                       |
+    * +---------------------------+---------------------------------+---------------------------+
     *
     * Where the graph that forms the initial DataFrame has been traversed and generated a new DataFrame that contains
     * the paths of the graph. Taking a look at this PathFrame we can see that it contains next path lengths:
@@ -50,7 +57,7 @@ object PathFrame {
     * - 2 length: triples from columns 1 to 5.
     * - 3 length: triples from columns 1 to 7.
     */
-  // scalastyle: on
+
   type PathFrame = DataFrame
 
   val SIdx = 1
@@ -59,27 +66,22 @@ object PathFrame {
 
   /** It receives a base dataframe with all triples of the graph and creates a new dataframe which will contain all
     * existing paths. This is done by iterating and accumulating results for every new depth level until there are no
-    * more triples to connect.
-    * @param baseDf Base dataframe with all the triples unconnected
-    * @param accDf The dataframe which it will accumulate every depth level of paths
-    * @param i Iteration index
-    * @param sIdx Subject index (for column renaming)
-    * @param pIdx Predicate index (for column renaming)
-    * @param oIdx Object index (for column renaming
+    * more triples to connect or it reaches some limit.
+    * @param initial Base dataframe with all the one length paths
+    * @param limit If some it will set a limit to iterate while constructing the PathFrame
     * @return Dataframe with all the triples connected creating paths
     */
   def constructPathFrame(
-      oneLengthPaths: DataFrame,
-      accPaths: DataFrame,
+      initial: DataFrame,
       limit: Option[Int]
   ): (Int, PathFrame) = {
 
     @tailrec
     def step(
-        oneLengthPaths: DataFrame,
-        accPaths: DataFrame,
+        oneLengthPaths: PathFrame,
+        accPaths: PathFrame,
         i: Int
-    ): (Int, DataFrame) = {
+    ): (Int, PathFrame) = {
 
       lazy val stepSlice: Int => Int = x => x + (2 * i)
 
@@ -113,10 +115,14 @@ object PathFrame {
     }
 
     val i = 1
-    step(oneLengthPaths, accPaths, i)
+    step(initial, initial, i)
   }
 
-  def getOneLengthPaths(df: DataFrame): DataFrame = {
+  /** This function will return a PathFrame containing the path 0 length for a given dataframe.
+    * @param df
+    * @return
+    */
+  def getOneLengthPaths(df: DataFrame): PathFrame = {
     df
       .drop("g")
       .withColumnRenamed("s", s"$SIdx")
@@ -124,12 +130,12 @@ object PathFrame {
       .withColumnRenamed("o", s"$OIdx")
   }
 
-  /** It returns a dataframe with all the vertex that points to itselft (0 length path), the predicate column will
-    * contain null values.
+  /** This function a PathFrame with all the vertex that points to itself (0 length path),
+    * the predicate column will contain null values.
     * @param df
     * @return
     */
-  def getZeroLengthPaths(df: DataFrame): DataFrame = {
+  def getZeroLengthPaths(df: DataFrame): PathFrame = {
     val sDf = df.select(df("s"))
     val oDf = df.select(df("o"))
 
@@ -142,15 +148,18 @@ object PathFrame {
       .withColumnRenamed("o", s"$OIdx")
   }
 
-  /** @param pathDf
-    * @param nPath
+  /** This function will return the n paths length triples from a given PathFrame.
+    * @param df Initial Dataframe (this is needed because for path 0 length we need to know all vertex, also the ones
+    *           not included in the PathFrame).
+    * @param pathFrame The PathFrame that contains all length paths.
+    * @param nPath The n length path that is wanted to be extracted.
     * @return
     */
   def getNLengthPathTriples(
       df: DataFrame,
-      pathDf: DataFrame,
+      pathFrame: PathFrame,
       nPath: Int
-  ): DataFrame = {
+  ): PathFrame = {
     if (nPath == 0) {
       getZeroLengthPaths(df)
     } else {
@@ -159,10 +168,10 @@ object PathFrame {
 
       val cols = Seq(SIdx.toString, PIdx.toString, oSlice.toString)
 
-      val nPaths = pathDf
+      val nPaths = pathFrame
         .select(cols.head, cols.tail: _*)
         .filter(cols.foldLeft(lit(true)) { case (acc, elem) =>
-          acc && pathDf(elem).isNotNull
+          acc && pathFrame(elem).isNotNull
         })
         .withColumnRenamed(s"$oSlice", s"$OIdx")
 
@@ -178,8 +187,8 @@ object PathFrame {
     */
   def merge(df1: DataFrame, df2: DataFrame): DataFrame = {
 
-    def getNewColumns(column: Set[String], merged_cols: Set[String]) = {
-      merged_cols.toList.map {
+    def getNewColumns(column: Set[String], mergedCols: Set[String]) = {
+      mergedCols.toList.map {
         case x if column.contains(x) => col(x)
         case x @ _                   => nullLiteral.as(x)
       }
@@ -194,6 +203,10 @@ object PathFrame {
     newDf1.unionByName(newDf2)
   }
 
+  /** It transforms a PathFrame into a Dataframe renaming columns to SPOG.
+    * @param pf Pathframe that is wanted to be converted.
+    * @return
+    */
   def toSPOG(pf: PathFrame): DataFrame = {
 
     def hasColumn(df: DataFrame, path: String) = Try(df(path)).isSuccess

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
@@ -143,265 +143,6 @@ class FuncPropertySpec
       }
     }
 
-    "OneOrMore function" should {
-
-      "return expected values" in {
-
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
-          )
-        ).toDF("s", "p", "o")
-
-        // ?s foaf:knows+ ?o
-        lazy val knowsUriFunc =
-          FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
-
-        val result = FuncProperty.oneOrMore(df, knowsUriFunc)
-
-        result.right.get.right.get.collect().toSet shouldEqual Set(
-          Row(
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>",
-            ""
-          )
-        )
-      }
-    }
-
-    "ZeroOrMore function" should {
-
-      "return expected values" in {
-
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
-          )
-        ).toDF("s", "p", "o")
-
-        // ?s foaf:knows* ?o
-        lazy val knowsUriFunc =
-          FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
-
-        val result = FuncProperty.zeroOrMore(df, knowsUriFunc)
-
-        result.right.get.right.get.show(false)
-
-        result.right.get.right.get.collect().toSet shouldEqual Set(
-          Row(
-            "<http://example.org/Alice>",
-            null,
-            "<http://example.org/Alice>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            null,
-            "<http://example.org/Bob>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Charles>",
-            null,
-            "<http://example.org/Charles>",
-            ""
-          ),
-          Row(
-            "\"Charles\"",
-            null,
-            "\"Charles\"",
-            ""
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>",
-            ""
-          )
-        )
-      }
-    }
-
-    "ZeroOrOne function" should {
-
-      "return expected values" in {
-
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
-          )
-        ).toDF("s", "p", "o")
-
-        // ?s foaf:knows? ?o
-        lazy val knowsUriFunc =
-          FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
-
-        val result = FuncProperty.zeroOrOne(df, knowsUriFunc)
-
-        result.right.get.right.get.collect().toSet shouldEqual Set(
-          Row(
-            "<http://example.org/Alice>",
-            null,
-            "<http://example.org/Alice>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            null,
-            "<http://example.org/Bob>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Charles>",
-            null,
-            "<http://example.org/Charles>",
-            ""
-          ),
-          Row(
-            "\"Charles\"",
-            null,
-            "\"Charles\"",
-            ""
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>",
-            ""
-          )
-        )
-      }
-    }
-
-    "ExactlyN function" should {
-
-      "return expected values" in {
-
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Daniel>"
-          ),
-          (
-            "<http://example.org/Daniel>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Erick>"
-          )
-        ).toDF("s", "p", "o")
-
-        // ?s foaf:knows{2} ?o
-        lazy val knowsUriFunc =
-          FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
-
-        val n      = 2
-        val result = FuncProperty.exactlyN(df, n, knowsUriFunc)
-
-        result.right.get.right.get.collect().toSet shouldEqual Set(
-          Row(
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Daniel>",
-            ""
-          ),
-          Row(
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Erick>",
-            ""
-          )
-        )
-      }
-    }
-
     "BetweenNAndM function" should {
 
       "return expected values" when {
@@ -541,62 +282,6 @@ class FuncPropertySpec
           val m = 2
 
           // ?s foaf:knows{3, 2} ?o
-          val result =
-            FuncProperty.betweenNAndM(df, Some(n), Some(m), knowsUriFunc)
-
-          result.right.get.right.get.collect().toSet shouldEqual Set(
-            Row(
-              "<http://example.org/Alice>",
-              "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>",
-              ""
-            ),
-            Row(
-              "<http://example.org/Bob>",
-              "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>",
-              ""
-            )
-          )
-        }
-
-        "from Some(3) to Some(3) path length (n == m)" in {
-
-          val df = List(
-            (
-              "<http://example.org/Alice>",
-              "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
-            ),
-            (
-              "<http://example.org/Bob>",
-              "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
-            ),
-            (
-              "<http://example.org/Charles>",
-              "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
-            ),
-            (
-              "<http://example.org/Charles>",
-              "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
-            ),
-            (
-              "<http://example.org/Daniel>",
-              "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
-            )
-          ).toDF("s", "p", "o")
-
-          lazy val knowsUriFunc =
-            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
-
-          val n = 3
-          val m = 3
-
-          // ?s foaf:knows{3, 3} ?o
           val result =
             FuncProperty.betweenNAndM(df, Some(n), Some(m), knowsUriFunc)
 
@@ -779,6 +464,401 @@ class FuncPropertySpec
             FuncProperty.betweenNAndM(df, Some(n), Some(m), knowsUriFunc)
 
           result shouldBe a[Left[_, _]]
+        }
+
+        "from Some(1) to None path length (one or more)" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          // ?s foaf:knows+ ?o
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+          val result =
+            FuncProperty.betweenNAndM(df, Some(1), None, knowsUriFunc)
+
+          result.right.get.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            )
+          )
+        }
+
+        "from Some(0) to None path length (zero or more)" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          // ?s foaf:knows* ?o
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+          val result =
+            FuncProperty.betweenNAndM(df, Some(0), None, knowsUriFunc)
+
+          result.right.get.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              null,
+              "<http://example.org/Alice>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              null,
+              "<http://example.org/Bob>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              null,
+              "<http://example.org/Charles>",
+              ""
+            ),
+            Row(
+              "\"Charles\"",
+              null,
+              "\"Charles\"",
+              ""
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              null,
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Erick>",
+              null,
+              "<http://example.org/Erick>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            )
+          )
+        }
+
+        "from Some(0) to Some(1) path length (zero or one)" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          // ?s foaf:knows? ?o
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+          val result =
+            FuncProperty.betweenNAndM(df, Some(0), Some(1), knowsUriFunc)
+
+          result.right.get.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              null,
+              "<http://example.org/Alice>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              null,
+              "<http://example.org/Bob>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              null,
+              "<http://example.org/Charles>",
+              ""
+            ),
+            Row(
+              "\"Charles\"",
+              null,
+              "\"Charles\"",
+              ""
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              null,
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Erick>",
+              null,
+              "<http://example.org/Erick>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            )
+          )
+        }
+
+        "from Some(3) to Some(3) path length (n == m) (exactly one)" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+          val n = 3
+          val m = 3
+
+          // ?s foaf:knows{3, 3} ?o
+          val result =
+            FuncProperty.betweenNAndM(df, Some(n), Some(m), knowsUriFunc)
+
+          result.right.get.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              ""
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              ""
+            )
+          )
         }
 
         "from Some(2) to None path length" in {

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
@@ -175,17 +175,20 @@ class FuncPropertySpec
           Row(
             "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
+            "<http://example.org/Bob>",
+            ""
           ),
           Row(
             "<http://example.org/Bob>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
+            "<http://example.org/Charles>",
+            ""
           ),
           Row(
             "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
+            "<http://example.org/Charles>",
+            ""
           )
         )
       }
@@ -219,41 +222,50 @@ class FuncPropertySpec
 
         val result = FuncProperty.zeroOrMore(df, knowsUriFunc)
 
+        result.right.get.right.get.show(false)
+
         result.right.get.right.get.collect().toSet shouldEqual Set(
           Row(
             "<http://example.org/Alice>",
             null,
-            "<http://example.org/Alice>"
+            "<http://example.org/Alice>",
+            ""
           ),
           Row(
             "<http://example.org/Bob>",
             null,
-            "<http://example.org/Bob>"
+            "<http://example.org/Bob>",
+            ""
           ),
           Row(
             "<http://example.org/Charles>",
             null,
-            "<http://example.org/Charles>"
+            "<http://example.org/Charles>",
+            ""
           ),
           Row(
             "\"Charles\"",
             null,
-            "\"Charles\""
+            "\"Charles\"",
+            ""
           ),
           Row(
             "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
+            "<http://example.org/Bob>",
+            ""
           ),
           Row(
             "<http://example.org/Bob>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
+            "<http://example.org/Charles>",
+            ""
           ),
           Row(
             "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
+            "<http://example.org/Charles>",
+            ""
           )
         )
       }
@@ -291,32 +303,38 @@ class FuncPropertySpec
           Row(
             "<http://example.org/Alice>",
             null,
-            "<http://example.org/Alice>"
+            "<http://example.org/Alice>",
+            ""
           ),
           Row(
             "<http://example.org/Bob>",
             null,
-            "<http://example.org/Bob>"
+            "<http://example.org/Bob>",
+            ""
           ),
           Row(
             "<http://example.org/Charles>",
             null,
-            "<http://example.org/Charles>"
+            "<http://example.org/Charles>",
+            ""
           ),
           Row(
             "\"Charles\"",
             null,
-            "\"Charles\""
+            "\"Charles\"",
+            ""
           ),
           Row(
             "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
+            "<http://example.org/Bob>",
+            ""
           ),
           Row(
             "<http://example.org/Bob>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
+            "<http://example.org/Charles>",
+            ""
           )
         )
       }
@@ -365,17 +383,20 @@ class FuncPropertySpec
           Row(
             "<http://example.org/Alice>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
+            "<http://example.org/Charles>",
+            ""
           ),
           Row(
             "<http://example.org/Bob>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Daniel>"
+            "<http://example.org/Daniel>",
+            ""
           ),
           Row(
             "<http://example.org/Charles>",
             "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Erick>"
+            "<http://example.org/Erick>",
+            ""
           )
         )
       }
@@ -429,47 +450,56 @@ class FuncPropertySpec
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             ),
             Row(
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
           )
         }
@@ -518,12 +548,14 @@ class FuncPropertySpec
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
           )
         }
@@ -572,12 +604,14 @@ class FuncPropertySpec
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
           )
         }
@@ -626,67 +660,80 @@ class FuncPropertySpec
             Row(
               "<http://example.org/Alice>",
               null,
-              "<http://example.org/Alice>"
+              "<http://example.org/Alice>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               null,
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               null,
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Daniel>",
               null,
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Erick>",
               null,
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             ),
             Row(
               "\"Charles\"",
               null,
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             ),
             Row(
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
           )
         }
@@ -777,32 +824,38 @@ class FuncPropertySpec
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
           )
         }
@@ -850,67 +903,80 @@ class FuncPropertySpec
             Row(
               "\"Charles\"",
               null,
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               null,
-              "<http://example.org/Alice>"
+              "<http://example.org/Alice>",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             Row(
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               null,
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               null,
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             ),
             Row(
               "<http://example.org/Daniel>",
               null,
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             Row(
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             ),
             Row(
               "<http://example.org/Erick>",
               null,
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
           )
         }
@@ -952,6 +1018,106 @@ class FuncPropertySpec
             FuncProperty.betweenNAndM(df, None, None, knowsUriFunc)
 
           result shouldBe a[Left[_, _]]
+        }
+      }
+    }
+
+    "NotOneOf function" should {
+
+      "return expected values" when {
+
+        "one uri" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+
+          // ?s !foaf:knows ?o
+          val result =
+            FuncProperty.notOneOf(df, List(knowsUriFunc))
+
+          result.right.get.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            )
+          )
+        }
+
+        "multiple uris" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          lazy val knowsUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/knows>")
+          lazy val fooUriFunc =
+            FuncProperty.uri("<http://xmlns.org/foaf/0.1/foo")
+
+          // ?s !(foaf:knows|foaf:foo) ?o
+          val result =
+            FuncProperty.notOneOf(df, List(knowsUriFunc, fooUriFunc))
+
+          result.right.get.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            )
+          )
         }
       }
     }


### PR DESCRIPTION
# Description

This PR adds support for NotOneOf property path. E.g:

```
PREFIX foaf: <http://xmlns.org/foaf/0.1/>

SELECT ?s ?o
WHERE {
 ?s !foaf:knows ?o .
}
```

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->
