### PR TITLE
added support for default and named graphs to property paths

### DIFF
--- a/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/optimizer/GraphsPushdown.scala
@@ -143,7 +143,11 @@ object GraphsPushdown {
           case DAG.Sequence(bps) =>
             graphsOrList => DAG.sequenceR(bps.map(_(graphsOrList)))
           case DAG.Path(s, p, o, g, rev) =>
-            graphsOrList => DAG.pathR(s, p, o, g, rev)
+            graphsOrList =>
+              graphsOrList.fold(
+                list => DAG.pathR(s, p, o, list, rev),
+                graphs => DAG.pathR(s, p, o, graphs.default, rev)
+              )
           case DAG.BGP(quads) =>
             graphsOrList =>
               graphsOrList.fold(

--- a/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
+++ b/modules/engine/src/main/scala/com/gsk/kg/engine/properties/FuncProperty.scala
@@ -71,7 +71,8 @@ object FuncProperty {
           .map(i => getNLengthPathTriples(df, pathsFrame, i))
           .toList
 
-      val betweenNAndMPaths = Foldable[List].fold(paths)
+      val betweenNAndMPaths = Foldable[List]
+        .fold(paths)
 
       toSPOG(betweenNAndMPaths)
         .asRight[Column]

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/compiler/PropertyPathsSpec.scala
@@ -177,6 +177,133 @@ class PropertyPathsSpec
             Row("\"Charles\"", "<http://example.org/Charles>")
           )
         }
+
+        "with default graph" in {
+
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows|foaf:name ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Charles>", "\"Charles\"")
+          )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows|foaf:name ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Charles>", "\"Charles\"")
+          )
+        }
       }
 
       "sequence / property path" when {
@@ -1371,6 +1498,153 @@ class PropertyPathsSpec
             )
           }
         }
+
+        "with default graph" in {
+
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows/foaf:name ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Bob>", "\"Charles\"")
+          )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows/foaf:name ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Bob>", "\"Charles\"")
+          )
+        }
       }
 
       "reverse ^ property path" in {
@@ -1400,128 +1674,532 @@ class PropertyPathsSpec
         )
       }
 
-      "arbitrary length + property path" in {
+      "arbitrary length + property path" when {
 
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
+        "simple path" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            )
+          ).toDF("s", "p", "o")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |WHERE {
+              | ?s foaf:knows+ ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>")
           )
-        ).toDF("s", "p", "o")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
-            |
-            |SELECT ?s ?o
-            |WHERE {
-            | ?s foaf:knows+ ?o .
-            |}
-            |""".stripMargin
+        "with default graph" in {
 
-        val result = Compiler.compile(df, query, config)
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
 
-        result.right.get.collect.toSet shouldEqual Set(
-          Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
-          Row("<http://example.org/Alice>", "<http://example.org/Charles>"),
-          Row("<http://example.org/Bob>", "<http://example.org/Charles>")
-        )
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows+ ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>")
+          )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows+ ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>")
+          )
+        }
       }
 
-      "arbitrary length * property path" in {
+      "arbitrary length * property path" when {
 
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
+        "simple path" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            )
+          ).toDF("s", "p", "o")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |WHERE {
+              | ?s foaf:knows* ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("\"Charles\"", "\"Charles\""),
+            Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>")
           )
-        ).toDF("s", "p", "o")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
-            |
-            |SELECT ?s ?o
-            |WHERE {
-            | ?s foaf:knows* ?o .
-            |}
-            |""".stripMargin
+        "with default graph" in {
 
-        val result = Compiler.compile(df, query, config)
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
 
-        result.right.get.collect.toSet shouldEqual Set(
-          Row("\"Charles\"", "\"Charles\""),
-          Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
-          Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
-          Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
-          Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
-          Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
-          Row("<http://example.org/Alice>", "<http://example.org/Charles>")
-        )
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows* ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("\"Charles\"", "\"Charles\""),
+            Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>")
+          )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows* ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("\"Charles\"", "\"Charles\""),
+            Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>")
+          )
+        }
       }
 
-      "optional ? property path" in {
+      "optional ? property path" when {
 
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
+        "simple path" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            )
+          ).toDF("s", "p", "o")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |WHERE {
+              | ?s foaf:knows? ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("\"Charles\"", "\"Charles\""),
+            Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>")
           )
