### PR TITLE
fixed bug where graph variables was being set to null on union operation

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/Engine.scala
@@ -221,7 +221,15 @@ object Engine {
   ): M[Multiset[DataFrame @@ Untyped]] = {
     val bindings =
       expr.bindings.filter(_.s != GRAPH_VARIABLE.s) + VARIABLE(graph)
-    val df = expr.relational.withColumn(graph, col(GRAPH_VARIABLE.s))
+
+    val graphColumnMetadata =
+      new MetadataBuilder().putString("graph_column_name", graph).build()
+    val updatedGraphCol =
+      col(GRAPH_VARIABLE.s).as("graph_column", graphColumnMetadata)
+
+    val df = expr.relational
+      .withColumn(graph, updatedGraphCol)
+
     Multiset[DataFrame @@ Untyped](
       bindings,
       df

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/relational/relational.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/relational/relational.scala
@@ -54,6 +54,7 @@ import simulacrum.typeclass
   def map[U: Encoder](df: A, fn: Row => U): A
   def flatMap[U: Encoder](df: A, fn: Row => TraversableOnce[U]): A
   def collect(df: A): Array[Row]
+  def show(df: A, truncate: Boolean): Unit
   def toDataFrame(df: A): DataFrame
 }
 
@@ -254,6 +255,9 @@ trait RelationalInstances {
 
       def collect(df: DataFrame @@ Untyped): Array[Row] =
         df.unwrap.collect()
+
+      def show(df: DataFrame @@ Untyped, truncate: Boolean): Unit =
+        df.unwrap.show(truncate)
 
       def toDataFrame(df: DataFrame @@ Untyped): DataFrame =
         df.unwrap


### PR DESCRIPTION
This PR fixed a bug where the graph variable column was being set to null when performing a union operation.

<!-- Summary of the changes -->

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->
