### PR TITLE
Typed dataframes: add DataFrame typer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,9 +155,6 @@ lazy val `bellman-spark-engine` = project
         "scalatestplus"
       ) % Test
     ),
-    libraryDependencies ++= on(2, 11)(
-      "net.sansa-stack" %% "sansa-rdf-spark" % Versions("sansa") % Test
-    ).value,
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core"    % "jackson-databind" % Versions("jackson"),
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions(

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Compiler.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Compiler.scala
@@ -2,7 +2,6 @@ package com.gsk.kg.engine
 
 import cats.data.Kleisli
 import cats.implicits._
-import cats.syntax.either._
 
 import higherkindness.droste.Basis
 import higherkindness.droste.util.newtypes.@@
@@ -24,7 +23,7 @@ object Compiler {
 
   // scalastyle:off
   def compile(df: DataFrame, query: String, config: Config)(implicit
-                                                            sc: SQLContext
+      sc: SQLContext
   ): Result[DataFrame] =
     compiler
       .run((query, df))
@@ -93,12 +92,13 @@ object Compiler {
     * @return
     */
   private def compiler[T: Basis[DAG, *]](implicit
-                                         sc: SQLContext
-                                        ): Phase[(String, DataFrame), DataFrame] = {
+      sc: SQLContext
+  ): Phase[(String, DataFrame), DataFrame] = {
     (parser
       .andThen(transformToGraph.first[Graphs])
       .andThen(staticAnalysis.first[Graphs])
-      .andThen(optimizer)).first[DataFrame]
+      .andThen(optimizer))
+      .first[DataFrame]
       .andThen(dataFrameTyper.second[T])
       .andThen(engine[T])
       .andThen(rdfFormatter)
@@ -124,8 +124,8 @@ object Compiler {
     * @return
     */
   private def engine[T: Basis[DAG, *]](implicit
-                                       sc: SQLContext
-                                      ): Phase[(T, DataFrame), DataFrame] =
+      sc: SQLContext
+  ): Phase[(T, DataFrame), DataFrame] =
     Kleisli[M, (T, DataFrame), DataFrame] { case (query, df) =>
       Log.info("Engine", "Running the engine") *>
         M.ask[Result, Config, Log, DataFrame @@ Untyped].flatMapF { config =>

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/DataFrameTyper.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/DataFrameTyper.scala
@@ -11,12 +11,12 @@ import com.gsk.kg.engine.functions.Literals.LocalizedLiteral
 import com.gsk.kg.engine.functions.Literals.TypedLiteral
 
 object Tokens {
-  val openAngleBracket = "<"
+  val openAngleBracket    = "<"
   val closingAngleBracket = ">"
-  val doubleQuote = "\""
-  val typeAnnotation = "^^"
-  val langAnnotation = "@"
-  val blankNode = "_:"
+  val doubleQuote         = "\""
+  val typeAnnotation      = "^^"
+  val langAnnotation      = "@"
+  val blankNode           = "_:"
 }
 
 trait RdfType {
@@ -71,9 +71,9 @@ object DataFrameTyper {
     .add("type", StringType)
 
   def applyTransformationToDF(
-                               df: DataFrame,
-                               transform: Column => Column
-                             ): DataFrame =
+      df: DataFrame,
+      transform: Column => Column
+  ): DataFrame =
     df.columns.foldLeft(df) { case (acc, column) =>
       acc.withColumn(column, transform(df(column)))
     }
@@ -141,10 +141,10 @@ object DataFrameTyper {
 
   // scalafix:off
   def createRecord(
-                    value: Column,
-                    tpe: Column,
-                    lang: Column = lit(null) // scalastyle:off
-                  ): Column =
+      value: Column,
+      tpe: Column,
+      lang: Column = lit(null) // scalastyle:off
+  ): Column =
     struct(
       value.as("value"),
       tpe.as("type"),

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/DataFrameTyper.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/DataFrameTyper.scala
@@ -1,8 +1,153 @@
 package com.gsk.kg.engine
 
-import com.gsk.kg.config.Config
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+
+import com.gsk.kg.config.Config
+import com.gsk.kg.engine.functions.Literals
+import com.gsk.kg.engine.functions.Literals.LocalizedLiteral
+import com.gsk.kg.engine.functions.Literals.TypedLiteral
+
+object Tokens {
+  val openAngleBracket = "<"
+  val closingAngleBracket = ">"
+  val doubleQuote = "\""
+  val typeAnnotation = "^^"
+  val langAnnotation = "@"
+  val blankNode = "_:"
+}
+
+trait RdfType {
+  val repr: Column
+}
+
+object RdfType {
+  case object String extends RdfType {
+    val repr = lit("http://www.w3.org/2001/XMLSchema#string")
+  }
+
+  case object Uri extends RdfType {
+    val repr = lit("uri")
+  }
+
+  case object Boolean extends RdfType {
+    val repr = lit("http://www.w3.org/2001/XMLSchema#boolean")
+  }
+
+  case object Int extends RdfType {
+    val repr = lit("http://www.w3.org/2001/XMLSchema#integer")
+  }
+
+  case object Double extends RdfType {
+    val repr = lit("http://www.w3.org/2001/XMLSchema#double")
+  }
+
+  case object Decimal extends RdfType {
+    val repr = lit("http://www.w3.org/2001/XMLSchema#decimal")
+  }
+
+  case object Blank extends RdfType {
+    val repr = lit("blank")
+  }
+
+  final case class Literal(str: String) extends RdfType {
+    val repr = lit(str)
+  }
+}
 
 object DataFrameTyper {
-  def typeDataFrame(inDf: DataFrame, config: Config): _root_.org.apache.spark.sql.DataFrame = ???
+  def typeDataFrame(inDf: DataFrame, config: Config): DataFrame =
+    if (config.typeDataframe) {
+      applyTransformationToDF(inDf, parse)
+    } else {
+      inDf
+    }
+
+  val structSchema: StructType = new StructType()
+    .add("value", StringType)
+    .add("lang", StringType, nullable = true)
+    .add("type", StringType)
+
+  def applyTransformationToDF(
+                               df: DataFrame,
+                               transform: Column => Column
+                             ): DataFrame =
+    df.columns.foldLeft(df) { case (acc, column) =>
+      acc.withColumn(column, transform(df(column)))
+    }
+
+  def parse(col: Column): Column =
+    when(
+      RdfFormatter.isUri(col),
+      createRecord(
+        rtrim(ltrim(col, Tokens.openAngleBracket), Tokens.closingAngleBracket),
+        RdfType.Uri.repr
+      )
+    ).when(
+      TypedLiteral.isTypedLiteral(col),
+      createRecord(
+        Literals.extractStringLiteral(col),
+        rtrim(
+          ltrim(TypedLiteral(col).tag, Tokens.openAngleBracket),
+          Tokens.closingAngleBracket
+        )
+      )
+    ).when(
+      RdfFormatter.isLocalizedString(col),
+      createRecord(
+        value = LocalizedLiteral(col).value,
+        tpe = RdfType.String.repr,
+        lang = LocalizedLiteral(col).tag
+      )
+    ).when(
+      col.startsWith(Tokens.doubleQuote) && col.endsWith(Tokens.doubleQuote),
+      createRecord(
+        value = rtrim(ltrim(col, Tokens.doubleQuote), Tokens.doubleQuote),
+        tpe = RdfType.String.repr
+      )
+    ).when(
+      RdfFormatter.isBoolean(col),
+      createRecord(
+        value = col,
+        tpe = RdfType.Boolean.repr
+      )
+    ).when(
+      RdfFormatter.isNumber(col) && col.contains("e"),
+      createRecord(
+        value = col,
+        tpe = RdfType.Double.repr
+      )
+    ).when(
+      RdfFormatter.isNumber(col) && col.contains("."),
+      createRecord(
+        value = col,
+        tpe = RdfType.Decimal.repr
+      )
+    ).when(
+      RdfFormatter.isNumber(col),
+      createRecord(
+        value = col,
+        tpe = RdfType.Int.repr
+      )
+    ).when(
+      RdfFormatter.isBlank(col),
+      createRecord(
+        ltrim(col, Tokens.blankNode),
+        RdfType.Blank.repr
+      )
+    )
+
+  // scalafix:off
+  def createRecord(
+                    value: Column,
+                    tpe: Column,
+                    lang: Column = lit(null) // scalastyle:off
+                  ): Column =
+    struct(
+      value.as("value"),
+      tpe.as("type"),
+      lang.as("lang")
+    )
 }

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/DataFrameTyper.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/DataFrameTyper.scala
@@ -1,0 +1,8 @@
+package com.gsk.kg.engine
+
+import com.gsk.kg.config.Config
+import org.apache.spark.sql.DataFrame
+
+object DataFrameTyper {
+  def typeDataFrame(inDf: DataFrame, config: Config): _root_.org.apache.spark.sql.DataFrame = ???
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/DataFrameTyperTest.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/DataFrameTyperTest.scala
@@ -1,0 +1,31 @@
+package com.gsk.kg.engine
+
+import com.gsk.kg.config.Config
+import com.gsk.kg.engine.compiler.SparkSpec
+import com.gsk.kg.engine.scalacheck.all._
+import org.apache.spark.sql.DataFrame
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class DataFrameTyperTest
+  extends AnyWordSpec
+    with Matchers
+    with SparkSpec
+    with ScalaCheckDrivenPropertyChecks {
+
+  "DataFrameTyper" should {
+
+    "type arbitrary dataframes" in {
+      val config =
+        Config.default.copy(typeDataframe = true, formatRdfOutput = true)
+
+      forAll { df: DataFrame =>
+        val typed = DataFrameTyper.typeDataFrame(df, config)
+        val untyped = RdfFormatter.formatDataFrame(typed, config)
+
+        df.collect shouldEqual untyped.collect
+      }
+    }
+  }
+}

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/DataFrameTyperTest.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/DataFrameTyperTest.scala
@@ -1,15 +1,17 @@
 package com.gsk.kg.engine
 
+import org.apache.spark.sql.DataFrame
+
 import com.gsk.kg.config.Config
 import com.gsk.kg.engine.compiler.SparkSpec
 import com.gsk.kg.engine.scalacheck.all._
-import org.apache.spark.sql.DataFrame
+
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class DataFrameTyperTest
-  extends AnyWordSpec
+    extends AnyWordSpec
     with Matchers
     with SparkSpec
     with ScalaCheckDrivenPropertyChecks {
@@ -21,7 +23,7 @@ class DataFrameTyperTest
         Config.default.copy(typeDataframe = true, formatRdfOutput = true)
 
       forAll { df: DataFrame =>
-        val typed = DataFrameTyper.typeDataFrame(df, config)
+        val typed   = DataFrameTyper.typeDataFrame(df, config)
         val untyped = RdfFormatter.formatDataFrame(typed, config)
 
         df.collect shouldEqual untyped.collect

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/RdfFormatterSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/RdfFormatterSpec.scala
@@ -40,7 +40,7 @@ class RdfFormatterSpec
       ("\"false\"^^xsd:boolean", "\"true\"^^xsd:boolean", "1")
     ).toDF("s", "p", "o")
 
-    val result = RdfFormatter.formatDataFrame(df, Config(true, true, true))
+    val result = RdfFormatter.formatDataFrame(df, Config(true, true, true, false))
 
     result.collect() shouldEqual expected.collect()
   }

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/RdfFormatterSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/RdfFormatterSpec.scala
@@ -40,7 +40,8 @@ class RdfFormatterSpec
       ("\"false\"^^xsd:boolean", "\"true\"^^xsd:boolean", "1")
     ).toDF("s", "p", "o")
 
-    val result = RdfFormatter.formatDataFrame(df, Config(true, true, true, false))
+    val result =
+      RdfFormatter.formatDataFrame(df, Config(true, true, true, false))
 
     result.collect() shouldEqual expected.collect()
   }

--- a/modules/parser/src/main/resources/application.conf
+++ b/modules/parser/src/main/resources/application.conf
@@ -1,3 +1,4 @@
 is-default-graph-exclusive = true
 strip-question-marks-on-output = false
 format-rdf-output = false
+type-dataframe = false

--- a/modules/parser/src/main/scala/com/gsk/kg/config/Config.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/config/Config.scala
@@ -1,11 +1,12 @@
 package com.gsk.kg.config
 
 final case class Config(
-    isDefaultGraphExclusive: Boolean,
-    stripQuestionMarksOnOutput: Boolean,
-    formatRdfOutput: Boolean
-)
+                         isDefaultGraphExclusive: Boolean,
+                         stripQuestionMarksOnOutput: Boolean,
+                         formatRdfOutput: Boolean,
+                         typeDataframe: Boolean
+                       )
 
 object Config {
-  val default: Config = Config(true, false, false)
+  val default: Config = Config(true, false, false, false)
 }

--- a/modules/parser/src/main/scala/com/gsk/kg/config/Config.scala
+++ b/modules/parser/src/main/scala/com/gsk/kg/config/Config.scala
@@ -1,11 +1,11 @@
 package com.gsk.kg.config
 
 final case class Config(
-                         isDefaultGraphExclusive: Boolean,
-                         stripQuestionMarksOnOutput: Boolean,
-                         formatRdfOutput: Boolean,
-                         typeDataframe: Boolean
-                       )
+    isDefaultGraphExclusive: Boolean,
+    stripQuestionMarksOnOutput: Boolean,
+    formatRdfOutput: Boolean,
+    typeDataframe: Boolean
+)
 
 object Config {
   val default: Config = Config(true, false, false, false)

--- a/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestConfig.scala
+++ b/modules/parser/src/test/scala/com/gsk/kg/sparqlparser/TestConfig.scala
@@ -13,6 +13,7 @@ trait TestConfig {
       | is-default-graph-exclusive = true,
       | strip-question-marks-on-output = false,
       | format-rdf-output = true
+      | type-dataframe = false
       |}
       |""".stripMargin
 


### PR DESCRIPTION
# Description

This PR introduces the `DataFrameTyper` layer to the engine.  This PR also changes the RdfFormatter to make it able to reformat typed dataframes too.

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->