-        ).toDF("s", "p", "o")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
-            |
-            |SELECT ?s ?o
-            |WHERE {
-            | ?s foaf:knows? ?o .
-            |}
-            |""".stripMargin
+        "with default graph" in {
 
-        val result = Compiler.compile(df, query, config)
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
 
-        result.right.get.collect.toSet shouldEqual Set(
-          Row("\"Charles\"", "\"Charles\""),
-          Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
-          Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
-          Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
-          Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
-          Row("<http://example.org/Alice>", "<http://example.org/Bob>")
-        )
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows? ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("\"Charles\"", "\"Charles\""),
+            Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>")
+          )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // graph1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            // graph2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows? ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("\"Charles\"", "\"Charles\""),
+            Row("<http://example.org/Charles>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Alice>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>")
+          )
+        }
       }
 
       "negated ! property path" when {
@@ -1633,287 +2311,1346 @@ class PropertyPathsSpec
             )
           )
         }
+
+        "with default graph" in {
+
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s !foaf:knows ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Charles>",
+              "\"Charles\""
+            )
+          )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s !foaf:knows ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Charles>",
+              "\"Charles\""
+            )
+          )
+        }
       }
 
-      "fixed length {n,m} property path" in {
+      "fixed length {n,m} property path" when {
 
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Daniel>"
-          ),
-          (
-            "<http://example.org/Daniel>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Erick>"
+        "simple path" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |WHERE {
+              | ?s foaf:knows{1, 3} ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Erick>"),
+            Row("<http://example.org/Charles>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Charles>", "<http://example.org/Erick>"),
+            Row("<http://example.org/Daniel>", "<http://example.org/Erick>")
           )
-        ).toDF("s", "p", "o")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
-            |
-            |SELECT ?s ?o
-            |WHERE {
-            | ?s foaf:knows{1, 3} ?o .
-            |}
-            |""".stripMargin
+        "with default graph" in {
 
-        val result = Compiler.compile(df, query, config)
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
 
-        result.right.get.collect.toSet shouldEqual Set(
-          Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
-          Row("<http://example.org/Alice>", "<http://example.org/Charles>"),
-          Row("<http://example.org/Alice>", "<http://example.org/Daniel>"),
-          Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
-          Row("<http://example.org/Bob>", "<http://example.org/Daniel>"),
-          Row("<http://example.org/Bob>", "<http://example.org/Erick>"),
-          Row("<http://example.org/Charles>", "<http://example.org/Daniel>"),
-          Row("<http://example.org/Charles>", "<http://example.org/Erick>"),
-          Row("<http://example.org/Daniel>", "<http://example.org/Erick>")
-        )
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows{1, 3} ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Erick>"),
+            Row("<http://example.org/Charles>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Charles>", "<http://example.org/Erick>"),
+            Row("<http://example.org/Daniel>", "<http://example.org/Erick>")
+          )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows{1, 3} ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row("<http://example.org/Alice>", "<http://example.org/Bob>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Alice>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Charles>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Bob>", "<http://example.org/Erick>"),
+            Row("<http://example.org/Charles>", "<http://example.org/Daniel>"),
+            Row("<http://example.org/Charles>", "<http://example.org/Erick>"),
+            Row("<http://example.org/Daniel>", "<http://example.org/Erick>")
+          )
+        }
       }
 
-      "fixed length {n,} property path" in {
+      "fixed length {n,} property path" when {
 
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Daniel>"
-          ),
-          (
-            "<http://example.org/Daniel>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Erick>"
+        "simple path" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |WHERE {
+              | ?s foaf:knows{2,} ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            )
           )
-        ).toDF("s", "p", "o")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
-            |
-            |SELECT ?s ?o
-            |WHERE {
-            | ?s foaf:knows{2,} ?o .
-            |}
-            |""".stripMargin
+        "with default graph" in {
 
-        val result = Compiler.compile(df, query, config)
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
 
-        result.right.get.collect.toSet shouldEqual Set(
-          Row(
-            "<http://example.org/Alice>",
-            "<http://example.org/Charles>"
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://example.org/Daniel>"
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://example.org/Erick>"
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://example.org/Daniel>"
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://example.org/Erick>"
-          ),
-          Row(
-            "<http://example.org/Charles>",
-            "<http://example.org/Erick>"
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows{2,} ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            )
           )
-        )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows{2,} ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            )
+          )
+        }
       }
 
-      "fixed length {,n} property path" in {
+      "fixed length {,n} property path" when {
 
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Daniel>"
-          ),
-          (
-            "<http://example.org/Daniel>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Erick>"
+        "simple path" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |WHERE {
+              | ?s foaf:knows{,2} ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "\"Charles\"",
+              "\"Charles\""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Alice>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Bob>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Bob>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Erick>",
+              "<http://example.org/Erick>"
+            )
           )
-        ).toDF("s", "p", "o")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
-            |
-            |SELECT ?s ?o
-            |WHERE {
-            | ?s foaf:knows{,2} ?o .
-            |}
-            |""".stripMargin
+        "with default graph" in {
 
-        val result = Compiler.compile(df, query, config)
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
 
-        result.right.get.collect.toSet shouldEqual Set(
-          Row(
-            "\"Charles\"",
-            "\"Charles\""
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://example.org/Alice>"
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://example.org/Bob>"
-          ),
-          Row(
-            "<http://example.org/Alice>",
-            "<http://example.org/Charles>"
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://example.org/Bob>"
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://example.org/Charles>"
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://example.org/Daniel>"
-          ),
-          Row(
-            "<http://example.org/Charles>",
-            "<http://example.org/Charles>"
-          ),
-          Row(
-            "<http://example.org/Charles>",
-            "<http://example.org/Daniel>"
-          ),
-          Row(
-            "<http://example.org/Charles>",
-            "<http://example.org/Erick>"
-          ),
-          Row(
-            "<http://example.org/Daniel>",
-            "<http://example.org/Daniel>"
-          ),
-          Row(
-            "<http://example.org/Daniel>",
-            "<http://example.org/Erick>"
-          ),
-          Row(
-            "<http://example.org/Erick>",
-            "<http://example.org/Erick>"
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows{,2} ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "\"Charles\"",
+              "\"Charles\""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Alice>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Bob>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Bob>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Erick>",
+              "<http://example.org/Erick>"
+            )
           )
-        )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.org/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows{,2} ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect.toSet shouldEqual Set(
+            Row(
+              "\"Charles\"",
+              "\"Charles\""
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Alice>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Bob>"
+            ),
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Bob>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Daniel>",
+              "<http://example.org/Erick>"
+            ),
+            Row(
+              "<http://example.org/Erick>",
+              "<http://example.org/Erick>"
+            )
+          )
+        }
       }
 
-      "fixed length {n} property path" in {
+      "fixed length {n} property path" when {
 
-        val df = List(
-          (
-            "<http://example.org/Alice>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Bob>"
-          ),
-          (
-            "<http://example.org/Bob>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Charles>"
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/name>",
-            "\"Charles\""
-          ),
-          (
-            "<http://example.org/Charles>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Daniel>"
-          ),
-          (
-            "<http://example.org/Daniel>",
-            "<http://xmlns.org/foaf/0.1/knows>",
-            "<http://example.org/Erick>"
+        "simple path" in {
+
+          val df = List(
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\""
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>"
+            )
+          ).toDF("s", "p", "o")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |WHERE {
+              | ?s foaf:knows{2} ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            )
           )
-        ).toDF("s", "p", "o")
+        }
 
-        val query =
-          """
-            |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
-            |
-            |SELECT ?s ?o
-            |WHERE {
-            | ?s foaf:knows{2} ?o .
-            |}
-            |""".stripMargin
+        "with default graph" in {
 
-        val result = Compiler.compile(df, query, config)
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
 
-        result.right.get.collect().toSet shouldEqual Set(
-          Row(
-            "<http://example.org/Alice>",
-            "<http://example.org/Charles>"
-          ),
-          Row(
-            "<http://example.org/Bob>",
-            "<http://example.org/Daniel>"
-          ),
-          Row(
-            "<http://example.org/Charles>",
-            "<http://example.org/Erick>"
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM <http://graph.org/graph1>
+              |WHERE {
+              | ?s foaf:knows{2} ?o .
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            )
           )
-        )
+        }
+
+        "with named graph" in {
+
+          val df = List(
+            // Graph 1
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph1>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph1>"
+            ),
+            // Graph 2
+            (
+              "<http://example.org/Alice>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Bob>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Bob>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Charles>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/name>",
+              "\"Charles\"",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Charles>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Daniel>",
+              "<http://graph.org/graph2>"
+            ),
+            (
+              "<http://example.org/Daniel>",
+              "<http://xmlns.org/foaf/0.1/knows>",
+              "<http://example.org/Erick>",
+              "<http://graph.org/graph2>"
+            )
+          ).toDF("s", "p", "o", "g")
+
+          val query =
+            """
+              |PREFIX foaf: <http://xmlns.org/foaf/0.1/>
+              |
+              |SELECT ?s ?o
+              |FROM NAMED <http://graph.rog/graph1>
+              |FROM NAMED <http://graph.org/graph2>
+              |WHERE {
+              | GRAPH <http://graph.org/graph1> { ?s foaf:knows{2} ?o . }
+              |}
+              |""".stripMargin
+
+          val result = Compiler.compile(df, query, config)
+
+          result.right.get.collect().toSet shouldEqual Set(
+            Row(
+              "<http://example.org/Alice>",
+              "<http://example.org/Charles>"
+            ),
+            Row(
+              "<http://example.org/Bob>",
+              "<http://example.org/Daniel>"
+            ),
+            Row(
+              "<http://example.org/Charles>",
+              "<http://example.org/Erick>"
+            )
+          )
+        }
       }
     }
 

--- a/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
+++ b/modules/engine/src/test/scala/com/gsk/kg/engine/properties/FuncPropertySpec.scala
@@ -71,29 +71,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           lazy val knowsUriFunc =
             FuncProperty.uri(df, "<http://xmlns.org/foaf/0.1/knows>")
@@ -169,29 +174,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           lazy val knowsUriFunc =
             FuncProperty.uri(df, "<http://xmlns.org/foaf/0.1/knows>")
@@ -225,29 +235,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           lazy val knowsUriFunc =
             FuncProperty.uri(df, "<http://xmlns.org/foaf/0.1/knows>")
@@ -347,29 +362,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           lazy val knowsUriFunc =
             FuncProperty.uri(df, "<http://xmlns.org/foaf/0.1/knows>")
@@ -390,29 +410,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           // ?s foaf:knows+ ?o
           lazy val knowsUriFunc =
@@ -491,29 +516,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           // ?s foaf:knows* ?o
           lazy val knowsUriFunc =
@@ -628,29 +658,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           // ?s foaf:knows? ?o
           lazy val knowsUriFunc =
@@ -729,29 +764,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           lazy val knowsUriFunc =
             FuncProperty.uri(df, "<http://xmlns.org/foaf/0.1/knows>")
@@ -785,29 +825,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           lazy val knowsUriFunc =
             FuncProperty.uri(df, "<http://xmlns.org/foaf/0.1/knows>")
@@ -864,29 +909,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           lazy val knowsUriFunc =
             FuncProperty.uri(df, "<http://xmlns.org/foaf/0.1/knows>")
@@ -985,29 +1035,34 @@ class FuncPropertySpec
             (
               "<http://example.org/Alice>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Bob>"
+              "<http://example.org/Bob>",
+              ""
             ),
             (
               "<http://example.org/Bob>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Charles>"
+              "<http://example.org/Charles>",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/name>",
-              "\"Charles\""
+              "\"Charles\"",
+              ""
             ),
             (
               "<http://example.org/Charles>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Daniel>"
+              "<http://example.org/Daniel>",
+              ""
             ),
             (
               "<http://example.org/Daniel>",
               "<http://xmlns.org/foaf/0.1/knows>",
-              "<http://example.org/Erick>"
+              "<http://example.org/Erick>",
+              ""
             )
-          ).toDF("s", "p", "o").@@[Untyped]
+          ).toDF("s", "p", "o", "g").@@[Untyped]
 
           lazy val knowsUriFunc =
             FuncProperty.uri(df, "<http://xmlns.org/foaf/0.1/knows>")


### PR DESCRIPTION
This PR adds support for default and named graphs when using property paths expressions.

<!-- Summary of the changes -->

## Type of change

Make sure you add the correct label for the PR:

- `enhacement` if this PR adds a new feature
- `bug` if it fixes a bug
- `documentation` if it adds docs
- `breaking-change` if this PR introduces a breaking change
- `dependency-updates` if it updates dependencies

<!-- Does this PR fix any issue? add `CLOSES #numberofissue` under this line -->
